### PR TITLE
Distribute operator and dependencies' licenses

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ dev/
 *.el
 *.tar*
 bin/
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /bin/
+vendor/
+*.tar.*
+*.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,13 @@ RUN go mod download
 COPY ./ /src/
 RUN make -e build GOBIN=/ CGO_ENABLED=0
 
+# This stage provides certificates (to be copied) from Amazon Linux 2.
+FROM amazonlinux:2 as al2
+
 # Build minimal container with a static build of the update operator executable.
 FROM scratch as update-operator
-COPY --from=build /etc/ssl /etc/ssl
+COPY --from=al2 /etc/ssl /etc/ssl
+COPY --from=al2 /etc/pki /etc/pki
 COPY --from=build /src/COPYRIGHT /src/LICENSE-* /usr/share/licenses/bottlerocket-update-operator/
 COPY --from=licenses /licenses/ /usr/share/licenses/bottlerocket-update-operator/vendor/
 COPY --from=build /bottlerocket-update-operator /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,35 @@
 # syntax=docker/dockerfile:experimental
+
+# LICENSES_IMAGE is a container image that contains license files for the source
+# and its dependencies. When building with `make container`, the licenses
+# container image is built and provided as LICENSE_IMAGE.
+ARG LICENSES_IMAGE=scratch
+FROM $LICENSES_IMAGE as licenses
+# Set WORKDIR to create /licenses/ if the directory is missing.
+#
+# Having an image with /licenses/ lets scratch be substituted in when
+# LICENSES_IMAGE isn't provided. For example, a user can manually run `docker
+# build -t neio:latest .` to build a working image without providing an expected
+# LICENSES_IMAGE.
+WORKDIR /licenses/
+
 FROM golang:1.13 as build
 ARG GO_LDFLAGS=
 ARG GOARCH=
 ARG SHORT_SHA=
 ENV GOPROXY=direct
-COPY go.mod go.sum /go/src/github.com/bottlerocket-os/bottlerocket-update-operator/
-WORKDIR /go/src/github.com/bottlerocket-os/bottlerocket-update-operator
+COPY go.mod go.sum /src/
+WORKDIR /src/
 RUN go mod download
-COPY . /go/src/github.com/bottlerocket-os/bottlerocket-update-operator/
+COPY ./ /src/
 RUN make -e build GOBIN=/ CGO_ENABLED=0
 
 # Build minimal container with a static build of the update operator executable.
 FROM scratch as update-operator
-COPY --from=build /bottlerocket-update-operator /etc/ssl /
+COPY --from=build /etc/ssl /etc/ssl
+COPY --from=build /src/COPYRIGHT /src/LICENSE-* /usr/share/licenses/bottlerocket-update-operator/
+COPY --from=licenses /licenses/ /usr/share/licenses/bottlerocket-update-operator/vendor/
+COPY --from=build /bottlerocket-update-operator /
 ENTRYPOINT ["/bottlerocket-update-operator"]
 CMD ["-help"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
-# Makefile - Bottlerocket Update Operator targets for build and development
+# Makefile - Bottlerocket update operator build and development targets
 #
 # ecr_uri=$(aws ecr describe-repositories --repository bottlerocket-os/bottlerocket-update-operator --query 'repositories[].repositoryUri' --output text)
 #
 # make container IMAGE_REPO_NAME="$ecr_uri"
-#
+
+# SHELL is set as bash to use some bashisms.
+SHELL = bash
 # IMAGE_NAME is the full name of the container image being built. This may be
 # specified to fully control the name of the container image's tag.
 IMAGE_NAME = $(IMAGE_REPO_NAME)$(IMAGE_ARCH_SUFFIX):$(IMAGE_VERSION)$(addprefix -,$(SHORT_SHA))
@@ -19,6 +21,11 @@ SHORT_SHA = $(shell git describe --abbrev=8 --always --dirty='-dev' --exclude '*
 # IMAGE_ARCH_SUFFIX is the runtime architecture designator for the container
 # image, it is appended to the IMAGE_NAME unless the name is specified.
 IMAGE_ARCH_SUFFIX = $(addprefix -,$(ARCH))
+# BUILDSYS_SDK_IMAGE is the Bottlerocket SDK image used for license scanning.
+BUILDSYS_SDK_IMAGE ?= bottlerocket/sdk-x86_64:v0.8
+# LICENSES_IMAGE_NAME is the name of the container image that has LICENSE files
+# for distribution.
+LICENSES_IMAGE = $(IMAGE_NAME)-licenses
 # DESTDIR is where the release artifacts will be written.
 DESTDIR = .
 # DISTFILE is the path to the dist target's output file - the container image
@@ -35,8 +42,6 @@ ARCH = $(lastword $(subst :, ,$(filter $(UNAME_ARCH):%,x86_64:amd64 aarch64:arm6
 # DOCKER_ARCH is the docker specific architecture specifier used for building on
 # multiarch container images.
 DOCKER_ARCH = $(lastword $(subst :, ,$(filter $(ARCH):%,amd64:amd64 arm64:arm64v8)))
-# Build container images using BuildKit strategy.
-export DOCKER_BUILDKIT = 1
 
 .PHONY: all build check
 
@@ -65,24 +70,26 @@ test:
 	go test -race -ldflags '$(GO_LDFLAGS)' $(GOPKGS)
 
 # Build a container image for daemon and tools.
-container:
+container: licenses
 	docker build \
 		--network=host \
 		--build-arg GO_LDFLAGS \
 		--build-arg GOARCH \
 		--build-arg SHORT_SHA='$(SHORT_SHA)' \
+		--build-arg LICENSES_IMAGE=$(LICENSES_IMAGE) \
 		--target="update-operator" \
 		--tag $(IMAGE_NAME) \
 		.
 
 # Build and test in a container.
-container-test:
+container-test: sdk-image licenses
 	docker build \
 		--network=host \
 		--build-arg GO_LDFLAGS='$(GO_LDFLAGS)' \
 		--build-arg GOARCH='$(GOARCH)' \
 		--build-arg SHORT_SHA='$(SHORT_SHA)' \
 		--build-arg NOCACHE='$(shell date +"%s")' \
+		--build-arg LICENSES_IMAGE=$(LICENSES_IMAGE) \
 		--target="test" \
 		--tag $(IMAGE_NAME)-test \
 		.
@@ -98,13 +105,33 @@ dist: container check
 	docker save $(IMAGE_NAME) | gzip > '$(DISTFILE)'
 
 # Run checks on the container image.
-check: check-executable
+check: check-executable check-licenses
 
 # Check that the container's executable works.
 check-executable:
 	@echo "Running check: $@"
+	@echo "Checking if the container image's ENTRYPOINT is executable..."
 	docker run --rm $(IMAGE_NAME) -help 2>&1 \
 		| grep -q '/bottlerocket-update-operator'
+
+# Check that the container has LICENSE files included for its dependencies.
+check-licenses: CONTAINER_HASH=$(shell echo "$(LICENSES_IMAGE_NAME)$$(pwd -P)" | sha256sum - | awk '{print $$1}' | head -c 16)
+check-licenses: CHECK_CONTAINER_NAME=check-licenses-$(CONTAINER_HASH)
+check-licenses:
+	@echo "Running check: $@"
+	@-if docker inspect $(CHECK_CONTAINER_NAME) &>/dev/null; then\
+		docker rm $(CHECK_CONTAINER_NAME) &>/dev/null; \
+	fi
+	@docker create --name $(CHECK_CONTAINER_NAME) $(IMAGE_NAME) >/dev/null
+	@echo "Checking if container image included dependencies' LICENSE files..."
+	@docker export $(CHECK_CONTAINER_NAME) | tar -tf - \
+		| grep usr/share/licenses/bottlerocket-update-operator/vendor \
+		| grep -q LICENSE || { \
+			echo "Container image is missing required LICENSE files (checked $(IMAGE_NAME))"; \
+			docker rm $(CHECK_CONTAINER_NAME) &>/dev/null; \
+			exit 1; \
+		}
+	@-docker rm $(CHECK_CONTAINER_NAME) &>/dev/null
 
 # Clean the build artifacts on disk.
 clean:
@@ -160,3 +187,22 @@ unsafe-dashboard:
 # Print the Node operational management status.
 get-nodes-status:
 	kubectl get nodes -o json | jq -C -S '.items | map(.metadata|{(.name): (.annotations|to_entries|map(select(.key|startswith("bottlerocket")))|from_entries)}) | add'
+
+# sdk-image fetches and loads the bottlerocket SDK container image for build and
+# license collection.
+sdk-image: BUILDSYS_SDK_IMAGE_URL=https://cache.bottlerocket.aws/$(BUILDSYS_SDK_IMAGE).tar.gz
+sdk-image:
+	docker inspect $(BUILDSYS_SDK_IMAGE) 2>&1 >/dev/null \
+		|| curl -# -qL $(BUILDSYS_SDK_IMAGE_URL) | docker load -i /dev/stdin
+
+# licenses builds a container image with the LICENSE & legal files from source
+# and its dependencies.
+#
+# These files are collected using the Go toolchain and license scanner in the
+# bottlerocket SDK image.
+licenses: sdk-image go.mod go.sum
+	docker build \
+		--network=host \
+		--build-arg SDK_IMAGE=$(BUILDSYS_SDK_IMAGE) \
+		-t $(LICENSES_IMAGE) \
+		-f build/Dockerfile.licenses .

--- a/Makefile
+++ b/Makefile
@@ -195,11 +195,12 @@ sdk-image:
 	docker inspect $(BUILDSYS_SDK_IMAGE) 2>&1 >/dev/null \
 		|| curl -# -qL $(BUILDSYS_SDK_IMAGE_URL) | docker load -i /dev/stdin
 
-# licenses builds a container image with the LICENSE & legal files from source
-# and its dependencies.
+# licenses builds a container image with the LICENSE & legal files from the
+# source's dependencies. This image is consumed during build (see `container`)
+# to COPY the result into the distributed container image.
 #
-# These files are collected using the Go toolchain and license scanner in the
-# bottlerocket SDK image.
+# Dependencies are walked using the Go toolchain and then processed with the
+# project's license scanner, which is built into the bottlerocket SDK image.
 licenses: sdk-image go.mod go.sum
 	docker build \
 		--network=host \

--- a/build/Dockerfile.licenses
+++ b/build/Dockerfile.licenses
@@ -1,0 +1,45 @@
+# This Dockerfile produces an image that has only the licenses of dependencies
+# used in the update operator. These are collected by bottlerocket-license-scan
+# and organized into a project-wide conventional directory structure rooted at
+# /licenses in the resulting image.
+
+# SDK_IMAGE is the Bottlerocket SDK container image that provides
+# `bottlerocket-license-scan`.
+#
+# Generally, this will track the value of BUILDSYS_SDK_IMAGE provided in
+# Bottlerocket's Makefile.toml:
+#
+# https://github.com/bottlerocket-os/bottlerocket/blob/develop/Makefile.toml
+#
+# For example, see this line in Makefile.toml:
+#
+# https://github.com/bottlerocket-os/bottlerocket/blob/a1d098dcd9908e3db1dc290ed9dad53e6f8fe44c/Makefile.toml#L31
+#
+ARG SDK_IMAGE
+
+# Fetch dependencies into a vendor/ directory.
+FROM golang:1.13 as src
+ENV GOPROXY=direct
+WORKDIR /src
+COPY go.mod go.sum /src/
+RUN go mod download
+# Unpack go modules into a vendor/ directory to run scanner on.
+COPY ./ /src/
+RUN go mod vendor
+
+# Run the license scanner and dump its processed & collected license data to be
+# used in distributed container image.
+FROM $SDK_IMAGE as license-scan
+COPY --from=src /src/vendor /src/vendor
+COPY --from=src /src/clarify.toml /src/clarify.toml
+USER root
+RUN bottlerocket-license-scan \
+    --spdx-data /usr/libexec/tools/spdx-data \
+    --out-dir /out/licenses \
+    --clarify /src/clarify.toml \
+    go-vendor /src/vendor
+
+# Final container image has LICENSE files and accompanying attributions
+# collected and produced by the license scanner.
+FROM scratch as licenses
+COPY --from=license-scan /out/licenses /licenses

--- a/build/Dockerfile.licenses
+++ b/build/Dockerfile.licenses
@@ -1,10 +1,12 @@
 # This Dockerfile produces an image that has only the licenses of dependencies
-# used in the update operator. These are collected by bottlerocket-license-scan
-# and organized into a project-wide conventional directory structure rooted at
+# used in the update operator.
+#
+# LICENSE, and other legal notices, are collected by bottlerocket-license-scan
+# to be organized into a project-wide conventional directory structure rooted at
 # /licenses in the resulting image.
 
 # SDK_IMAGE is the Bottlerocket SDK container image that provides
-# `bottlerocket-license-scan`.
+# `bottlerocket-license-scan` in it.
 #
 # Generally, this will track the value of BUILDSYS_SDK_IMAGE provided in
 # Bottlerocket's Makefile.toml:

--- a/clarify.toml
+++ b/clarify.toml
@@ -1,0 +1,7 @@
+[clarify."sigs.k8s.io/yaml"]
+# The package's files are a mix of MIT with contributions attributed to "The Go
+# Authors" licensed as BSD-3-Clause.
+expression = "MIT AND BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0xcdf3ae00 },
+]


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

The licenses of the update operator and its dependencies are now copied into the resulting container image at `/usr/share/licenses/bottlerocket-update-operator` (for the operator itself) and `/usr/share/licenses/bottlerocket-update-operator/vendor` (for dependencies). The dependencies' licenses are collected and processed by the project's license scanner for a given build. In addition, this change includes clarification (in `clarify.toml`) for the licenses that were not automatically detected - namely: `sigs.k8s.io/yaml`.

**Testing done:**

```sh
make container
make dist
make check
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.


---

*note: the current based branch will be updated to `develop` when #3 is merged*