### PR TITLE
Add SECURITY.md boilerplate.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+## Reporting a Vulnerability
+
+If you discover a potential security issue in this project, we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to aws-security@amazon.com.
+Please do **not** create a public GitHub issue.


### PR DESCRIPTION
This adds a security doc that will show up in the security policy link.

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
