### PR TITLE
change `platform-version` to `updater-interface-version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,27 +48,29 @@ kubectl apply -f ./update-operator.yaml
 Once the deployment's resources are in place, there is one more step needed to schedule and place the required pods on Bottlerocket nodes.
 By default - in the suggested deployment, each Workload resource constrains scheduling of the update operator by limiting pods to Bottlerocket nodes based on their labels.
 These labels are not applied on nodes automatically and will need to be set on each using `kubectl`.
-Deployments match on `bottlerocket.aws/platform-version` (a host compatibility label) to determine which pod to schedule.
+The agent relies on each node's updater components and schedules its pods based on their interface supported.
+The node indicates its updater interface version in a label called `bottlerocket.aws/updater-interface-version`.
+Agent deployments, respective to the interface version, are scheduled using this label and target only a single version in each.
 
-For the `1.0.0` `platform-version`, this label looks like:
+For the `1.0.0` `updater-interface-version`, this label looks like:
 
 ``` text
-bottlerocket.aws/platform-version=1.0.0
+bottlerocket.aws/updater-interface-version=1.0.0
 ```
 
 `kubectl` can be used to set this label on a node in the cluster:
 
 ``` sh
-kubectl label node $NODE_NAME bottlerocket.aws/platform-version=1.0.0
+kubectl label node $NODE_NAME bottlerocket.aws/updater-interface-version=1.0.0
 ```
 
-If all nodes in the cluster are running Bottlerocket and have the same `platform-version`, all can be labeled at the same time:
+If all nodes in the cluster are running Bottlerocket and have the same `updater-interface-version`, all can be labeled at the same time:
 
 ``` sh
-kubectl label node $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}') bottlerocket.aws/platform-version=1.0.0
+kubectl label node $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}') bottlerocket.aws/updater-interface-version=1.0.0
 ```
 
-Each workload resource may have additional constraints or scheduling affinities based on each node's labels in addition to the `bottlerocket.aws/platform-version` label scheduling constraint.
+Each workload resource may have additional constraints or scheduling affinities based on each node's labels in addition to the `bottlerocket.aws/updater-interface-version` label scheduling constraint.
 
 Customized deployments may use the [suggested deployment](./update-operator.yaml) or the [example development deployment](./dev/deployment.yaml) as a starting point, with customized container images specified if needed.
 

--- a/dev/deployment.yaml
+++ b/dev/deployment.yaml
@@ -94,7 +94,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: bottlerocket.aws/platform-version
+                  - key: bottlerocket.aws/updater-interface-version
                     operator: Exists
                   - key: "kubernetes.io/os"
                     operator: In
@@ -109,7 +109,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 10
               podAffinityTerm:
-                topologyKey: bottlerocket.aws/platform-version
+                topologyKey: bottlerocket.aws/updater-interface-version
                 labelSelector:
                   matchExpressions:
                     - key: update-operator
@@ -152,7 +152,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: bottlerocket.aws/platform-version
+                  - key: bottlerocket.aws/updater-interface-version
                     operator: Exists
                   - key: "kubernetes.io/os"
                     operator: In

--- a/pkg/marker/keys.go
+++ b/pkg/marker/keys.go
@@ -8,18 +8,18 @@ const (
 
 	// NodeSelectorLabel is used to identify controlled nodes in Kubernetes
 	// selectors.
-	NodeSelectorLabel = PlatformVersionKey
+	NodeSelectorLabel = UpdaterInterfaceVersionKey
 	// PodSelectorLabel is used to identify Pods participating with the
 	// operator.
-	PodSelectorLabel = PlatformVersionKey
+	PodSelectorLabel = UpdaterInterfaceVersionKey
 
 	// UpdateAvailableKey is used to identify a Node as having an update
 	// available. The value itself is not checked at this time but may be used
 	// to communicate a version at a later time.
 	UpdateAvailableKey Key = Prefix + "/update-available"
-	// PlatformVersionKey is where the compatibility version is posted for the
+	// UpdaterInterfaceVersionKey is where the compatibility version is posted for the
 	// given Node.
-	PlatformVersionKey Key = Prefix + "/platform-version"
+	UpdaterInterfaceVersionKey Key = Prefix + "/updater-interface-version"
 	// OperatorVersionKey is where the compatibility version is posted for the
 	// given Node. This version describes the understood "protocol" between
 	// Operating Controller and the managed Nodes.

--- a/update-operator.yaml
+++ b/update-operator.yaml
@@ -94,7 +94,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: bottlerocket.aws/platform-version
+                  - key: bottlerocket.aws/updater-interface-version
                     operator: Exists
                   - key: "kubernetes.io/os"
                     operator: In
@@ -109,7 +109,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 10
               podAffinityTerm:
-                topologyKey: bottlerocket.aws/platform-version
+                topologyKey: bottlerocket.aws/updater-interface-version
                 labelSelector:
                   matchExpressions:
                     - key: update-operator
@@ -152,7 +152,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: bottlerocket.aws/platform-version
+                  - key: bottlerocket.aws/updater-interface-version
                     operator: Exists
                   - key: "kubernetes.io/os"
                     operator: In


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses https://github.com/bottlerocket-os/bottlerocket-update-operator/issues/4


**Description of changes:**
This commit renames references of `platform-version` to
`platform-interface-version` to better convey the label's meaning and
avoid conflicts with other keywords.


**Testing done:**
Built my own Bottlerocket update operator container with the changes, modified `update-operator.yaml` to pull that container for the agent and controller.
Labelled my nodes in my cluster with the updated key name (`bottlerocket.aws/updater-interface-version`) and I see the pods being scheduled to run immediately after.
```
$ kubectl label node $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}') bottlerocket.aws/updater-interface-version=1.0.0
node/ip-192-168-17-182.us-west-2.compute.internal labeled
node/ip-192-168-25-184.us-west-2.compute.internal labeled
node/ip-192-168-40-60.us-west-2.compute.internal labeled
node/ip-192-168-60-95.us-west-2.compute.internal labeled
node/ip-192-168-70-84.us-west-2.compute.internal labeled
node/ip-192-168-9-191.us-west-2.compute.internal labeled 
$ kubectl get pods -A
NAMESPACE      NAME                                         READY   STATUS    RESTARTS   AGE
bottlerocket   update-operator-agent-5zm4x                  1/1     Running   0          14s
bottlerocket   update-operator-agent-6wlwq                  1/1     Running   0          14s
bottlerocket   update-operator-agent-85xfj                  1/1     Running   0          14s
bottlerocket   update-operator-agent-j99mq                  1/1     Running   0          14s
bottlerocket   update-operator-agent-r27ng                  1/1     Running   0          14s
bottlerocket   update-operator-agent-tjwjs                  1/1     Running   0          14s
bottlerocket   update-operator-controller-f749847d7-2mvhs   1/1     Running   0          2m52s
....
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
