### PR TITLE
Dockerfile: golang image version bump from 1.13 to 1.14.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG LICENSES_IMAGE=scratch
 
 # GOLANG_IMAGE is the go toolchain container image used to build the update
 # operator.
-ARG GOLANG_IMAGE=golang:1.13
+ARG GOLANG_IMAGE=golang:1.14.1
 
 FROM $LICENSES_IMAGE as licenses
 # Set WORKDIR to create /licenses/ if the directory is missing.

--- a/build/Dockerfile.licenses
+++ b/build/Dockerfile.licenses
@@ -22,7 +22,7 @@ ARG SDK_IMAGE
 # GOLANG_IMAGE is the image to be used for collecting modules. This should be
 # the same image used in the build. The idea is to have the same toolchain to
 # avoid running into any differences between versions.
-ARG GOLANG_IMAGE=golang:1.13
+ARG GOLANG_IMAGE=golang:1.14.1
 
 # Fetch dependencies into a vendor/ directory.
 #


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Bumps the golang image version from 1.13 to 1.14.1 to match the
bottlerocket's SDK golang toolchain version


**Testing done:**
`make container` builds the update operator container image successfully.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
