### PR TITLE
platform-updog: treat no update available as a non error

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -159,6 +159,8 @@ func (a *Agent) checkUpdate(log logging.Logger) (bool, error) {
 	log = log.WithField("update-available", hasUpdate)
 	if hasUpdate {
 		log.Info("an update is available")
+	} else {
+		log.Info("no update available")
 	}
 	return hasUpdate, nil
 }


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses https://github.com/bottlerocket-os/bottlerocket-update-operator/issues/24


**Description of changes:**
Determines if `updog` has returned `no update available` when querying
for updates and have the agent treat it as a non-error even if `updog`
returns a non-zero exit code.


**Testing done:**
Launched latest Bottlerocket version instance, have it join my cluster, label it for the update operator.
<details>
<summary>Observed the following</summary>

```
DEBU[2020-04-06T21:54:53Z] starting                                      component=agent worker=informer
DEBU[2020-04-06T21:54:53Z] resource add event                            component=agent worker=informer
DEBU[2020-04-06T21:54:53Z] active intent received                        component=agent intent="stabilize,unknown,unknown update:unknown" node=ip-192-168-7-212.us-west-2.compute.internal
DEBU[2020-04-06T21:54:53Z] handling intent                               component=agent intent="stabilize,unknown,unknown update:unknown" worker=handler
DEBU[2020-04-06T21:54:53Z] posted intent                                 component=agent intent="stabilize,stabilize,busy update:unknown" node=ip-192-168-7-212.us-west-2.compute.internal
DEBU[2020-04-06T21:54:53Z] sitrep                                        component=agent intent="stabilize,unknown,unknown update:unknown" worker=handler
DEBU[2020-04-06T21:54:53Z] querying status                               component=platform
DEBU[2020-04-06T21:54:53Z] fetching list of available updates            component=platform
DEBU[2020-04-06T21:54:53Z] running command                               cmd="/usr/bin/updog check-update" component=updog subcomponent=host-bin
INFO[2020-04-06T21:54:54Z] no update available                           component=agent intent="stabilize,unknown,unknown update:unknown" update-available=false worker=handler 
...
``` 

</details>

<details>
<summary>Whereas before ... (without these changes):</summary>

```
DEBU[2020-04-06T22:09:11Z] running command                               cmd="/usr/bin/updog check-update" component=updog subcomponent=host-bin
ERRO[2020-04-06T22:09:11Z] error during command run                      cmd="/usr/bin/updog check-update" component=updog error="exit status 1" subcomponent=host-bin
ERRO[2020-04-06T22:09:11Z] unable to query available updates             component=agent error="unable to check for updates: exit status 1" intent="stabilize,stabilize,busy update:unknown" worker=handler
ERRO[2020-04-06T22:09:11Z] sitrep update check errored                   component=agent error="unable to check for updates: exit status 1" intent="stabilize,stabilize,busy update:unknown" worker=handler 
```

</details>

The updater interface no longer treats no available update as an error.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
