### PR TITLE
platform api: list update when non-nil

### DIFF
--- a/pkg/platform/api/platform.go
+++ b/pkg/platform/api/platform.go
@@ -53,6 +53,10 @@ type listAvailableResponse struct {
 }
 
 func (lar *listAvailableResponse) Updates() []platform.Update {
+	if lar.chosenUpdate == nil {
+		return nil
+	}
+
 	return []platform.Update{lar.chosenUpdate}
 }
 


### PR DESCRIPTION


<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

When using the `update-api` update platform, the node lists itself as having updates available when it does not. This is because the response includes a `nil` update in its list. The update itself isn't inspected and instead the response is checked for `len(availableUpdatesResponse.Updates()) > 0`. The `nil` element makes this evaluate to `true` and then the node will cycle through update attempts.

**Testing done:**

Nodes in a cluster running Bottlerocket `0.5.0` upgrades successfully to an artificial `0.5.1` then stabilize.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
