### PR TITLE
use superpowered label for the API agent

### DIFF
--- a/update-operator.yaml
+++ b/update-operator.yaml
@@ -191,6 +191,12 @@ spec:
           volumeMounts:
             - name: bottlerocket-api-socket
               mountPath: /run/api.sock
+          securityContext:
+            seLinuxOptions:
+              user: system_u
+              role: system_r
+              type: super_t
+              level: s0
       volumes:
         - name: bottlerocket-api-socket
           hostPath:


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
After https://github.com/bottlerocket-os/bottlerocket/pull/1056 makes its way into a release, Bottlerocket will require containers to opt-in to API access by using either the `control_t` or `super_t` labels.

Since `control_t` is not defined in the SELinux policy on older versions of Bottlerocket, set `super_t` instead until that release is widely available.


**Testing done:**
Installed the operator on my cluster and verified that the agent had the expected label.

```
$ ps Z $(pgrep -f bottlerocket-update-operator)
LABEL                               PID TTY      STAT   TIME COMMAND
system_u:system_r:super_t:s0     544512 ?        Ssl    0:00 /bottlerocket-update-operator -agent -debug -nodeName ...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
