### PR TITLE
Update docs, update cpu/memory request, limits for update-api agent DaemonSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,27 +52,31 @@ The agent relies on each node's updater components and schedules its pods based 
 The node indicates its updater interface version in a label called `bottlerocket.aws/updater-interface-version`.
 Agent deployments, respective to the interface version, are scheduled using this label and target only a single version in each.
 
-For the `1.0.0` `updater-interface-version`, this label looks like:
+- For Bottlerocket OS versions >= v0.4.1, we recommend using `update-interface-version` 2.0.0 to leverage Bottlerocket's API to dispatch updates.
+- Bottlerocket OS versions < v0.4.1 are only compatible with `update-interface-version` 1.0.0.
+  - With this version, the agent needs to run in a priviledged container with access to the root filesystem.
+
+For the `2.0.0` `updater-interface-version`, this label looks like:
 
 ``` text
-bottlerocket.aws/updater-interface-version=1.0.0
+bottlerocket.aws/updater-interface-version=2.0.0
 ```
 
 `kubectl` can be used to set this label on a node in the cluster:
 
 ``` sh
-kubectl label node $NODE_NAME bottlerocket.aws/updater-interface-version=1.0.0
+kubectl label node $NODE_NAME bottlerocket.aws/updater-interface-version=2.0.0
 ```
 
 If all nodes in the cluster are running Bottlerocket and have the same `updater-interface-version`, all can be labeled at the same time:
 
 ``` sh
-kubectl label node $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}') bottlerocket.aws/updater-interface-version=1.0.0
+kubectl label node $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}') bottlerocket.aws/updater-interface-version=2.0.0
 ```
 
 Each workload resource may have additional constraints or scheduling affinities based on each node's labels in addition to the `bottlerocket.aws/updater-interface-version` label scheduling constraint.
 
-Customized deployments may use the [suggested deployment](./update-operator.yaml) or the [example development deployment](./dev/deployment.yaml) as a starting point, with customized container images specified if needed.
+Customized deployments may use the [suggested deployment](./update-operator.yaml) as a starting point, with customized container images specified if needed.
 
 ## Scheduled Components
 

--- a/update-operator.yaml
+++ b/update-operator.yaml
@@ -131,7 +131,7 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
 ---
-# This DaemonSet is for Bottlerocket hosts that support updates through the Bottlerocket API
+# This DaemonSet is for Bottlerocket hosts that support updates through the Bottlerocket API (Bottlerocket OS versions >= v0.4.1)
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -203,7 +203,7 @@ spec:
             path: /run/api.sock
             type: Socket
 ---
-# This DaemonSet is for Bottlerocket hosts that can only support updates through updog
+# This DaemonSet is for Bottlerocket hosts that can only support updates through updog (Bottlerocket OS versions < v0.4.1)
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/update-operator.yaml
+++ b/update-operator.yaml
@@ -184,10 +184,10 @@ spec:
                   fieldPath: spec.nodeName
           resources:
             limits:
-              memory: 600Mi
+              memory: 50Mi
             requests:
-              cpu: 100m
-              memory: 600Mi
+              cpu: 10m
+              memory: 50Mi
           volumeMounts:
             - name: bottlerocket-api-socket
               mountPath: /run/api.sock


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
https://github.com/bottlerocket-os/bottlerocket-update-operator/issues/54
https://github.com/bottlerocket-os/bottlerocket-update-operator/issues/47

**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Feb 15 13:17:29 2021 -0800

    deployment: change cpu and memory request, limits for api agent pods
    
    Significantly lower cpu, memory request/limits for the update-api agent
    DaemonSet


```

```
commit 96771ced4149e95ebc92ae65aeb63a436e573d74
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Feb 15 13:05:04 2021 -0800

    README: change recommended update interface version to 2.0.0, add desc
    
    Update documentation to include short descriptions of the update
    interface versions. Include compatibility information

```


**Testing done:**

Monitored the memory usage of the agent using the update API. I never saw it peak above 25MB in physical memory usage.
Tried different CPU request values, the agent still works fine in updating nodes when requesting 10 millicores.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
