### PR TITLE
Handles drain failure and node health check

### DIFF
--- a/pkg/controller/manager_kubernetes.go
+++ b/pkg/controller/manager_kubernetes.go
@@ -1,6 +1,9 @@
 package controller
 
 import (
+	"context"
+	"time"
+
 	"github.com/bottlerocket-os/bottlerocket-update-operator/pkg/intent"
 	"github.com/bottlerocket-os/bottlerocket-update-operator/pkg/k8sutil"
 	"github.com/bottlerocket-os/bottlerocket-update-operator/pkg/logging"
@@ -14,6 +17,7 @@ import (
 )
 
 type k8sNodeManager struct {
+	log  logging.Logger
 	kube kubernetes.Interface
 }
 
@@ -23,8 +27,33 @@ func (k *k8sNodeManager) forNode(nodeName string) (*v1.Node, *drain.Helper, erro
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "unable to retrieve node from api")
 	}
-	drainer = &drain.Helper{Client: k.kube}
+	drainer = &drain.Helper{
+		Ctx:    context.TODO(),
+		Client: k.kube,
+		Out:    k.log.WriterLevel(logrus.InfoLevel),
+		ErrOut: k.log.WriterLevel(logrus.ErrorLevel),
+		// Ignore daemon-set drain so that agent running on node is not drained. Also, Kubernetes
+		// daemon-set ignores unschedulable markings and gets immediately replaced, so there is no
+		// point in draining pods managed by daemon-sets
+		IgnoreAllDaemonSets: true,
+		// Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained).
+		DeleteEmptyDirData: true,
+		// The length of time to wait before giving up, default is infinite.
+		// 15 minutes is just a reasonable estimate
+		Timeout: time.Duration(15) * time.Minute,
+		// Custom logic to prevent drain of update operator controller
+		AdditionalFilters: []drain.PodFilter{
+			k.skipController,
+		},
+	}
 	return node, drainer, err
+}
+
+func (k *k8sNodeManager) skipController(pod v1.Pod) drain.PodDeleteStatus {
+	if pod.GetLabels()["update-operator"] == "controller" {
+		return drain.MakePodDeleteStatusWithWarning(false, "ignoring update operator controller pod")
+	}
+	return drain.MakePodDeleteStatusOkay()
 }
 
 func (k *k8sNodeManager) setCordon(nodeName string, cordoned bool) error {
@@ -52,7 +81,25 @@ func (k *k8sNodeManager) Drain(nodeName string) error {
 }
 
 func (am *actionManager) checkNode(nodeName string) error {
-	return nil
+	node, err := am.kube.CoreV1().Nodes().Get(context.TODO(), nodeName, v1meta.GetOptions{})
+	if err != nil {
+		return errors.WithMessage(err, "unable to retrieve node from api")
+	}
+	// Retry node condition Ready for max 5 minutes
+	lastCondition := v1.NodeCondition{}
+	for i := 0; i < 30; i++ {
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == v1.NodeReady {
+				if condition.Status == v1.ConditionTrue {
+					return nil
+				}
+				lastCondition = condition
+			}
+		}
+		// delay before checking again
+		time.Sleep(10 * time.Second)
+	}
+	return errors.Errorf("node did not come up healthy: %q", lastCondition)
 }
 
 type k8sPoster struct {

--- a/pkg/platform/api/platform.go
+++ b/pkg/platform/api/platform.go
@@ -85,6 +85,10 @@ func (p apiPlatform) Prepare(target platform.Update) error {
 	if err != nil {
 		return err
 	}
+	if updateStatus.UpdateState == stateReady {
+		// update preformed previously
+		return nil
+	}
 	if updateStatus.UpdateState != stateAvailable && updateStatus.UpdateState != stateStaged {
 		return errors.Errorf("unexpected update state: %s, expecting state to be 'Available' or 'Staged'. update action performed out of band?", updateStatus.UpdateState)
 	}
@@ -109,6 +113,10 @@ func (p apiPlatform) Update(target platform.Update) error {
 	updateStatus, err := p.apiClient.GetUpdateStatus()
 	if err != nil {
 		return err
+	}
+	if updateStatus.UpdateState == stateReady {
+		// update preformed previously
+		return nil
 	}
 	if updateStatus.UpdateState != stateStaged {
 		return errors.Errorf("unexpected update state: %s, expecting state to be 'Staged'. update action performed out of band?", updateStatus.UpdateState)

--- a/update-operator.yaml
+++ b/update-operator.yaml
@@ -15,6 +15,14 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "delete"]
+  # Needed to determine Pod owners
+  - apiGroups: [ "apps" ]
+    resources: [ "daemonsets" ]
+    verbs: [ "get", "list" ]
+  # Needed to evict pods
+  - apiGroups: [ "" ]
+    resources: [ "pods/eviction" ]
+    verbs: [ "create" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#12 


**Description of changes:**

    Previously, update operator would ignore the drain failure and
    move on to updating the node anyway. This change configures Kubernetes
    Drain helper to ignore Daemonset drain and Brupop controller drain.
    Additionally, drain failure is considered a fatal error and error is
    returned after changing node to be schedulable. In addition to drain
    fixes, this change does node health check and adds delay for workload
    to return on node after update.

**Testing done:**
1. Started a Kubernetes cluster with two instances and saw them getting updated successfully with brupop.
2. Started a Kubernetes cluster with two instances and a nginx deployment with PDB and saw them getting updated successfully with brupop.

Nginx deployment yaml:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
spec:
  selector:
    matchLabels:
      app: nginx
  replicas: 2 # tells deployment to run 2 pods matching the template
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
---
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  name: zk-pdb
spec:
  minAvailable: 1
  selector:
    matchLabels:
      app: nginx
```
Important logs: 
```
time="2021-07-30T18:07:16Z" level=info msg="starting drain" component=controller intent="reboot-update,perform-update,ready update:true" node=ip-192-168-63-201.us-west-2.compute.internal worker=manager
time="2021-07-30T18:07:16Z" level=error msg="WARNING: ignoring DaemonSet-managed Pods: bottlerocket/update-operator-agent-update-api-mx68n, kube-system/aws-node-bzp9l, kube-system/kube-proxy-vnqzp; ignoring update operator controller pod: bottlerocket/update-operator-controller-76c456fc6c-4txx4" component=controller worker=manager
time="2021-07-30T18:07:16Z" level=info msg="evicting pod bottlerocket/nginx-deployment-66b6c48dd5-v6kxc" component=controller worker=manager
time="2021-07-30T18:07:16Z" level=info msg="drain successful" component=controller intent="reboot-update,perform-update,ready update:true" node=ip-192-168-63-201.us-west-2.compute.internal worker=manager
```

There is lot more testing required, therefore marking this PR as draft.
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
