### PR TITLE
0.2.0: Add initial implementation of agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,23 @@ dependencies = [
 [[package]]
 name = "agent"
 version = "0.1.0"
+dependencies = [
+ "apiserver",
+ "chrono",
+ "dotenv",
+ "env_logger",
+ "futures",
+ "k8s-openapi",
+ "kube",
+ "kube-runtime",
+ "log",
+ "models",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+]
 
 [[package]]
 name = "ahash"
@@ -318,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "bytes"
@@ -573,9 +590,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
  "cfg-if",
 ]
@@ -922,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
@@ -1643,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
  "base64",
  "bytes",
@@ -2178,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
+checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2433,9 +2450,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
@@ -2508,8 +2525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -6,3 +6,22 @@ edition = "2018"
 publish = false
 
 [dependencies]
+models = { path = "../models", version = "0.1.0" }
+apiserver = { path = "../apiserver", version = "0.1.0" }
+
+dotenv = "0.15"
+env_logger = "0.9"
+futures = "0.3"
+
+# k8s-openapi must match the version required by kube and enable a k8s version feature
+k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_20"] }
+kube = { version = "0.59.0", default-features = true, features = [ "derive"] }
+kube-runtime = "0.59.0"
+
+log = "0.4"
+serde = { version = "1", features = [ "derive" ] }
+serde_json = "1"
+snafu = "0.6"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+reqwest = { version = "0.11", features =  [ "json" ] }
+chrono = { version = "0.4.11", features = [ "serde" ] }

--- a/agent/src/agentclient.rs
+++ b/agent/src/agentclient.rs
@@ -1,0 +1,310 @@
+use chrono::naive::NaiveDateTime;
+use k8s_openapi::api::core::v1::Node;
+use kube::Api;
+use snafu::OptionExt;
+use snafu::ResultExt;
+use std::env;
+use std::process::Command;
+use tokio::time::{sleep, Duration};
+
+use crate::apiclient::{boot_update, get_os_info, list_available, prepare, update};
+use crate::error::{self, Result};
+use apiserver::api::{CreateBottlerocketNodeRequest, UpdateBottlerocketNodeRequest};
+use models::constants::{APISERVER_SERVICE_NAME, APISERVER_SERVICE_PORT, NAMESPACE};
+use models::node::{
+    node_resource_name, BottlerocketNode, BottlerocketNodeSelector, BottlerocketNodeState,
+    BottlerocketNodeStatus,
+};
+
+const AGENT_SLEEP_DURATION: Duration = Duration::from_secs(5);
+const NODE_RESOURCE_ENDPOINT: &'static str = "/bottlerocket-node-resource";
+
+#[derive(Clone)]
+pub struct BrupopAgent {
+    k8s_client: kube::client::Client,
+    node_selector: Option<BottlerocketNodeSelector>,
+}
+
+impl BrupopAgent {
+    pub fn new(k8s_client: kube::client::Client) -> Self {
+        BrupopAgent {
+            k8s_client,
+            node_selector: None,
+        }
+    }
+
+    pub async fn check_node_custom_resource_exists(&mut self) -> Result<bool> {
+        let associated_bottlerocketnode_name = node_resource_name(&self.get_node_selector().await?);
+        let bottlerocket_nodes: Api<BottlerocketNode> =
+            Api::namespaced(self.k8s_client.clone(), NAMESPACE);
+
+        Ok(bottlerocket_nodes
+            .get(&associated_bottlerocketnode_name)
+            .await
+            .context(error::BottlerocketNodeNotExist {
+                node_name: associated_bottlerocketnode_name,
+            })
+            .is_ok())
+    }
+
+    pub async fn check_custom_resource_status_exists(&mut self) -> Result<bool> {
+        Ok(self.fetch_custom_resource().await?.status.is_some())
+    }
+
+    async fn get_node_selector(&mut self) -> Result<BottlerocketNodeSelector> {
+        if self.node_selector.is_none() {
+            let associated_node_name = env::var("MY_NODE_NAME").context(error::GetNodeName)?;
+
+            let nodes: Api<Node> = Api::all(self.k8s_client.clone());
+            let associated_node: Node = nodes
+                .get(&associated_node_name)
+                .await
+                .context(error::FetchNode)?;
+
+            let associated_node_uid = associated_node
+                .metadata
+                .uid
+                .context(error::MissingNodeUid)?;
+            self.node_selector = Some(BottlerocketNodeSelector {
+                node_name: associated_node_name.clone(),
+                node_uid: associated_node_uid.clone(),
+            });
+        }
+
+        Ok(self
+            .node_selector
+            .clone()
+            .context(error::NodeSelectorIsNone)?)
+    }
+
+    // fetch associated bottlerocketnode (custom resource) and help to get node `metadata`, `spec`, and  `status`.
+    async fn fetch_custom_resource(&mut self) -> Result<BottlerocketNode> {
+        // get associated bottlerocketnode (custom resource) name, and we can use this
+        // bottlerocketnode name to fetch targeted bottlerocketnode (custom resource) and get node `metadata`, `spec`, and  `status`.
+
+        //TODO: use a reflector to watch event instead of polling etcd
+        let associated_bottlerocketnode_name =
+            format!("brn-{}", self.get_node_selector().await?.node_name);
+
+        let bottlerocket_nodes: Api<BottlerocketNode> =
+            Api::namespaced(self.k8s_client.clone(), NAMESPACE);
+        let associated_bottlerocketnode: BottlerocketNode = bottlerocket_nodes
+            .get(&associated_bottlerocketnode_name)
+            .await
+            .context(error::FetchCustomResource)?;
+
+        Ok(associated_bottlerocketnode)
+    }
+
+    /// Gather metadata about the system, node status provided by spec.
+    async fn gather_system_metadata(
+        &mut self,
+        state: BottlerocketNodeState,
+    ) -> Result<BottlerocketNodeStatus> {
+        let current_version = get_os_info()
+            .await
+            .context(error::BottlerocketNodeStatusVersion)?;
+        let update_versions = list_available()
+            .await
+            .context(error::BottlerocketNodeStatusAvailableVersions)?;
+
+        Ok(BottlerocketNodeStatus {
+            current_version: current_version.version_id.clone(),
+            available_versions: update_versions,
+            current_state: state,
+        })
+    }
+
+    /// create the custom resource associated with this node
+    pub async fn create_metadata_custom_resource(&mut self) -> Result<()> {
+        let client = reqwest::Client::new();
+        let current_node_selector = self.get_node_selector().await?;
+        let node_req = CreateBottlerocketNodeRequest {
+            node_selector: current_node_selector.clone(),
+        };
+        let server_domain = get_server_domain();
+
+        let response = client
+            .post(format!(
+                "http://{}{}",
+                &server_domain, NODE_RESOURCE_ENDPOINT
+            ))
+            .json(&node_req)
+            .send()
+            .await
+            .context(error::CreateBottlerocketNodeResource {
+                node_name: current_node_selector.node_name,
+            })?;
+
+        log::info!(
+            "{}",
+            response
+                .text()
+                .await
+                .context(error::ConvertResponseToText)?
+        );
+
+        Ok(())
+    }
+
+    /// update the custom resource associated with this node
+    async fn update_metadata_custom_resource(
+        &mut self,
+        _current_metadata: BottlerocketNodeStatus,
+    ) -> Result<()> {
+        let client = reqwest::Client::new();
+        let current_node_selector = self.get_node_selector().await?;
+        let server_domain = get_server_domain();
+
+        let node_req = UpdateBottlerocketNodeRequest {
+            node_status: _current_metadata,
+            node_selector: current_node_selector.clone(),
+        };
+
+        let response = client
+            .put(format!(
+                "http://{}{}",
+                &server_domain, NODE_RESOURCE_ENDPOINT
+            ))
+            .json(&node_req)
+            .send()
+            .await
+            .context(error::UpdateBottlerocketNodeResource {
+                node_name: current_node_selector.node_name,
+            })?;
+
+        log::info!(
+            "{}",
+            response
+                .text()
+                .await
+                .context(error::ConvertResponseToText)?
+        );
+
+        Ok(())
+    }
+
+    /// initialize bottlerocketnode (custom resource) `status` when create new bottlerocketnode
+    pub async fn initialize_metadata_custom_resource(&mut self) -> Result<()> {
+        let update_node_status = self
+            .gather_system_metadata(BottlerocketNodeState::WaitingForUpdate)
+            .await?;
+
+        self.update_metadata_custom_resource(update_node_status)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn run(&mut self) -> Result<()> {
+        // A running agent has two responsibilities:
+        // - Gather metadata about the system and update the custom resource associated with this node
+        // - Determine if the spec on the system's custom resource demands the node take action. If so, begin taking that action.
+
+        loop {
+            // Requests metadata 'status' and 'spec' for the current BottlerocketNode
+            let bottlerocket_node = self.fetch_custom_resource().await?;
+
+            let bottlerocket_node_status = bottlerocket_node
+                .status
+                .context(error::MissingBottlerocketNodeStatus)?;
+            let bottlerocket_node_spec = bottlerocket_node.spec;
+
+            // Determine if the spec on the system's custom resource demands the node take action. If so, begin taking that action.
+            if bottlerocket_node_spec.state != bottlerocket_node_status.current_state {
+                log::info!("Detected drift between spec state and current state. Requesting node to take action: {:?}.", &bottlerocket_node_spec.state);
+
+                match bottlerocket_node_spec.state {
+                    BottlerocketNodeState::WaitingForUpdate => {
+                        log::info!("Ready to finish monitoring and start update process")
+                    }
+                    BottlerocketNodeState::PreparingToUpdate => {
+                        log::info!("Preparing update");
+                        prepare().await.context(error::UpdateActions {
+                            action: "Prepare".to_string(),
+                        })?;
+
+                        // TODO: This function needs to use the k8s drain API to remove any pods from the host,
+                        // and then we need to wait until the host is successfully drained before transitioning
+                        // to the next state.
+                    }
+                    BottlerocketNodeState::PerformingUpdate => {
+                        log::info!("Performing update");
+                        update().await.context(error::UpdateActions {
+                            action: "Perform".to_string(),
+                        })?;
+                    }
+                    BottlerocketNodeState::RebootingToUpdate => {
+                        log::info!("Rebooting node to complete update");
+
+                        if ensure_reboot_happened(&bottlerocket_node_status)? {
+                            // previous execution `reboot` exited loop and did not update the custom resource
+                            // associated with this node. When re-enter loop and finished reboot,
+                            // try to update the custom resource.
+                            let update_node_status = self
+                                .gather_system_metadata(bottlerocket_node_spec.state.clone())
+                                .await?;
+                            self.update_metadata_custom_resource(update_node_status)
+                                .await?;
+                        } else {
+                            boot_update().await.context(error::UpdateActions {
+                                action: "Reboot".to_string(),
+                            })?;
+                        }
+                    }
+                    BottlerocketNodeState::MonitoringUpdate => {
+                        log::info!("Monitoring node's healthy condtion");
+                        // TODO: we need add some critierias here by which we decide to transition
+                        // from MonitoringUpdate to WaitingForUpdate.
+                    }
+                }
+            } else {
+                log::info!("Did not detect action demand.");
+            }
+
+            // update the custom resource associated with this node
+            let update_node_status = self
+                .gather_system_metadata(bottlerocket_node_spec.state.clone())
+                .await?;
+            self.update_metadata_custom_resource(update_node_status)
+                .await?;
+
+            log::debug!(
+                "Agent loop completed. Sleeping for {:?}.",
+                AGENT_SLEEP_DURATION
+            );
+            sleep(AGENT_SLEEP_DURATION).await;
+        }
+    }
+}
+
+// ensure if the nodes just rebooted and re-enter the loop.
+fn ensure_reboot_happened(status: &BottlerocketNodeStatus) -> Result<bool> {
+    // criteria that make sure node just rebooted
+    // 1. Check if system last reboot time is same as or around the timestamp that agent tried to reboot the system
+    // 2. Check current system version if it's same as the version we wanted to update to. (latest version)
+
+    let output = Command::new("uptime")
+        .args(["-s"])
+        .output()
+        .context(error::GetUptime)?;
+
+    // convert output string to naivedatetime
+    let uptime = String::from_utf8_lossy(&output.stdout).to_string();
+    let reboot_time = NaiveDateTime::parse_from_str(&uptime.trim_end(), "%Y-%m-%d %H:%M:%S")
+        .context(error::ConvertStringToDatetime { uptime })?;
+
+    // TODO: compare uptime to the timestamp that we're issuing at custom resource
+    // currently we compare it to current time, if the reboot happened in the past 24 hours, we
+    // assume the system just rebooted.
+    let now = chrono::offset::Utc::now().naive_local();
+    let duration_since_reboot = now.signed_duration_since(reboot_time).num_hours();
+
+    Ok(duration_since_reboot <= 1 && status.available_versions[0] == status.current_version)
+}
+
+fn get_server_domain() -> String {
+    format!(
+        "{}.{}.svc.cluster.local:{}",
+        APISERVER_SERVICE_NAME, NAMESPACE, APISERVER_SERVICE_PORT
+    )
+}

--- a/agent/src/apiclient.rs
+++ b/agent/src/apiclient.rs
@@ -1,0 +1,351 @@
+/*!
+apiclient is a client for interacting with the Bottlerocket Update API.
+Brupop volume mounts apiclient binary into the agent container.
+
+Bottlerocket Update API: https://github.com/bottlerocket-os/bottlerocket/tree/develop/sources/updater
+Bottlerocket apiclient: https://github.com/bottlerocket-os/bottlerocket/tree/develop/sources/api/apiclient
+*/
+
+use serde::Deserialize;
+use snafu::{ensure, ResultExt};
+use std::process::{Command, Output};
+use tokio::time::{sleep, Duration};
+
+const API_CLIENT_BIN: &str = "apiclient";
+const UPDATES_STATUS_URI: &str = "/updates/status";
+const OS_URI: &str = "/os";
+const REFRESH_UPDATES_URI: &str = "/actions/refresh-updates";
+const PREPARE_UPDATES_URI: &str = "/actions/prepare-update";
+const ACTIVATE_UPDATES_URI: &str = "/actions/activate-update";
+const REBOOT_URI: &str = "/actions/reboot";
+const MAX_ATTEMPTS: i8 = 5;
+const UPDATE_API_SLEEP_DURATION: Duration = Duration::from_millis(10000);
+const UPDATE_API_BUSY_STATUSCODE: &str = "423";
+
+/// The module-wide result type.
+pub type Result<T> = std::result::Result<T, apiclient_error::Error>;
+
+/// UpdateState represents four states during system update process
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
+pub enum UpdateState {
+    // Idle: Unknow
+    Idle,
+    // Available: available versions system can update to
+    Available,
+    // Staged: processing system update (refresh, prepare, activate)
+    Staged,
+    // Ready: successfully complete update commands, ready to reboot
+    Ready,
+}
+
+/// UpdateCommand represents three commands to update system
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UpdateCommand {
+    // Refresh: refresh the list of available updates
+    Refresh,
+    // Prepare: request that the update be downloaded and applied to disk
+    Prepare,
+    // Activate: proceed to "activate" the update
+    Activate,
+}
+
+/// CommandStatus represents three status after running update command
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
+enum CommandStatus {
+    Success,
+    Failed,
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StagedImage {
+    image: Option<UpdateImage>,
+    next_to_boot: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommandResult {
+    cmd_type: UpdateCommand,
+    cmd_status: CommandStatus,
+    timestamp: String,
+    exit_status: u32,
+    stderr: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateImage {
+    arch: String,
+    version: String,
+    variant: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OsInfo {
+    pub version_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateStatus {
+    update_state: UpdateState,
+    available_updates: Vec<String>,
+    chosen_update: Option<UpdateImage>,
+    active_partition: Option<StagedImage>,
+    staging_partition: Option<StagedImage>,
+    most_recent_command: CommandResult,
+}
+
+fn get_raw_args(mut args: Vec<String>) -> Vec<String> {
+    let mut subcommand_args = vec!["raw".to_string(), "-u".to_string()];
+    subcommand_args.append(&mut args);
+
+    return subcommand_args;
+}
+
+/// Extract error statuscode from stderr string
+/// Error Example:
+/// "Failed POST request to '/actions/refresh-updates': Status 423 when POSTing /actions/refresh-updates: Update lock held\n"
+fn extract_status_code_from_error(error: &str) -> &str {
+    let error_content_split_by_status: Vec<&str> = error.split("Status").collect();
+    let error_content_split_by_whitespace: Vec<&str> = error_content_split_by_status[1]
+        .split_whitespace()
+        .collect();
+    let error_statuscode = error_content_split_by_whitespace[0];
+
+    error_statuscode
+}
+
+/// Apiclient binary has been volume mounted into the agent container, so agent is able to
+/// invoke `/bin apiclient` to interact with the Bottlerocket Update API.
+/// This function helps to invoke apiclient raw command.
+async fn invoke_apiclient(args: Vec<String>) -> Result<Output> {
+    let mut attempts: i8 = 0;
+    // Retry up to 5 times in case the Update API is busy; Waiting 10 seconds between each attempt.
+    while attempts < MAX_ATTEMPTS {
+        let output = Command::new(API_CLIENT_BIN)
+            .args(&args)
+            .output()
+            .context(apiclient_error::ApiClientRawCommand { args: args.clone() })?;
+
+        if output.status.success() {
+            return Ok(output);
+        }
+        let error_content = String::from_utf8_lossy(&output.stderr).to_string();
+        let error_statuscode = extract_status_code_from_error(&error_content);
+
+        match error_statuscode {
+            UPDATE_API_BUSY_STATUSCODE => {
+                log::info!(
+                    "API server busy, retrying in {:?} seconds ...",
+                    UPDATE_API_SLEEP_DURATION
+                );
+                // Retry after ten seconds if we get a 423 Locked response (update API busy)
+                sleep(UPDATE_API_SLEEP_DURATION).await;
+                attempts += 1;
+            }
+            _ => {
+                // API response was a non-transient error, bail out
+                return apiclient_error::BadHttpResponse {
+                    statuscode: error_statuscode,
+                }
+                .fail();
+            }
+        };
+    }
+    // Update API is currently unavailable, bail out
+    Err(apiclient_error::Error::UpdateApiUnavailable { args })
+}
+
+pub async fn get_update_status() -> Result<UpdateStatus> {
+    // Refresh list of updates and check if there are any available
+    refresh_updates().await?;
+
+    let raw_args = vec![UPDATES_STATUS_URI.to_string()];
+
+    let update_status_output = invoke_apiclient(get_raw_args(raw_args)).await?;
+
+    let update_status_string = String::from_utf8_lossy(&update_status_output.stdout).to_string();
+    let update_status: UpdateStatus = serde_json::from_str(&update_status_string)
+        .context(apiclient_error::UpdateStatusContent)?;
+
+    Ok(update_status)
+}
+
+/// extract OS info from the local system. For now this is just the version id.
+pub async fn get_os_info() -> Result<OsInfo> {
+    let raw_args = vec![OS_URI.to_string()];
+
+    let os_info_output = invoke_apiclient(get_raw_args(raw_args)).await?;
+
+    let os_info_content_string = String::from_utf8_lossy(&os_info_output.stdout).to_string();
+    let os_info: OsInfo =
+        serde_json::from_str(&os_info_content_string).context(apiclient_error::OsContent)?;
+
+    Ok(os_info)
+}
+
+pub async fn refresh_updates() -> Result<Output> {
+    let raw_args = vec![
+        REFRESH_UPDATES_URI.to_string(),
+        "-m".to_string(),
+        "POST".to_string(),
+    ];
+
+    Ok(invoke_apiclient(get_raw_args(raw_args)).await?)
+}
+
+pub async fn prepare_update() -> Result<()> {
+    let raw_args = vec![
+        PREPARE_UPDATES_URI.to_string(),
+        "-m".to_string(),
+        "POST".to_string(),
+    ];
+
+    invoke_apiclient(get_raw_args(raw_args)).await?;
+
+    Ok(())
+}
+
+pub async fn activate_update() -> Result<()> {
+    let raw_args = vec![
+        ACTIVATE_UPDATES_URI.to_string(),
+        "-m".to_string(),
+        "POST".to_string(),
+    ];
+
+    invoke_apiclient(get_raw_args(raw_args)).await?;
+
+    Ok(())
+}
+
+pub async fn reboot() -> Result<Output> {
+    let raw_args = vec![REBOOT_URI.to_string(), "-m".to_string(), "POST".to_string()];
+
+    Ok(invoke_apiclient(get_raw_args(raw_args)).await?)
+}
+
+// List all available versions which current Bottlerocket OS can update to.
+pub async fn list_available() -> Result<Vec<String>> {
+    let update_status = get_update_status().await?;
+
+    // Raise error if failed to refresh update or update acton performed out of band
+    ensure!(
+        update_status.most_recent_command.cmd_type == UpdateCommand::Refresh
+            && update_status.most_recent_command.cmd_status == CommandStatus::Success,
+        apiclient_error::RefreshUpdate
+    );
+
+    Ok(update_status.available_updates)
+}
+
+pub async fn prepare() -> Result<()> {
+    let update_status = get_update_status().await?;
+
+    ensure!(
+        update_status.update_state == UpdateState::Available
+            || update_status.update_state == UpdateState::Staged,
+        apiclient_error::UpdateStage {
+            expect_state: "Available or Staged".to_string(),
+            update_state: update_status.update_state,
+        },
+    );
+
+    // Download the update and apply it to the inactive partition
+    prepare_update().await?;
+
+    // Raise error if failed to prepare update or update action performed out of band
+    let recent_command = get_update_status().await?.most_recent_command;
+    ensure!(
+        recent_command.cmd_type == UpdateCommand::Prepare
+            || recent_command.cmd_status == CommandStatus::Success,
+        apiclient_error::PrepareUpdate
+    );
+
+    Ok(())
+}
+
+pub async fn update() -> Result<()> {
+    let update_status = get_update_status().await?;
+
+    ensure!(
+        update_status.update_state == UpdateState::Staged,
+        apiclient_error::UpdateStage {
+            expect_state: "Staged".to_string(),
+            update_state: update_status.update_state,
+        }
+    );
+
+    // Activate the prepared update
+    activate_update().await?;
+
+    // Raise error if failed to activate update or update action performed out of band
+    let recent_command = get_update_status().await?.most_recent_command;
+
+    ensure!(
+        recent_command.cmd_type == UpdateCommand::Activate
+            || recent_command.cmd_status == CommandStatus::Success,
+        apiclient_error::Update
+    );
+
+    Ok(())
+}
+
+// Reboot the host into the activated update
+pub async fn boot_update() -> Result<Output> {
+    let update_status = get_update_status().await?;
+
+    ensure!(
+        update_status.update_state == UpdateState::Ready,
+        apiclient_error::UpdateStage {
+            expect_state: "Ready".to_string(),
+            update_state: update_status.update_state,
+        }
+    );
+
+    Ok(reboot().await?)
+}
+
+pub mod apiclient_error {
+
+    use crate::apiclient::UpdateState;
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub")]
+    pub enum Error {
+        #[snafu(display("Failed to run apiclient command apiclient {:?}: {}", args.join(" "), source))]
+        ApiClientRawCommand {
+            args: Vec<String>,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to deserialize Os info: {}", source))]
+        OsContent { source: serde_json::Error },
+
+        #[snafu(display("Failed to deserialize update status: {}", source))]
+        UpdateStatusContent { source: serde_json::Error },
+
+        #[snafu(display("failed to refresh updates or update action performed out of band"))]
+        RefreshUpdate {},
+
+        #[snafu(display("failed to prepare update or update action performed out of band"))]
+        PrepareUpdate {},
+
+        #[snafu(display("failed to activate update or update action performed out of band"))]
+        Update {},
+
+        #[snafu(display(
+        "unexpected update state: {:?}, expecting state to be {}. update action performed out of band?",
+         update_state, expect_state
+    ))]
+        UpdateStage {
+            expect_state: String,
+            update_state: UpdateState,
+        },
+        #[snafu(display("bad http response, status code: {}", statuscode))]
+        BadHttpResponse { statuscode: String },
+
+        #[snafu(display("Unable to process command apiclient {}: update API unavailable: retries exhausted", args.join(" ")))]
+        UpdateApiUnavailable { args: Vec<String> },
+    }
+}

--- a/agent/src/error.rs
+++ b/agent/src/error.rs
@@ -1,0 +1,97 @@
+use crate::apiclient::apiclient_error;
+use snafu::Snafu;
+
+/// The crate-wide result type.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// The crate-wide error type.
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub")]
+pub enum Error {
+    #[snafu(display("Unable to create client: {}", source))]
+    ClientCreate { source: kube::Error },
+
+    #[snafu(display(
+        "Unable to fetch the Kubernetes custom resource associated with this node: {}",
+        source
+    ))]
+    FetchCustomResource { source: kube::Error },
+
+    #[snafu(display("Unable to get associated node name: {}", source))]
+    GetNodeName { source: std::env::VarError },
+
+    #[snafu(display(
+        "Unable to fetch the Kubernetes node associated with this pod: {}",
+        source
+    ))]
+    FetchNode { source: kube::Error },
+
+    #[snafu(display("Unable to get Node uid because of missing Node `uid` value"))]
+    MissingNodeUid {},
+
+    #[snafu(display("Fail to get Node selector value: Node selector value is None"))]
+    NodeSelectorIsNone {},
+
+    #[snafu(display("Unable to get Bottlerocket Node {}: {}", node_name, source))]
+    BottlerocketNodeNotExist {
+        node_name: String,
+        source: kube::Error,
+    },
+
+    #[snafu(display(
+        "Unable to get Bottlerocket node 'status' because of missing 'status' value"
+    ))]
+    MissingBottlerocketNodeStatus,
+
+    #[snafu(display("Unable to get Bottlerocket node 'spec' because of missing 'spec' value"))]
+    MissingBottlerocketNodeSpec,
+
+    #[snafu(display("Unable to gather system version metadata: {}", source))]
+    BottlerocketNodeStatusVersion { source: apiclient_error::Error },
+
+    #[snafu(display("Unable to gather system available versions metadata: {}", source))]
+    BottlerocketNodeStatusAvailableVersions { source: apiclient_error::Error },
+
+    #[snafu(display(
+        "Unable to update the custom resource associated with this node '{}' : {}",
+        node_name,
+        source
+    ))]
+    UpdateBottlerocketNodeResource {
+        node_name: String,
+        source: reqwest::Error,
+    },
+
+    #[snafu(display(
+        "Unable to create the custom resource associated with this node '{}' : {}",
+        node_name,
+        source
+    ))]
+    CreateBottlerocketNodeResource {
+        node_name: String,
+        source: reqwest::Error,
+    },
+
+    #[snafu(display("Unable to take action '{}': {}", action, source))]
+    UpdateActions {
+        action: String,
+        source: apiclient_error::Error,
+    },
+
+    #[snafu(display(
+        "Failed to run command 'uptime -s' to get latest system reboot time: '{}'",
+        source
+    ))]
+    GetUptime { source: std::io::Error },
+
+    #[snafu(display("Unable to convert `{} `to datetime: {}", uptime, source))]
+    ConvertStringToDatetime {
+        uptime: String,
+        source: chrono::ParseError,
+    },
+    #[snafu(display(
+        "Unable to convert response of interacting with custom resource to readable text: {}",
+        source
+    ))]
+    ConvertResponseToText { source: reqwest::Error },
+}

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod agentclient;
+pub mod apiclient;
+pub mod error;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,3 +1,43 @@
-fn main() {
-    println!("Hello, world!");
+use agent::agentclient::BrupopAgent;
+use agent::error::{self, Result};
+
+use snafu::ResultExt;
+
+use std::env;
+use std::fs;
+
+const TERMINATION_LOG: &str = "/dev/termination-log";
+#[tokio::main]
+async fn main() {
+    let termination_log = env::var("TERMINATION_LOG").unwrap_or(TERMINATION_LOG.to_string());
+
+    match run_agent().await {
+        Err(error) => {
+            fs::write(&termination_log, format!("{}", error))
+                .expect("Could not write k8s termination log.");
+        }
+        Ok(()) => {}
+    }
+}
+
+async fn run_agent() -> Result<()> {
+    env_logger::init();
+
+    let k8s_client = kube::client::Client::try_default()
+        .await
+        .context(error::ClientCreate)?;
+
+    let mut agent = BrupopAgent::new(k8s_client);
+
+    // Create a bottlerocketnode (custom resource) if associated bottlerocketnode does not exist
+    if !agent.check_node_custom_resource_exists().await? {
+        agent.create_metadata_custom_resource().await?;
+    }
+
+    // Initialize bottlerocketnode (custom resource) `status` if associated bottlerocketnode does not have `status`
+    if !agent.check_custom_resource_status_exists().await? {
+        agent.initialize_metadata_custom_resource().await?;
+    }
+
+    agent.run().await
 }

--- a/models/src/node.rs
+++ b/models/src/node.rs
@@ -88,8 +88,8 @@ pub const K8S_NODE_SHORTNAME: &str = "brn";
     printcolumn = r#"{"name":"Target Version", "type":"string", "jsonPath":".spec.version"}"#
 )]
 pub struct BottlerocketNodeSpec {
-    state: BottlerocketNodeState,
-    version: Option<String>,
+    pub state: BottlerocketNodeState,
+    pub version: Option<String>,
 }
 
 /// `BottlerocketNodeStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent,
@@ -108,7 +108,7 @@ pub struct BottlerocketNodeSelector {
     pub node_uid: String,
 }
 
-fn node_resource_name(node_selector: &BottlerocketNodeSelector) -> String {
+pub fn node_resource_name(node_selector: &BottlerocketNodeSelector) -> String {
     format!("brn-{}", node_selector.node_name)
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#80 #78  #79


**Description of changes:**
Implementing agent component which have two responsibilities
- Gather metadata about the system and update the custom resource associated with this node
- Determine if the spec on the system's custom resource demands the node take action. If so, begin taking that action.   

**Testing done:**
Creating agent for each node by apply deamonset
Test lists
- [x] If agent can correctly create bottlerocketnode (custom resource)
- [x] If agent can correctly update bottlerocketnode status (custom resource)
- [x] If agent can interact with Bottlerocket Update API via apiclient

```
[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws describe brn brn-ip-192-168-66-248.us-west-2.compute.internal
Name:         brn-ip-192-168-66-248.us-west-2.compute.internal
Namespace:    brupop-bottlerocket-aws
Labels:       <none>
Annotations:  <none>
API Version:  brupop.bottlerocket.aws/v1
Kind:         BottlerocketNode
Metadata:
  Creation Timestamp:  2021-10-26T06:06:04Z
  Generation:          1
  Managed Fields:
    API Version:  brupop.bottlerocket.aws/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"3905a2e5-e2df-4c58-ab86-9ecc33d60997"}:
            .:
            f:apiVersion:
            f:kind:
            f:name:
            f:uid:
      f:spec:
        .:
        f:state:
        f:version:
      f:status:
        .:
        f:available_versions:
        f:current_state:
        f:current_version:
    Manager:    unknown
    Operation:  Update
    Time:       2021-10-26T06:06:04Z
  Owner References:
    API Version:     v1
    Kind:            BottlerocketNode
    Name:            ip-192-168-66-248.us-west-2.compute.internal
    UID:             3905a2e5-e2df-4c58-ab86-9ecc33d60997
  Resource Version:  47784043
  Self Link:         /apis/brupop.bottlerocket.aws/v1/namespaces/brupop-bottlerocket-aws/bottlerocketnodes/brn-ip-192-168-66-248.us-west-2.compute.internal
  UID:               f90796e1-c6e3-4963-bfaa-2c6b45d103a9
Spec:
  State:    WaitingForUpdate
  Version:  <nil>
Status:
  available_versions:
    1.3.0
    1.2.1
    1.2.0
    1.1.4
    1.1.3
    1.1.2
    1.1.1
    1.1.0
    1.0.8
    1.0.7
    1.0.6
    1.0.5
    1.0.4
    1.0.3
    1.0.2
  current_state:    WaitingForUpdate
  current_version:  1.1.1
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
