### PR TITLE
0.2.0 apiserver tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "apiserver"
 version = "0.1.0"
 dependencies = [
@@ -238,12 +247,18 @@ dependencies = [
  "log",
  "mockall",
  "models",
+ "opentelemetry",
  "reqwest",
  "schemars",
  "serde",
  "serde_json",
  "snafu",
  "tokio",
+ "tracing",
+ "tracing-actix-web",
+ "tracing-bunyan-formatter",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -387,6 +402,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
 ]
 
 [[package]]
@@ -712,6 +747,16 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1095,6 +1140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1229,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "tracing",
 ]
 
 [[package]]
@@ -1282,6 +1337,25 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project 1.0.8",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1540,6 +1614,15 @@ checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -1810,6 +1893,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +2074,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,6 +2198,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,6 +2283,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-actix-web"
+version = "0.4.0-beta.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a2baadea06db0c8108ba3100c9a0d0cedc30a798d4ef032737420fed16dd"
+dependencies = [
+ "actix-web",
+ "pin-project 1.0.8",
+ "tracing",
+ "tracing-futures",
+ "uuid",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,12 +2307,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-bunyan-formatter"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718867c20ea03700d41a9413610cccf5d772caea792f34cc73cdd43f0e14a6"
+dependencies = [
+ "chrono",
+ "gethostname",
+ "log",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-core"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project 1.0.8",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599f388ecb26b28d9c1b2e4437ae019a7b336018b45ed911458cd9ebf91129f6"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2254,6 +2462,15 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -9,6 +9,16 @@ license = "Apache-2.0 OR MIT"
 models = { path = "../models" }
 
 actix-web = { version = "4.0.0-beta.9", default-features = false }
+
+# tracing-actix-web version must align with actix-web version
+tracing-actix-web = "0.4.0-beta.14"
+tracing = "0.1"
+tracing-subscriber = { version = "0.2", features = ["registry", "env-filter"] }
+tracing-bunyan-formatter = "0.1"
+opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"]}
+tracing-opentelemetry = "0.15"
+
+
 env_logger = "0.9"
 futures = "0.3"
 

--- a/apiserver/src/error.rs
+++ b/apiserver/src/error.rs
@@ -21,6 +21,11 @@ pub enum Error {
 
     #[snafu(display("Error running HTTP server: '{}'", source))]
     HttpServerError { source: std::io::Error },
+
+    #[snafu(display("Error configuring tracing: '{}'", source))]
+    TracingConfiguration {
+        source: tracing::subscriber::SetGlobalDefaultError,
+    },
 }
 
 impl error::ResponseError for Error {}

--- a/apiserver/src/lib.rs
+++ b/apiserver/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod api;
 pub mod error;
+pub mod telemetry;

--- a/apiserver/src/main.rs
+++ b/apiserver/src/main.rs
@@ -1,6 +1,8 @@
 use apiserver::api::{self, APIServerSettings};
 use apiserver::error::{self, Result};
+use apiserver::telemetry::init_telemetry;
 use models::node::K8SBottlerocketNodeClient;
+use tracing::{event, Level};
 
 use snafu::ResultExt;
 
@@ -13,20 +15,22 @@ const TERMINATION_LOG: &str = "/dev/termination-log";
 
 #[actix_web::main]
 async fn main() {
-    let termination_log = env::var("TERMINATION_LOG")
-        .map_err(|_| TERMINATION_LOG.to_string())
-        .unwrap();
+    let termination_log = env::var("TERMINATION_LOG").unwrap_or(TERMINATION_LOG.to_string());
+
     match run_server().await {
         Err(error) => {
+            event!(Level::ERROR, %error, "brupop apiserver failed.");
             fs::write(&termination_log, format!("{}", error))
                 .expect("Could not write k8s termination log.");
         }
         Ok(()) => {}
     }
+
+    opentelemetry::global::shutdown_tracer_provider();
 }
 
 async fn run_server() -> Result<()> {
-    env_logger::init();
+    init_telemetry()?;
 
     let k8s_client = kube::client::Client::try_default()
         .await

--- a/apiserver/src/telemetry.rs
+++ b/apiserver/src/telemetry.rs
@@ -1,0 +1,42 @@
+use crate::error::{self, Result};
+use models::constants::APISERVER;
+
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use opentelemetry::sdk::propagation::TraceContextPropagator;
+use snafu::ResultExt;
+use tracing::Span;
+use tracing_actix_web::{DefaultRootSpanBuilder, RootSpanBuilder};
+use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
+use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
+
+pub(crate) struct BrupopApiserverRootSpanBuilder;
+
+impl RootSpanBuilder for BrupopApiserverRootSpanBuilder {
+    fn on_request_start(request: &ServiceRequest) -> Span {
+        // Indicate that a `node_name` will be added to the span.
+        // TODO: Add node_name to a standardized request header (requires changes to the brupop agent's request creation)
+        tracing_actix_web::root_span!(request, node_name = tracing::field::Empty)
+    }
+
+    fn on_request_end<B>(
+        span: Span,
+        response: &std::result::Result<ServiceResponse<B>, actix_web::Error>,
+    ) {
+        DefaultRootSpanBuilder::on_request_end(span, response);
+    }
+}
+
+/// Initializes global tracing and telemetry state for the apiserver.
+pub fn init_telemetry() -> Result<()> {
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("info"));
+    let stdio_formatting_layer = BunyanFormattingLayer::new(APISERVER.into(), std::io::stdout);
+    let subscriber = Registry::default()
+        .with(env_filter)
+        .with(JsonStorageLayer)
+        .with(stdio_formatting_layer);
+    tracing::subscriber::set_global_default(subscriber).context(error::TracingConfiguration)?;
+
+    Ok(())
+}

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -18,3 +18,4 @@ schemars = "0.8"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 snafu = "0.6"
+tracing = "0.1"


### PR DESCRIPTION
**Issue number:** Solves #94 



**Description of changes:**
This change adds `tracing` support to the `apiserver` component, using `tracing-actix-web` to create a span per-request. For now, logs are formatted as JSON blobs and dumped to stdout, where they are retrievable via `kubectl logs`.

As a future change, we can add tracers via `opentracing` to support Prometheus and AWS X-Ray.

One problem with this change is that it doesn't filter out the HTTP status check route from the logs. After battling with `tracing-actix-web` for a while on this, I've concluded that it may be best to add support for this upstream.


**Testing done:** I made a `POST` request to `/bottlerocket-node-resource` and then gathered request logs:

```
$ grep '59617a5c-60d0-4dde-9444-f1617eb69e87' log-sample.txt 
{"v":0,"name":"apiserver","msg":"[HTTP REQUEST - START]","level":30,"hostname":"brupop-apiserver-847bf7f44c-k8qmv","pid":1,"time":"2021-10-21T08:32:25.229552009+00:00","target":"apiserver::telemetry","line":11,"file":"apiserver/src/telemetry.rs","request_id":"59617a5c-60d0-4dde-9444-f1617eb69e87","http.flavor":"1.1","otel.kind":"server","http.client_ip":"192.168.66.198:23863","http.method":"POST","http.host":"52.24.238.246:30000","http.user_agent":"","http.scheme":"http","http.target":"/bottlerocket-node-resource","http.route":"/bottlerocket-node-resource"}
{"v":0,"name":"apiserver","msg":"[CREATE_NODE - START]","level":30,"hostname":"brupop-apiserver-847bf7f44c-k8qmv","pid":1,"time":"2021-10-21T08:32:25.229599960+00:00","target":"models::node","line":229,"file":"models/src/node.rs","request_id":"59617a5c-60d0-4dde-9444-f1617eb69e87","node_name":"<node_name>","http.flavor":"1.1","otel.kind":"server","http.client_ip":"192.168.66.198:23863","http.method":"POST","node_uid":"623ca9b3-bfc6-4c0f-b5d8-d8bd320a0a2f","http.host":"<ipaddr>:30000","http.user_agent":"","http.scheme":"http","http.target":"/bottlerocket-node-resource","http.route":"/bottlerocket-node-resource"}
{"v":0,"name":"apiserver","msg":"[CREATE_NODE - EVENT] Sending BottlerocketNode create request to kubernetes cluster.","level":30,"hostname":"brupop-apiserver-847bf7f44c-k8qmv","pid":1,"time":"2021-10-21T08:32:25.229618790+00:00","request_id":"59617a5c-60d0-4dde-9444-f1617eb69e87","node_name":"<node_name>","http.flavor":"1.1","otel.kind":"server","http.client_ip":"192.168.66.198:23863","http.method":"POST","node_uid":"623ca9b3-bfc6-4c0f-b5d8-d8bd320a0a2f","http.host":"<ipaddr>:30000","http.user_agent":"","http.scheme":"http","http.target":"/bottlerocket-node-resource","http.route":"/bottlerocket-node-resource"}
{"v":0,"name":"apiserver","msg":"[CREATE_NODE - EVENT] BottlerocketNode create request completed successfully.","level":30,"hostname":"brupop-apiserver-847bf7f44c-k8qmv","pid":1,"time":"2021-10-21T08:32:25.260271657+00:00","request_id":"59617a5c-60d0-4dde-9444-f1617eb69e87","node_name":"<node_name>","http.flavor":"1.1","otel.kind":"server","http.client_ip":"192.168.66.198:23863","http.method":"POST","node_uid":"623ca9b3-bfc6-4c0f-b5d8-d8bd320a0a2f","http.host":"<ipaddr>:30000","http.user_agent":"","http.scheme":"http","http.target":"/bottlerocket-node-resource","http.route":"/bottlerocket-node-resource"}
{"v":0,"name":"apiserver","msg":"[CREATE_NODE - END]","level":30,"hostname":"brupop-apiserver-847bf7f44c-k8qmv","pid":1,"time":"2021-10-21T08:32:25.260303328+00:00","target":"models::node","line":229,"file":"models/src/node.rs","request_id":"59617a5c-60d0-4dde-9444-f1617eb69e87","node_name":"<node_name>","elapsed_milliseconds":30,"http.flavor":"1.1","otel.kind":"server","http.client_ip":"192.168.66.198:23863","http.method":"POST","node_uid":"623ca9b3-bfc6-4c0f-b5d8-d8bd320a0a2f","http.host":"<ipaddr>:30000","http.user_agent":"","http.scheme":"http","http.target":"/bottlerocket-node-resource","http.route":"/bottlerocket-node-resource"}
{"v":0,"name":"apiserver","msg":"[HTTP REQUEST - END]","level":30,"hostname":"brupop-apiserver-847bf7f44c-k8qmv","pid":1,"time":"2021-10-21T08:32:25.260344394+00:00","target":"apiserver::telemetry","line":11,"file":"apiserver/src/telemetry.rs","request_id":"59617a5c-60d0-4dde-9444-f1617eb69e87","node_name":"<node_name>","elapsed_milliseconds":30,"http.flavor":"1.1","otel.kind":"server","http.client_ip":"192.168.66.198:23863","otel.status_code":"OK","http.method":"POST","http.status_code":200,"http.host":"<ipaddr>:30000","http.user_agent":"","http.scheme":"http","http.target":"/bottlerocket-node-resource","http.route":"/bottlerocket-node-resource"}
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
