### PR TITLE
Add agent yaml generation

### DIFF
--- a/models/src/agent.rs
+++ b/models/src/agent.rs
@@ -1,0 +1,261 @@
+use crate::constants::{
+    AGENT, AGENT_NAME, APP_COMPONENT, APP_MANAGED_BY, APP_PART_OF, BRUPOP,
+    BRUPOP_INTERFACE_VERSION, LABEL_BRUPOP_INTERFACE_NAME, LABEL_COMPONENT, NAMESPACE,
+};
+use k8s_openapi::api::apps::v1::{DaemonSet, DaemonSetSpec};
+use k8s_openapi::api::core::v1::{
+    Affinity, Container, EnvVar, EnvVarSource, HostPathVolumeSource, LocalObjectReference,
+    NodeAffinity, NodeSelector, NodeSelectorRequirement, NodeSelectorTerm, ObjectFieldSelector,
+    PodSpec, PodTemplateSpec, ProjectedVolumeSource, ResourceRequirements, SELinuxOptions,
+    SecurityContext, ServiceAccount, ServiceAccountTokenProjection, Volume, VolumeMount,
+    VolumeProjection,
+};
+use k8s_openapi::api::rbac::v1::{ClusterRole, ClusterRoleBinding, PolicyRule, RoleRef, Subject};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+use kube::api::ObjectMeta;
+use maplit::btreemap;
+
+const BRUPOP_AGENT_SERVICE_ACCOUNT: &str = "brupop-agent-service-account";
+const BRUPOP_AGENT_CLUSTER_ROLE: &str = "brupop-agent-role";
+
+/// Defines the brupop-agent service account
+pub fn agent_service_account() -> ServiceAccount {
+    ServiceAccount {
+        metadata: ObjectMeta {
+            name: Some(BRUPOP_AGENT_SERVICE_ACCOUNT.to_string()),
+            namespace: Some(NAMESPACE.to_string()),
+            annotations: Some(btreemap! {
+                "kubernetes.io/service-account.name".to_string() => BRUPOP_AGENT_SERVICE_ACCOUNT.to_string()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Defines the brupop-agent cluster role
+pub fn agent_cluster_role() -> ClusterRole {
+    ClusterRole {
+        metadata: ObjectMeta {
+            name: Some(BRUPOP_AGENT_CLUSTER_ROLE.to_string()),
+            namespace: Some(NAMESPACE.to_string()),
+            ..Default::default()
+        },
+        rules: Some(vec![
+            PolicyRule {
+                api_groups: Some(vec!["".to_string()]),
+                resources: Some(vec!["nodes".to_string()]),
+                verbs: vec!["create", "get", "list", "patch", "update", "watch"]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+                ..Default::default()
+            },
+            PolicyRule {
+                api_groups: Some(vec!["brupop.bottlerocket.aws".to_string()]),
+                resources: Some(vec![
+                    "bottlerocketnodes".to_string(),
+                    "bottlerocketnodes/status".to_string(),
+                ]),
+                verbs: vec!["get", "list", "watch"]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+                ..Default::default()
+            },
+        ]),
+        ..Default::default()
+    }
+}
+
+/// Defines the brupop-agent cluster role binding
+pub fn agent_cluster_role_binding() -> ClusterRoleBinding {
+    ClusterRoleBinding {
+        metadata: ObjectMeta {
+            name: Some("brupop-agent-role-binding".to_string()),
+            namespace: Some(NAMESPACE.to_string()),
+            ..Default::default()
+        },
+        role_ref: RoleRef {
+            api_group: "rbac.authorization.k8s.io".to_string(),
+            kind: "ClusterRole".to_string(),
+            name: BRUPOP_AGENT_CLUSTER_ROLE.to_string(),
+        },
+        subjects: Some(vec![Subject {
+            kind: "ServiceAccount".to_string(),
+            name: BRUPOP_AGENT_SERVICE_ACCOUNT.to_string(),
+            namespace: Some(NAMESPACE.to_string()),
+            ..Default::default()
+        }]),
+    }
+}
+
+/// Defines the brupop-agent DaemonSet
+pub fn agent_daemonset(agent_image: String, image_pull_secret: Option<String>) -> DaemonSet {
+    let image_pull_secrets =
+        image_pull_secret.map(|secret| vec![LocalObjectReference { name: Some(secret) }]);
+
+    DaemonSet {
+        metadata: ObjectMeta {
+            labels: Some(
+                btreemap! {
+                    APP_COMPONENT => AGENT,
+                    APP_MANAGED_BY => BRUPOP,
+                    APP_PART_OF => BRUPOP,
+                    LABEL_COMPONENT => AGENT,
+                }
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            ),
+            name: Some(AGENT_NAME.to_string()),
+            namespace: Some(NAMESPACE.to_string()),
+            ..Default::default()
+        },
+        spec: Some(DaemonSetSpec {
+            selector: LabelSelector {
+                match_labels: Some(btreemap! { LABEL_COMPONENT.to_string() => AGENT.to_string()}),
+                ..Default::default()
+            },
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(btreemap! {
+                        LABEL_COMPONENT.to_string() => AGENT.to_string(),
+                    }),
+                    namespace: Some(NAMESPACE.to_string()),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    affinity: Some(Affinity {
+                        node_affinity: Some(NodeAffinity {
+                            required_during_scheduling_ignored_during_execution: Some(
+                                NodeSelector {
+                                    node_selector_terms: vec![NodeSelectorTerm {
+                                        match_expressions: Some(vec![
+                                            NodeSelectorRequirement {
+                                                key: "kubernetes.io/os".to_string(),
+                                                operator: "In".to_string(),
+                                                values: Some(vec!["linux".to_string()]),
+                                            },
+                                            NodeSelectorRequirement {
+                                                key: LABEL_BRUPOP_INTERFACE_NAME.to_string(),
+                                                operator: "In".to_string(),
+                                                values: Some(vec![
+                                                    BRUPOP_INTERFACE_VERSION.to_string()
+                                                ]),
+                                            },
+                                            NodeSelectorRequirement {
+                                                key: "kubernetes.io/arch".to_string(),
+                                                operator: "In".to_string(),
+                                                values: Some(vec![
+                                                    "amd64".to_string(),
+                                                    "arm64".to_string(),
+                                                ]),
+                                            },
+                                        ]),
+                                        ..Default::default()
+                                    }],
+                                },
+                            ),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    containers: vec![Container {
+                        image: Some(agent_image),
+                        name: BRUPOP.to_string(),
+                        image_pull_policy: None,
+                        command: Some(vec!["./agent".to_string()]),
+                        env: Some(vec![EnvVar {
+                            name: "MY_NODE_NAME".to_string(),
+                            value_from: Some(EnvVarSource {
+                                field_ref: Some(ObjectFieldSelector {
+                                    field_path: "spec.nodeName".to_string(),
+                                    ..Default::default()
+                                }),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        }]),
+                        resources: Some(ResourceRequirements {
+                            limits: Some(btreemap! {
+                                "memory".to_string() => Quantity("50Mi".to_string()),
+                            }),
+                            requests: Some(btreemap! {
+                                "memory".to_string() => Quantity("50Mi".to_string()),
+                                "cpu".to_string() => Quantity("10m".to_string()),
+                            }),
+                            ..Default::default()
+                        }),
+                        volume_mounts: Some(vec![
+                            VolumeMount {
+                                name: "bottlerocket-api-socket".to_string(),
+                                mount_path: "/run/api.sock".to_string(),
+                                ..Default::default()
+                            },
+                            VolumeMount {
+                                name: "bottlerocket-apiclient".to_string(),
+                                mount_path: "/bin/apiclient".to_string(),
+                                ..Default::default()
+                            },
+                            VolumeMount {
+                                name: "bottlerocket-agent-service-account-token".to_string(),
+                                mount_path: "/var/run/secrets/tokens".to_string(),
+                                ..Default::default()
+                            },
+                        ]),
+                        security_context: Some(SecurityContext {
+                            se_linux_options: Some(SELinuxOptions {
+                                role: Some("system_r".to_string()),
+                                type_: Some("super_t".to_string()),
+                                user: Some("system_u".to_string()),
+                                level: Some("s0".to_string()),
+                            }),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }],
+                    service_account_name: Some(BRUPOP_AGENT_SERVICE_ACCOUNT.to_string()),
+                    image_pull_secrets,
+                    volumes: Some(vec![
+                        Volume {
+                            name: "bottlerocket-api-socket".to_string(),
+                            host_path: Some(HostPathVolumeSource {
+                                path: "/run/api.sock".to_string(),
+                                type_: Some("Socket".to_string()),
+                            }),
+                            ..Default::default()
+                        },
+                        Volume {
+                            name: "bottlerocket-apiclient".to_string(),
+                            host_path: Some(HostPathVolumeSource {
+                                path: "/bin/apiclient".to_string(),
+                                type_: Some("File".to_string()),
+                            }),
+                            ..Default::default()
+                        },
+                        Volume {
+                            name: "bottlerocket-agent-service-account-token".to_string(),
+                            projected: Some(ProjectedVolumeSource {
+                                sources: Some(vec![VolumeProjection {
+                                    service_account_token: Some(ServiceAccountTokenProjection {
+                                        path: "bottlerocket-agent-service-account-token"
+                                            .to_string(),
+                                        ..Default::default()
+                                    }),
+                                    ..Default::default()
+                                }]),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                    ]),
+                    ..Default::default()
+                }),
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}

--- a/models/src/constants.rs
+++ b/models/src/constants.rs
@@ -15,6 +15,8 @@ pub const API_VERSION: &str = brupop_domain!("v1");
 pub const NAMESPACE: &str = "brupop-bottlerocket-aws";
 pub const BRUPOP: &str = "brupop";
 pub const BRUPOP_DOMAIN_LIKE_NAME: &str = brupop_domain!();
+pub const LABEL_BRUPOP_INTERFACE_NAME: &str = "bottlerocket.aws/updater-interface-version";
+pub const BRUPOP_INTERFACE_VERSION: &str = "2.0.0";
 
 // Label keys
 pub const LABEL_COMPONENT: &str = brupop_domain!("component");
@@ -34,3 +36,7 @@ pub const APISERVER_SERVICE_PORT: i32 = 80; // The k8s service port hosting the 
 pub const APISERVER_MAX_UNAVAILABLE: &str = "33%"; // The maximum number of unavailable nodes for the apiserver deployment.
 pub const APISERVER_HEALTH_CHECK_ROUTE: &str = "/ping"; // Route used for apiserver k8s liveness and readiness checks.
 pub const APISERVER_SERVICE_NAME: &str = "brupop-apiserver"; // The name for the `svc` fronting the apiserver.
+
+// agent constants
+pub const AGENT: &str = "agent";
+pub const AGENT_NAME: &str = "brupop-agent";

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod apiserver;
 pub mod constants;
 pub mod namespace;

--- a/yamlgen/deploy/brupop-agent.yaml
+++ b/yamlgen/deploy/brupop-agent.yaml
@@ -1,0 +1,142 @@
+# This file is generated. Do not edit.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: brupop
+  name: brupop-bottlerocket-aws
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: brupop-agent-service-account
+  name: brupop-agent-service-account
+  namespace: brupop-bottlerocket-aws
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: brupop-agent-role
+  namespace: brupop-bottlerocket-aws
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - brupop.bottlerocket.aws
+    resources:
+      - bottlerocketnodes
+      - bottlerocketnodes/status
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: brupop-agent-role-binding
+  namespace: brupop-bottlerocket-aws
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: brupop-agent-role
+subjects:
+  - kind: ServiceAccount
+    name: brupop-agent-service-account
+    namespace: brupop-bottlerocket-aws
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: agent
+  name: brupop-agent
+  namespace: brupop-bottlerocket-aws
+spec:
+  selector:
+    matchLabels:
+      brupop.bottlerocket.aws/component: agent
+  template:
+    metadata:
+      labels:
+        brupop.bottlerocket.aws/component: agent
+      namespace: brupop-bottlerocket-aws
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: bottlerocket.aws/updater-interface-version
+                    operator: In
+                    values:
+                      - 2.0.0
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+      containers:
+        - command:
+            - "./agent"
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: "109276217309.dkr.ecr.us-west-2.amazonaws.com/brupop:latest"
+          name: brupop
+          resources:
+            limits:
+              memory: 50Mi
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          securityContext:
+            seLinuxOptions:
+              level: s0
+              role: system_r
+              type: super_t
+              user: system_u
+          volumeMounts:
+            - mountPath: /run/api.sock
+              name: bottlerocket-api-socket
+            - mountPath: /bin/apiclient
+              name: bottlerocket-apiclient
+            - mountPath: /var/run/secrets/tokens
+              name: bottlerocket-agent-service-account-token
+      imagePullSecrets:
+        - name: brupop
+      serviceAccountName: brupop-agent-service-account
+      volumes:
+        - hostPath:
+            path: /run/api.sock
+            type: Socket
+          name: bottlerocket-api-socket
+        - hostPath:
+            path: /bin/apiclient
+            type: File
+          name: bottlerocket-apiclient
+        - name: bottlerocket-agent-service-account-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: bottlerocket-agent-service-account-token


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#80 #78  #79

**Description of changes:**
This change adds an agent component build step which converts agent Rust models into YAML files which can be deployed to kubernetes.

Also mount a service token provided by Token Volume Projection on Pod which gives pod permission to use apiclient to update `bottlerocketCustomresourceNode`.

**Testing done:**
Apply agent yaml file to EKS cluster,  all things had been created successfully
```
kubectl -n brupop-bottlerocket-aws get pods
NAME                               READY   STATUS             RESTARTS   AGE
brupop-agent-4qnjs                 1/1     Running            0          23m
brupop-agent-n4pnk                 1/1     Running            0          23m
brupop-agent-nsdmh                 1/1     Running            0          23m
brupop-apiserver-ff767d4bd-b4m8s   1/1     Running            0          10h
brupop-apiserver-ff767d4bd-h7n6q   1/1     Running            0          10h
brupop-apiserver-ff767d4bd-nqzl5   1/1     Running            0          10h

[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get se
secrets                                     securitygrouppolicies.vpcresources.k8s.aws  serviceaccounts                             services

[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get secrets
NAME                                            TYPE                                  DATA   AGE
brupop                                          kubernetes.io/dockerconfigjson        1      11h
kubernetes.io/service-account-token   3      11h
default-token-q5xzl                             kubernetes.io/service-account-token   3      7d12h

kubectl -n brupop-bottlerocket-aws get clusterrole
brupop-agent-role                                                      2021-10-25T21:31:33Z

[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get namespaces
NAME                      STATUS   AGE
brupop-bottlerocket-aws   Active   7d12h
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
