### PR TITLE
0.2.0 Add additional information to `kubectl get bottlerocketnodes`

### DIFF
--- a/models/src/node.rs
+++ b/models/src/node.rs
@@ -80,7 +80,11 @@ pub const K8S_NODE_SHORTNAME: &str = "brn";
     shortname = "brn",
     singular = "bottlerocketnode",
     status = "BottlerocketNodeStatus",
-    version = "v1"
+    version = "v1",
+    printcolumn = r#"{"name":"State", "type":"string", "jsonPath":".status.current_state"}"#,
+    printcolumn = r#"{"name":"Version", "type":"string", "jsonPath":".status.current_version"}"#,
+    printcolumn = r#"{"name":"Target State", "type":"string", "jsonPath":".spec.state"}"#,
+    printcolumn = r#"{"name":"Target Version", "type":"string", "jsonPath":".spec.version"}"#
 )]
 pub struct BottlerocketNodeSpec {
     state: BottlerocketNodeState,

--- a/yamlgen/deploy/bottlerocket-node-crd.yaml
+++ b/yamlgen/deploy/bottlerocket-node-crd.yaml
@@ -15,7 +15,19 @@ spec:
     singular: bottlerocketnode
   scope: Namespaced
   versions:
-    - additionalPrinterColumns: []
+    - additionalPrinterColumns:
+        - jsonPath: ".status.current_state"
+          name: State
+          type: string
+        - jsonPath: ".status.current_version"
+          name: Version
+          type: string
+        - jsonPath: ".spec.state"
+          name: Target State
+          type: string
+        - jsonPath: ".spec.version"
+          name: Target Version
+          type: string
       name: v1
       schema:
         openAPIV3Schema:


### PR DESCRIPTION
**Issue number:** N/A



**Description of changes:** This uses the `additionalPrinterColumns` attribute of the BottlerocketNode custom resource definition to allow kubectl to provide more useful output when describing BottlerocketNode custom resources.



**Testing done:**

```$ kubectl get brn
NAME                                               STATE              VERSION   TARGET STATE       TARGET VERSION
brn-ip-192-168-10-1.us-west-2.compute.internal     WaitingForUpdate   1.3.0     WaitingForUpdate   
brn-ip-192-168-55-52.us-west-2.compute.internal    MonitoringUpdate   1.3.0     WaitingForUpdate   
brn-ip-192-168-81-141.us-west-2.compute.internal   WaitingForUpdate   1.2.1     WaitingForUpdate   <no value>
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
