### PR TITLE
Filter apiserver health check requests from telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "futures",
  "k8s-openapi",
  "kube",
+ "lazy_static",
  "log",
  "mockall",
  "models",

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -26,6 +26,7 @@ futures = "0.3"
 k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_20"] }
 kube = { version = "0.62.0", default-features = true, features = [ "derive"] }
 
+lazy_static = "1.4"
 log = "0.4"
 reqwest = { version = "0.11", features =  [ "json" ] }
 schemars = "0.8"

--- a/apiserver/src/api.rs
+++ b/apiserver/src/api.rs
@@ -14,6 +14,9 @@ use tracing_actix_web::{RootSpan, TracingLogger};
 
 const NODE_RESOURCE_ENDPOINT: &'static str = "/bottlerocket-node-resource";
 
+// The set of API endpoints for which `tracing::Span`s will not be recorded.
+pub const NO_TELEMETRY_ENDPOINTS: &[&str] = &[APISERVER_HEALTH_CHECK_ROUTE];
+
 /// HTTP endpoint that implements a shallow health check for the HTTP service.
 async fn health_check() -> impl Responder {
     HttpResponse::Ok().body("pong")
@@ -105,6 +108,7 @@ pub async fn run_server<T: 'static + BottlerocketNodeClient>(
     settings: APIServerSettings<T>,
 ) -> Result<()> {
     let server_port = settings.server_port;
+
     HttpServer::new(move || {
         App::new()
             .wrap(TracingLogger::<telemetry::BrupopApiserverRootSpanBuilder>::new())

--- a/apiserver/src/telemetry.rs
+++ b/apiserver/src/telemetry.rs
@@ -1,7 +1,9 @@
+use crate::api::NO_TELEMETRY_ENDPOINTS;
 use crate::error::{self, Result};
 use models::constants::APISERVER;
 
 use actix_web::dev::{ServiceRequest, ServiceResponse};
+use lazy_static::lazy_static;
 use opentelemetry::sdk::propagation::TraceContextPropagator;
 use snafu::ResultExt;
 use tracing::Span;
@@ -9,13 +11,32 @@ use tracing_actix_web::{DefaultRootSpanBuilder, RootSpanBuilder};
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 
+use std::collections::HashSet;
+
+// tracing-actix-web doesn't provide a convenient way to remove any routes from the logs, so we use a global
+// settings containing API paths to generate empty `tracing::Span`s on paths which we don't want logged.
+lazy_static! {
+    static ref EXCLUDED_PATHS: HashSet<String> = {
+        let mut excluded = HashSet::new();
+        for endpoint in NO_TELEMETRY_ENDPOINTS {
+            excluded.insert(endpoint.to_string());
+        }
+        excluded
+    };
+}
+
+#[derive(Default)]
 pub(crate) struct BrupopApiserverRootSpanBuilder;
 
 impl RootSpanBuilder for BrupopApiserverRootSpanBuilder {
     fn on_request_start(request: &ServiceRequest) -> Span {
-        // Indicate that a `node_name` will be added to the span.
-        // TODO: Add node_name to a standardized request header (requires changes to the brupop agent's request creation)
-        tracing_actix_web::root_span!(request, node_name = tracing::field::Empty)
+        if EXCLUDED_PATHS.get(request.path()).is_none() {
+            // Indicate that a `node_name` will be added to the span.
+            // TODO: Add node_name to a standardized request header (requires changes to the brupop agent's request creation)
+            tracing_actix_web::root_span!(request, node_name = tracing::field::Empty)
+        } else {
+            Span::none()
+        }
     }
 
     fn on_request_end<B>(


### PR DESCRIPTION
**Issue number:** #111 



**Description of changes:** This allows setting of a constant array of routes which will not be traced by default (or at the very least, not by `tracing-actix-web`). `tracing-actix-web` [does not provide a straightforward mechanism for setting the log level](https://github.com/LukeMathWalker/tracing-actix-web/issues/6), or of excluding certain paths, so we'll do this for now and try to contribute to that issue separately.



**Testing done:** Ran the update operator with three old bottlerocket nodes. I noted that the logs only contained messages to the `/bottlerocket-node-resource` routes, and no longer contained messages regarding the `/ping` route.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
