### PR TITLE
0.2.0 Improve Readability of State Machine State Names

### DIFF
--- a/agent/src/agentclient.rs
+++ b/agent/src/agentclient.rs
@@ -185,7 +185,7 @@ impl BrupopAgent {
     /// initialize bottlerocketnode (custom resource) `status` when create new bottlerocketnode
     pub async fn initialize_metadata_custom_resource(&mut self) -> Result<()> {
         let update_node_status = self
-            .gather_system_metadata(BottlerocketNodeState::WaitingForUpdate)
+            .gather_system_metadata(BottlerocketNodeState::Idle)
             .await?;
 
         self.update_metadata_custom_resource(update_node_status)
@@ -212,10 +212,10 @@ impl BrupopAgent {
                 log::info!("Detected drift between spec state and current state. Requesting node to take action: {:?}.", &bottlerocket_node_spec.state);
 
                 match bottlerocket_node_spec.state {
-                    BottlerocketNodeState::WaitingForUpdate => {
+                    BottlerocketNodeState::Idle => {
                         log::info!("Ready to finish monitoring and start update process")
                     }
-                    BottlerocketNodeState::PreparedToUpdate => {
+                    BottlerocketNodeState::StagedUpdate => {
                         log::info!("Preparing update");
                         prepare().await.context(error::UpdateActions {
                             action: "Prepare".to_string(),
@@ -231,7 +231,7 @@ impl BrupopAgent {
                             action: "Perform".to_string(),
                         })?;
                     }
-                    BottlerocketNodeState::RebootedToUpdate => {
+                    BottlerocketNodeState::RebootedIntoUpdate => {
                         log::info!("Rebooting node to complete update");
 
                         if running_desired_version(&bottlerocket_node_spec).await? {

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -43,7 +43,7 @@ impl<T: BottlerocketNodeClient> BrupopController<T> {
             .iter()
             .filter(|brn| {
                 brn.status.as_ref().map_or(false, |brn_status| {
-                    brn_status.current_state != BottlerocketNodeState::WaitingForUpdate
+                    brn_status.current_state != BottlerocketNodeState::Idle
                         || !brn.has_reached_desired_state()
                 })
             })

--- a/controller/src/statemachine.rs
+++ b/controller/src/statemachine.rs
@@ -13,7 +13,7 @@ pub fn determine_next_node_spec(brn: &BottlerocketNode) -> BottlerocketNodeSpec 
         Some(node_status) if node_status.current_state != brn.spec.state => brn.spec.clone(),
         Some(node_status) => {
             match brn.spec.state {
-                BottlerocketNodeState::WaitingForUpdate => {
+                BottlerocketNodeState::Idle => {
                     // TODO replace this with logic which just accepts the suggested version from the target host.
                     // If there's a newer version available, then begin updating to that version.
                     let mut available_versions = node_status.available_versions();
@@ -25,7 +25,7 @@ pub fn determine_next_node_spec(brn: &BottlerocketNode) -> BottlerocketNodeSpec 
                         })
                         .map(|latest_available| {
                             BottlerocketNodeSpec::new_starting_now(
-                                BottlerocketNodeState::PreparedToUpdate,
+                                BottlerocketNodeState::StagedUpdate,
                                 Some(latest_available.clone()),
                             )
                         })

--- a/yamlgen/deploy/bottlerocket-node-crd.yaml
+++ b/yamlgen/deploy/bottlerocket-node-crd.yaml
@@ -39,10 +39,10 @@ spec:
                 state:
                   description: "Records the desired state of the `BottlerocketNode`"
                   enum:
-                    - WaitingForUpdate
-                    - PreparedToUpdate
+                    - Idle
+                    - StagedUpdate
                     - PerformedUpdate
-                    - RebootedToUpdate
+                    - RebootedIntoUpdate
                     - MonitoringUpdate
                   type: string
                 state_transition_timestamp:
@@ -68,10 +68,10 @@ spec:
                 current_state:
                   description: "BottlerocketNodeState represents a node's state in the update state machine."
                   enum:
-                    - WaitingForUpdate
-                    - PreparedToUpdate
+                    - Idle
+                    - StagedUpdate
                     - PerformedUpdate
-                    - RebootedToUpdate
+                    - RebootedIntoUpdate
                     - MonitoringUpdate
                   type: string
                 current_version:


### PR DESCRIPTION
**Testing done:**
Straightforward change to the state names for our update state machine, after some in-person discussions that trended towards these being less ambiguous than the previous names.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
