### PR TITLE
0.2.0: Add client abstraction for apiserver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,16 @@ version = 3
 
 [[package]]
 name = "actix-codec"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5dbeb2d9e51344cb83ca7cc170f1217f9fe25bfc50160e6e200b5c31c1019a"
+checksum = "13895df506faee81e423febbae3a33b27fca71831b96bb3d60adf16ebcfea952"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-core",
  "futures-sink",
  "log",
+ "memchr",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -83,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea360596a50aa9af459850737f99293e5cb9114ae831118cb6026b3bbc7583ad"
+checksum = "4a0c218d0a17c120f10ee0c69c9f0c45d87319e8f66b1f065e8412b612fc3e24"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -94,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7367665785765b066ad16e1086d26a087f696bc7c42b6f93004ced6cfcf1eeca"
+checksum = "b6b89926c69db2de5d998a382e3c8381cf0865d8e0379367f86bd08df007c6a2"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -253,7 +254,7 @@ name = "apiserver"
 version = "0.1.0"
 dependencies = [
  "actix-web",
- "env_logger",
+ "async-trait",
  "futures",
  "k8s-openapi",
  "kube",
@@ -268,6 +269,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
+ "tokio-retry",
  "tracing",
  "tracing-actix-web",
  "tracing-bunyan-formatter",
@@ -2149,6 +2151,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project 1.0.8",
+ "rand",
  "tokio",
 ]
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 models = { path = "../models", version = "0.1.0" }
-apiserver = { path = "../apiserver", version = "0.1.0" }
+apiserver = { path = "../apiserver", version = "0.1.0", features = ["client"] }
 
 dotenv = "0.15"
 env_logger = "0.9"

--- a/agent/src/error.rs
+++ b/agent/src/error.rs
@@ -53,23 +53,19 @@ pub enum Error {
     BottlerocketNodeStatusAvailableVersions { source: apiclient_error::Error },
 
     #[snafu(display(
-        "Unable to update the custom resource associated with this node '{}' : '{}'",
-        node_name,
+        "Unable to update the custom resource associated with this node: '{}'",
         source
     ))]
     UpdateBottlerocketNodeResource {
-        node_name: String,
-        source: reqwest::Error,
+        source: apiserver::client::ClientError,
     },
 
     #[snafu(display(
-        "Unable to create the custom resource associated with this node '{}' : '{}'",
-        node_name,
+        "Unable to create the custom resource associated with this node: '{}'",
         source
     ))]
     CreateBottlerocketNodeResource {
-        node_name: String,
-        source: reqwest::Error,
+        source: apiserver::client::ClientError,
     },
 
     #[snafu(display("Unable to take action '{}': '{}'", action, source))]

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,5 +1,6 @@
 use agent::agentclient::BrupopAgent;
 use agent::error::{self, Result};
+use apiserver::client::K8SAPIServerClient;
 
 use snafu::ResultExt;
 
@@ -27,7 +28,10 @@ async fn run_agent() -> Result<()> {
         .await
         .context(error::ClientCreate)?;
 
-    let mut agent = BrupopAgent::new(k8s_client);
+    let k8s_auth_token = "TODO".to_string();
+    let apiserver_client = K8SAPIServerClient::new(k8s_auth_token);
+
+    let mut agent = BrupopAgent::new(k8s_client, apiserver_client);
 
     // Create a bottlerocketnode (custom resource) if associated bottlerocketnode does not exist
     if !agent.check_node_custom_resource_exists().await? {

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -5,35 +5,40 @@ edition = "2018"
 publish = false
 license = "Apache-2.0 OR MIT"
 
+[features]
+default = ["client", "server"]
+client = []
+server = []
+
+
 [dependencies]
 models = { path = "../models", version = "0.1.0" }
 
-actix-web = { version = "4.0.0-beta.9", default-features = false }
-
 # tracing-actix-web version must align with actix-web version
-tracing-actix-web = "0.4.0-beta.14"
+actix-web = { version = "4.0.0-beta.9", default-features = false }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
+tracing-actix-web = "0.4.0-beta.14"
 tracing-bunyan-formatter = "0.3"
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"]}
 tracing-opentelemetry = "0.16"
-
-
-env_logger = "0.9"
-futures = "0.3"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_20"] }
 kube = { version = "0.62.0", default-features = true, features = [ "derive"] }
 
+async-trait = "0.1"
+futures = "0.3"
 lazy_static = "1.4"
 log = "0.4"
-reqwest = { version = "0.11", features =  [ "json" ] }
+mockall = { version = "0.10", optional = true }
+reqwest = { version = "0.11", features =  [ "json", "native-tls" ] }
 schemars = "0.8"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 snafu = "0.6"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+tokio-retry = "0.3"
 
 [dev-dependencies]
 mockall = "0.10"

--- a/apiserver/src/api.rs
+++ b/apiserver/src/api.rs
@@ -1,18 +1,62 @@
-use crate::error::{self, Result};
-use crate::telemetry;
+use crate::{
+    constants::{
+        HEADER_BRUPOP_K8S_AUTH_TOKEN, HEADER_BRUPOP_NODE_NAME, HEADER_BRUPOP_NODE_UID,
+        NODE_RESOURCE_ENDPOINT,
+    },
+    error::{self, Result},
+    telemetry,
+};
 use models::constants::APISERVER_HEALTH_CHECK_ROUTE;
 use models::node::{BottlerocketNodeClient, BottlerocketNodeSelector, BottlerocketNodeStatus};
 
 use actix_web::{
+    http::HeaderMap,
     web::{self, Data},
     App, HttpRequest, HttpResponse, HttpServer, Responder,
 };
-use serde::{Deserialize, Serialize};
 use serde_json::json;
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use tracing_actix_web::{RootSpan, TracingLogger};
 
-const NODE_RESOURCE_ENDPOINT: &'static str = "/bottlerocket-node-resource";
+use std::convert::TryFrom;
+
+/// A struct containing information intended to be passed to the apiserver via HTTP headers.
+struct ApiserverCommonHeaders {
+    node_selector: BottlerocketNodeSelector,
+    _k8s_auth_token: String,
+}
+
+/// Returns a string value extracted from HTTP headers.
+fn extract_header_string(headers: &HeaderMap, key: &'static str) -> Result<String> {
+    Ok(headers
+        .get(key)
+        .context(error::HTTPHeaderParse {
+            missing_header: key,
+        })?
+        .to_str()
+        .map_err(|_| error::Error::HTTPHeaderParse {
+            missing_header: key,
+        })?
+        .to_string())
+}
+
+impl TryFrom<&HeaderMap> for ApiserverCommonHeaders {
+    type Error = error::Error;
+
+    fn try_from(headers: &HeaderMap) -> Result<Self> {
+        let node_name = extract_header_string(headers, HEADER_BRUPOP_NODE_NAME)?;
+        let node_uid = extract_header_string(headers, HEADER_BRUPOP_NODE_UID)?;
+        let _k8s_auth_token = extract_header_string(headers, HEADER_BRUPOP_K8S_AUTH_TOKEN)?;
+
+        Ok(ApiserverCommonHeaders {
+            node_selector: BottlerocketNodeSelector {
+                node_name,
+                node_uid,
+            },
+            _k8s_auth_token,
+        })
+    }
+}
 
 // The set of API endpoints for which `tracing::Span`s will not be recorded.
 pub const NO_TELEMETRY_ENDPOINTS: &[&str] = &[APISERVER_HEALTH_CHECK_ROUTE];
@@ -22,24 +66,16 @@ async fn health_check() -> impl Responder {
     HttpResponse::Ok().body("pong")
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-/// Describes a node for which a BottlerocketNode custom resource should be constructed.
-pub struct CreateBottlerocketNodeRequest {
-    pub node_selector: BottlerocketNodeSelector,
-}
-
 /// HTTP endpoint which creates BottlerocketNode custom resources on behalf of the caller.
 async fn create_bottlerocket_node_resource<T: BottlerocketNodeClient>(
     req: HttpRequest,
     settings: web::Data<APIServerSettings<T>>,
-    create_request: web::Json<CreateBottlerocketNodeRequest>,
+    http_req: HttpRequest,
     root_span: RootSpan,
 ) -> Result<impl Responder> {
-    root_span.record(
-        "node_name",
-        &create_request.node_selector.node_name.as_str(),
-    );
-    inner_create_bottlerocket_node_resource(req, settings, create_request).await
+    let headers = ApiserverCommonHeaders::try_from(http_req.headers())?;
+    root_span.record("node_name", &headers.node_selector.node_name.as_str());
+    inner_create_bottlerocket_node_resource(req, settings, http_req).await
 }
 
 /// Inner implementation of `create_bottlerocket_node_resource`. Provided so that unit tests can avoid setting up
@@ -47,36 +83,29 @@ async fn create_bottlerocket_node_resource<T: BottlerocketNodeClient>(
 async fn inner_create_bottlerocket_node_resource<T: BottlerocketNodeClient>(
     _req: HttpRequest,
     settings: web::Data<APIServerSettings<T>>,
-    create_request: web::Json<CreateBottlerocketNodeRequest>,
+    http_req: HttpRequest,
 ) -> Result<impl Responder> {
+    let headers = ApiserverCommonHeaders::try_from(http_req.headers())?;
     let br_node = settings
         .node_client
-        .create_node(&create_request.node_selector)
+        .create_node(&headers.node_selector)
         .await
         .context(error::BottlerocketNodeCreate)?;
 
     Ok(HttpResponse::Ok().body(format!("{}", json!(&br_node))))
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-/// Describes updates to a BottlerocketNode object's `status`.
-pub struct UpdateBottlerocketNodeRequest {
-    pub node_selector: BottlerocketNodeSelector,
-    pub node_status: BottlerocketNodeStatus,
-}
-
 /// HTTP endpoint which updates the `status` of a BottlerocketNode custom resource on behalf of the caller.
 async fn update_bottlerocket_node_resource<T: BottlerocketNodeClient>(
     req: HttpRequest,
     settings: web::Data<APIServerSettings<T>>,
-    update_request: web::Json<UpdateBottlerocketNodeRequest>,
+    http_req: HttpRequest,
+    node_status: web::Json<BottlerocketNodeStatus>,
     root_span: RootSpan,
 ) -> Result<impl Responder> {
-    root_span.record(
-        "node_name",
-        &update_request.node_selector.node_name.as_str(),
-    );
-    inner_update_bottlerocket_node_resource(req, settings, update_request).await
+    let headers = ApiserverCommonHeaders::try_from(http_req.headers())?;
+    root_span.record("node_name", &headers.node_selector.node_name.as_str());
+    inner_update_bottlerocket_node_resource(req, settings, http_req, node_status).await
 }
 
 /// Inner implementation of `update_bottlerocket_node_resource`. Provided so that unit tests can avoid setting up
@@ -84,15 +113,17 @@ async fn update_bottlerocket_node_resource<T: BottlerocketNodeClient>(
 async fn inner_update_bottlerocket_node_resource<T: BottlerocketNodeClient>(
     _req: HttpRequest,
     settings: web::Data<APIServerSettings<T>>,
-    update_request: web::Json<UpdateBottlerocketNodeRequest>,
+    http_req: HttpRequest,
+    node_status: web::Json<BottlerocketNodeStatus>,
 ) -> Result<impl Responder> {
+    let headers = ApiserverCommonHeaders::try_from(http_req.headers())?;
     settings
         .node_client
-        .update_node_status(&update_request.node_selector, &update_request.node_status)
+        .update_node_status(&headers.node_selector, &node_status)
         .await
         .context(error::BottlerocketNodeUpdate)?;
 
-    Ok(HttpResponse::Ok().body(format!("{}", json!(&update_request.node_status))))
+    Ok(HttpResponse::Ok().body(format!("{}", json!(&node_status))))
 }
 
 #[derive(Clone)]
@@ -134,8 +165,8 @@ mod tests {
     use super::*;
     use models::constants::APISERVER_INTERNAL_PORT;
     use models::node::{
-        BottlerocketNode, BottlerocketNodeSpec, BottlerocketNodeState, MockBottlerocketNodeClient,
-        Version,
+        BottlerocketNode, BottlerocketNodeSelector, BottlerocketNodeSpec, BottlerocketNodeState,
+        BottlerocketNodeStatus, MockBottlerocketNodeClient, Version,
     };
 
     use actix_web::body::AnyBody;
@@ -163,9 +194,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_node() {
+        let node_name = "test-node-name";
+        let node_uid = "test-node-uid";
+
         let node_selector = BottlerocketNodeSelector {
-            node_name: "test-node-name".to_string(),
-            node_uid: "test-node-uid".to_string(),
+            node_name: node_name.to_string(),
+            node_uid: node_uid.to_string(),
         };
 
         let return_value =
@@ -182,7 +216,9 @@ mod tests {
 
         let req = test::TestRequest::post()
             .uri(NODE_RESOURCE_ENDPOINT)
-            .set_json(&CreateBottlerocketNodeRequest { node_selector })
+            .insert_header((HEADER_BRUPOP_K8S_AUTH_TOKEN, "authy"))
+            .insert_header((HEADER_BRUPOP_NODE_NAME, node_name))
+            .insert_header((HEADER_BRUPOP_NODE_UID, node_uid))
             .to_request();
 
         let mut app = test::init_service(
@@ -212,9 +248,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_node() {
+        let node_name = "test-node-name";
+        let node_uid = "test-node-uid";
+
         let node_selector = BottlerocketNodeSelector {
-            node_name: "test-node-name".to_string(),
-            node_uid: "test-node-uid".to_string(),
+            node_name: node_name.to_string(),
+            node_uid: node_uid.to_string(),
         };
         let node_status = BottlerocketNodeStatus::new(
             Version::new(1, 2, 1),
@@ -238,10 +277,10 @@ mod tests {
 
         let req = test::TestRequest::put()
             .uri(NODE_RESOURCE_ENDPOINT)
-            .set_json(&UpdateBottlerocketNodeRequest {
-                node_selector: node_selector.clone(),
-                node_status: node_status.clone(),
-            })
+            .insert_header((HEADER_BRUPOP_K8S_AUTH_TOKEN, "authy"))
+            .insert_header((HEADER_BRUPOP_NODE_NAME, node_name))
+            .insert_header((HEADER_BRUPOP_NODE_UID, node_uid))
+            .set_json(&node_status)
             .to_request();
 
         let mut app = test::init_service(

--- a/apiserver/src/client/error.rs
+++ b/apiserver/src/client/error.rs
@@ -1,0 +1,32 @@
+use models::node::BottlerocketNodeSelector;
+
+use snafu::Snafu;
+
+/// The client result type.
+pub type Result<T> = std::result::Result<T, ClientError>;
+
+/// Error type representing issues using an apiserver client.
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub")]
+pub enum ClientError {
+    #[snafu(display(
+        "Unable to create BottlerocketNode ({}, {}): '{}'",
+        selector.node_name,
+        selector.node_uid,
+        source
+    ))]
+    CreateBottlerocketNodeResource {
+        source: Box<dyn std::error::Error>,
+        selector: BottlerocketNodeSelector,
+    },
+    #[snafu(display(
+        "Unable to update BottlerocketNode status ({}, {}): '{}'",
+        selector.node_name,
+        selector.node_uid,
+        source
+    ))]
+    UpdateBottlerocketNodeResource {
+        source: Box<dyn std::error::Error>,
+        selector: BottlerocketNodeSelector,
+    },
+}

--- a/apiserver/src/client/mock.rs
+++ b/apiserver/src/client/mock.rs
@@ -1,0 +1,30 @@
+/// This module contains client implementations that are useful for testing purposes.
+use super::{error::Result, APIServerClient};
+use crate::{
+    CreateBottlerocketNodeRequest, DrainAndCordonBottlerocketNodeRequest,
+    UncordonBottlerocketNodeRequest, UpdateBottlerocketNodeRequest,
+};
+use models::node::{BottlerocketNode, BottlerocketNodeStatus};
+
+use async_trait::async_trait;
+
+use mockall::{mock, predicate::*};
+
+mock! {
+    /// A Mock APIServerClient for use in tests.
+    pub APIServerClient {}
+    #[async_trait]
+    impl APIServerClient for APIServerClient {
+        async fn create_bottlerocket_node(
+            &self,
+            req: CreateBottlerocketNodeRequest,
+        ) -> Result<BottlerocketNode>;
+        async fn update_bottlerocket_node(
+            &self,
+            req: UpdateBottlerocketNodeRequest,
+        ) -> Result<BottlerocketNodeStatus>;
+        async fn drain_and_cordon_node(&self, req: DrainAndCordonBottlerocketNodeRequest)
+            -> Result<()>;
+        async fn uncordon_node(&self, req: UncordonBottlerocketNodeRequest) -> Result<()>;
+    }
+}

--- a/apiserver/src/client/mod.rs
+++ b/apiserver/src/client/mod.rs
@@ -1,0 +1,8 @@
+pub mod error;
+mod webclient;
+
+#[cfg(any(feature = "mockall", test))]
+pub mod mock;
+
+pub use error::ClientError;
+pub use webclient::{APIServerClient, K8SAPIServerClient};

--- a/apiserver/src/client/webclient.rs
+++ b/apiserver/src/client/webclient.rs
@@ -1,0 +1,176 @@
+use super::error::{self, Result};
+use crate::{
+    constants::{
+        HEADER_BRUPOP_K8S_AUTH_TOKEN, HEADER_BRUPOP_NODE_NAME, HEADER_BRUPOP_NODE_UID,
+        NODE_RESOURCE_ENDPOINT,
+    },
+    CreateBottlerocketNodeRequest, DrainAndCordonBottlerocketNodeRequest,
+    UncordonBottlerocketNodeRequest, UpdateBottlerocketNodeRequest,
+};
+use models::{
+    constants::{APISERVER_SERVICE_NAME, APISERVER_SERVICE_PORT, NAMESPACE},
+    node::{BottlerocketNode, BottlerocketNodeSelector, BottlerocketNodeStatus},
+};
+
+use async_trait::async_trait;
+use snafu::ResultExt;
+use tokio::time::Duration;
+use tokio_retry::{
+    strategy::{jitter, ExponentialBackoff},
+    Retry,
+};
+use tracing::instrument;
+
+// The web client uses exponential backoff.
+// These values configure how long to delay between tries.
+const RETRY_BASE_DELAY: Duration = Duration::from_millis(100);
+const RETRY_MAX_DELAY: Duration = Duration::from_secs(10);
+const NUM_RETRIES: usize = 5;
+
+fn retry_strategy() -> impl Iterator<Item = Duration> {
+    ExponentialBackoff::from_millis(RETRY_BASE_DELAY.as_millis() as u64)
+        .max_delay(RETRY_MAX_DELAY)
+        .map(jitter)
+        .take(NUM_RETRIES)
+}
+
+#[async_trait]
+pub trait APIServerClient {
+    async fn create_bottlerocket_node(
+        &self,
+        req: CreateBottlerocketNodeRequest,
+    ) -> Result<BottlerocketNode>;
+    async fn update_bottlerocket_node(
+        &self,
+        req: UpdateBottlerocketNodeRequest,
+    ) -> Result<BottlerocketNodeStatus>;
+    async fn drain_and_cordon_node(&self, req: DrainAndCordonBottlerocketNodeRequest)
+        -> Result<()>;
+    async fn uncordon_node(&self, req: UncordonBottlerocketNodeRequest) -> Result<()>;
+}
+
+#[derive(Debug, Clone)]
+pub struct K8SAPIServerClient {
+    k8s_auth_token: String,
+}
+
+impl K8SAPIServerClient {
+    pub fn new(k8s_auth_token: String) -> Self {
+        Self { k8s_auth_token }
+    }
+
+    pub fn scheme() -> String {
+        "http".to_string()
+    }
+
+    pub fn server_domain() -> String {
+        format!(
+            "{}.{}.svc.cluster.local:{}",
+            APISERVER_SERVICE_NAME, NAMESPACE, APISERVER_SERVICE_PORT
+        )
+    }
+
+    fn add_common_request_headers(
+        &self,
+        req: reqwest::RequestBuilder,
+        node_selector: &BottlerocketNodeSelector,
+    ) -> reqwest::RequestBuilder {
+        req.header(HEADER_BRUPOP_NODE_UID, &node_selector.node_uid)
+            .header(HEADER_BRUPOP_NODE_NAME, &node_selector.node_name)
+            .header(HEADER_BRUPOP_K8S_AUTH_TOKEN, &self.k8s_auth_token)
+    }
+}
+
+#[async_trait]
+impl APIServerClient for K8SAPIServerClient {
+    #[instrument]
+    async fn create_bottlerocket_node(
+        &self,
+        req: CreateBottlerocketNodeRequest,
+    ) -> Result<BottlerocketNode> {
+        Retry::spawn(retry_strategy(), || async {
+            let http_client = reqwest::Client::new();
+
+            let response = self
+                .add_common_request_headers(
+                    http_client.post(format!(
+                        "{}://{}{}",
+                        Self::scheme(),
+                        Self::server_domain(),
+                        NODE_RESOURCE_ENDPOINT
+                    )),
+                    &req.node_selector,
+                )
+                .json(&req)
+                .send()
+                .await
+                .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
+                .context(error::CreateBottlerocketNodeResource {
+                    selector: req.node_selector.clone(),
+                })?;
+
+            let node = response
+                .json::<BottlerocketNode>()
+                .await
+                .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
+                .context(error::CreateBottlerocketNodeResource {
+                    selector: req.node_selector.clone(),
+                })?;
+
+            Ok(node)
+        })
+        .await
+    }
+
+    #[instrument]
+    async fn update_bottlerocket_node(
+        &self,
+        req: UpdateBottlerocketNodeRequest,
+    ) -> Result<BottlerocketNodeStatus> {
+        Retry::spawn(retry_strategy(), || async {
+            let http_client = reqwest::Client::new();
+
+            let response = self
+                .add_common_request_headers(
+                    http_client.put(format!(
+                        "{}://{}{}",
+                        Self::scheme(),
+                        Self::server_domain(),
+                        NODE_RESOURCE_ENDPOINT
+                    )),
+                    &req.node_selector,
+                )
+                .json(&req.node_status)
+                .send()
+                .await
+                .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
+                .context(error::UpdateBottlerocketNodeResource {
+                    selector: req.node_selector.clone(),
+                })?;
+
+            let node_status = response
+                .json::<BottlerocketNodeStatus>()
+                .await
+                .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
+                .context(error::UpdateBottlerocketNodeResource {
+                    selector: req.node_selector.clone(),
+                })?;
+
+            Ok(node_status)
+        })
+        .await
+    }
+
+    #[instrument]
+    async fn drain_and_cordon_node(
+        &self,
+        _req: DrainAndCordonBottlerocketNodeRequest,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    #[instrument]
+    async fn uncordon_node(&self, _req: UncordonBottlerocketNodeRequest) -> Result<()> {
+        todo!()
+    }
+}

--- a/apiserver/src/constants.rs
+++ b/apiserver/src/constants.rs
@@ -1,0 +1,6 @@
+pub const NODE_RESOURCE_ENDPOINT: &str = "/bottlerocket-node-resource";
+
+// Key names for HTTP headers for apiserver.
+pub(crate) const HEADER_BRUPOP_NODE_NAME: &str = "BrupopNodeName";
+pub(crate) const HEADER_BRUPOP_NODE_UID: &str = "BrupopNodeUid";
+pub(crate) const HEADER_BRUPOP_K8S_AUTH_TOKEN: &str = "BrupopK8sAuthToken";

--- a/apiserver/src/error.rs
+++ b/apiserver/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     #[snafu(display("Unable to create client: '{}'", source))]
     ClientCreate { source: kube::Error },
 
+    #[snafu(display("Unable to parse HTTP header. Missing '{}'", missing_header))]
+    HTTPHeaderParse { missing_header: &'static str },
+
     #[snafu(display("Error creating BottlerocketNode: '{}'", source))]
     BottlerocketNodeCreate { source: BottlerocketNodeError },
 

--- a/apiserver/src/lib.rs
+++ b/apiserver/src/lib.rs
@@ -1,3 +1,39 @@
+#[cfg(feature = "server")]
 pub mod api;
+#[cfg(feature = "server")]
 pub mod error;
+#[cfg(feature = "server")]
 pub mod telemetry;
+
+#[cfg(feature = "client")]
+pub mod client;
+
+pub(crate) mod constants;
+
+use models::node::{BottlerocketNodeSelector, BottlerocketNodeStatus};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Describes a node for which a BottlerocketNode custom resource should be constructed.
+pub struct CreateBottlerocketNodeRequest {
+    pub node_selector: BottlerocketNodeSelector,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Describes updates to a BottlerocketNode object's `status`.
+pub struct UpdateBottlerocketNodeRequest {
+    pub node_selector: BottlerocketNodeSelector,
+    pub node_status: BottlerocketNodeStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Describes a node which should have its k8s pods drained, and be cordoned to avoid more pods being scheduled..
+pub struct DrainAndCordonBottlerocketNodeRequest {
+    pub node_selector: BottlerocketNodeSelector,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Describes a node which should be uncordoned, allowing k8s Pods to be scheduled to it.
+pub struct UncordonBottlerocketNodeRequest {
+    pub node_selector: BottlerocketNodeSelector,
+}

--- a/apiserver/src/telemetry.rs
+++ b/apiserver/src/telemetry.rs
@@ -51,7 +51,7 @@ impl RootSpanBuilder for BrupopApiserverRootSpanBuilder {
 pub fn init_telemetry() -> Result<()> {
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
 
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("info"));
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     let stdio_formatting_layer = BunyanFormattingLayer::new(APISERVER.into(), std::io::stdout);
     let subscriber = Registry::default()
         .with(env_filter)

--- a/yamlgen/deploy/brupop-resources.yaml
+++ b/yamlgen/deploy/brupop-resources.yaml
@@ -45,6 +45,13 @@ rules:
       - list
       - patch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Issue number:** Beginning to implement #99 #97 #80

**Description of changes:**

Add apiserver client abstraction
    
This unifies calls to the apiserver under a single client. The intent is to start using HTTP headers to hold k8s Node and authN information so that it can be validated by actix-web middleware.

The client implements the header changes, as well as retries with exponential backoff.


**Testing done:**
Unit tests pass. Ran the controller and noted that the brupop agent successfully made writes to `brn` objects.
```
$ kubectl get brn
NAME                                               STATE   VERSION   TARGET STATE   TARGET VERSION
brn-ip-192-168-26-177.us-west-2.compute.internal   Idle    1.2.1     StagedUpdate   1.3.0
brn-ip-192-168-42-241.us-west-2.compute.internal   Idle    1.2.1     Idle           <no value>
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
