### PR TITLE
Implement token-based authN/authZ in apiserver

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ dev/
 *.el
 *.tar*
 target/
+design/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b89926c69db2de5d998a382e3c8381cf0865d8e0379367f86bd08df007c6a2"
+checksum = "7367665785765b066ad16e1086d26a087f696bc7c42b6f93004ced6cfcf1eeca"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -256,10 +256,12 @@ dependencies = [
  "actix-web",
  "async-trait",
  "futures",
+ "http",
  "k8s-openapi",
  "kube",
  "lazy_static",
  "log",
+ "maplit",
  "mockall",
  "models",
  "opentelemetry",
@@ -1005,10 +1007,11 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.62.0"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db51365e1dbaaf9e5216849ca7d0c03e2c43bae5a9d7a4f6104999448eb16b4"
+checksum = "75e877325e5540a3041b519bd7ee27a858691f9f816cf533d652cbb33cbfea45"
 dependencies = [
+ "k8s-openapi",
  "kube-client",
  "kube-core",
  "kube-derive",
@@ -1017,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.62.0"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd12d68768b54bbd50547f4c7b57b73cff680ef8da3ba409463ee995cf0d707"
+checksum = "bb8e1a36f17c63e263ba0ffa2c0658de315c75decad983d83aaeafeda578cc78"
 dependencies = [
  "base64",
  "bytes",
@@ -1052,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.62.0"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb6083983fc47d9144f1796d47edfeaba7e012de94c151bec8533af89d9b198"
+checksum = "a91e572d244436fbc0d0b5a4829d96b9d623e08eb6b5d1e80418c1fab10b162a"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1069,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.62.0"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f61042dcda7b3026e2a741692ea8feba6c76c7781eeb5380364f3dacb0ce85"
+checksum = "2034f57f3db36978ef366f45f1e263e623d9a6a8fcc6a6b1ef8879a213e1d2c4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1082,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.62.0"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc77aa51353e95d9f16157adf9f8e5322ec8fa2bffaabe895ed815b968cfc5e"
+checksum = "6018cf8410f9d460be3a3ac35deef63b71c860c368016d7bf6871994343728b4"
 dependencies = [
  "dashmap",
  "derivative",
@@ -1882,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "indexmap",
  "itoa",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -7,15 +7,15 @@ publish = false
 
 [dependencies]
 models = { path = "../models", version = "0.1.0" }
-apiserver = { path = "../apiserver", version = "0.1.0", features = ["client"] }
+apiserver = { path = "../apiserver", version = "0.1.0", default-features = false, features = ["client"] }
 
 dotenv = "0.15"
 env_logger = "0.9"
 futures = "0.3"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.62.0", default-features = true, features = [ "derive", "runtime" ] }
+k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_20"] }
+kube = { version = "0.63.2", default-features = true, features = [ "derive", "runtime" ] }
 
 log = "0.4"
 semver = { version = "1.0", features = [ "serde" ] }

--- a/agent/src/error.rs
+++ b/agent/src/error.rs
@@ -90,4 +90,9 @@ pub enum Error {
         source
     ))]
     ConvertResponseToText { source: reqwest::Error },
+
+    // The assertion type lets us return a Result in cases where we would otherwise use `unwrap()` on results that
+    // we know cannot be Err. This lets us bubble up to our error handler which writes to the termination log.
+    #[snafu(display("Agent failed due to internal assertion issue: '{}'", message))]
+    Assertion { message: String },
 }

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -25,7 +25,7 @@ tracing-opentelemetry = "0.16"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_20"] }
-kube = { version = "0.62.0", default-features = true, features = [ "derive"] }
+kube = { version = "0.63.2", default-features = true, features = [ "derive", "runtime" ] }
 
 async-trait = "0.1"
 futures = "0.3"
@@ -41,5 +41,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tokio-retry = "0.3"
 
 [dev-dependencies]
+http = "0.2"
+maplit = "1.0"
 mockall = "0.10"
 models = { path = "../models", version = "0.1.0", features = [ "mockall" ] }

--- a/apiserver/src/auth/authorizor.rs
+++ b/apiserver/src/auth/authorizor.rs
@@ -1,0 +1,435 @@
+//! This module provides abstractions for authenticating and authorizing requests from brupop agents to make changes to
+//! the underlying Node's resources (including BottlerocketNode custom resources, or draining the host Nodes of Pods.)
+use super::error::*;
+use models::node::BottlerocketNodeSelector;
+
+use async_trait::async_trait;
+use k8s_openapi::api::{
+    authentication::v1::{TokenReview, TokenReviewSpec, TokenReviewStatus},
+    core::v1::Pod,
+};
+use kube::{
+    api::{Api, PostParams},
+    runtime::reflector::{ObjectRef, Store},
+};
+use snafu::OptionExt;
+use tracing::instrument;
+
+use std::collections::HashSet;
+
+/// A token authorizor can determine if a given identity is authorized to make changes to a particular node.
+#[async_trait]
+pub trait TokenAuthorizor: Clone {
+    /// Determine if the identity represented by the provided auth token has access to the provided node.
+    async fn check_request_authorized(
+        &self,
+        node_selector: &BottlerocketNodeSelector,
+        auth_token: &str,
+    ) -> Result<(), AuthorizationError>;
+}
+
+// The k8s TokenReview authenticator adds the pod name in the `extra` field of the UserInfo
+// provided with our TokenReview.status. This is the key to retrieve it.
+//
+// Presence in the `extra` field means that this is non-standard, so it's possible that brupop will not
+// work with some implementations of a TokenReview server. The current Kubernetes API implementation seems to guarantee it.
+pub const POD_NAME_INFO_KEY: &str = "authentication.kubernetes.io/pod-name";
+
+#[derive(Clone)]
+pub struct K8STokenAuthorizor<T: TokenReviewer> {
+    token_reviewer: T,
+    namespace: String,
+    pod_reader: Store<Pod>,
+    k8s_audiences: Option<Vec<String>>,
+}
+
+#[async_trait]
+impl<T: TokenReviewer> TokenAuthorizor for K8STokenAuthorizor<T> {
+    /// Returns Ok(()) if a write operation is permitted to this given node by the requester, and Err(_) otherwise.
+    #[instrument(skip(self, auth_token))]
+    async fn check_request_authorized(
+        &self,
+        node_selector: &BottlerocketNodeSelector,
+        auth_token: &str,
+    ) -> Result<(), AuthorizationError> {
+        let token_review_req = TokenReview {
+            spec: TokenReviewSpec {
+                token: Some(auth_token.to_string()),
+                audiences: self.k8s_audiences.clone(),
+            },
+            ..Default::default()
+        };
+
+        let review_status = self
+            .token_reviewer
+            .create_token_review(token_review_req)
+            .await?;
+
+        if let Some(err_msg) = review_status.error {
+            return Err(AuthorizationError::TokenReviewServerError { err_msg });
+        }
+
+        // We are authorized under the conditions that:
+        // * `review_status.authenticated` is Some(true)
+        // * The intersection of `review_status.audiences` and `k8s_audiences` is not empty
+        // * `review_status.extra` contains the pod name, and the referred pod is deployed to our target node.
+        self.check_token_has_authenticated(&review_status)?;
+        self.check_audiences_are_compatible(&review_status)?;
+        self.check_requester_is_from_correct_node(&review_status, node_selector)
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl<T: TokenReviewer> K8STokenAuthorizor<T> {
+    pub(crate) fn new(
+        token_reviewer: T,
+        namespace: String,
+        pod_reader: Store<Pod>,
+        k8s_audiences: Option<Vec<String>>,
+    ) -> Self {
+        K8STokenAuthorizor {
+            token_reviewer,
+            namespace,
+            pod_reader,
+            k8s_audiences,
+        }
+    }
+
+    /// Returns whether or not the TokenReview server has authenticated the given token.
+    fn check_token_has_authenticated(
+        &self,
+        token_review_status: &TokenReviewStatus,
+    ) -> Result<(), AuthorizationError> {
+        if token_review_status.authenticated == Some(true) {
+            Ok(())
+        } else {
+            Err(AuthorizationError::TokenNotAuthenticated {})
+        }
+    }
+
+    /// Returns Ok(()) if the Token owner and reviewer have compatible audience lists.
+    fn check_audiences_are_compatible(
+        &self,
+        token_review_status: &TokenReviewStatus,
+    ) -> Result<(), AuthorizationError> {
+        // If we've been provided audiences, assert that we were returned audiences and the intersection is not empty.
+        if let Some(provided_audiences) = self.k8s_audiences.as_ref() {
+            if let Some(returned_audiences) = token_review_status.audiences.as_ref() {
+                let lhs: HashSet<String> = provided_audiences.iter().cloned().collect();
+                let rhs: HashSet<String> = returned_audiences.iter().cloned().collect();
+                if lhs.intersection(&rhs).next().is_none() {
+                    Err(AuthorizationError::AudienceMismatch {})
+                } else {
+                    Ok(())
+                }
+            } else {
+                Err(AuthorizationError::TokenReviewMissingPodName {})
+            }
+        } else {
+            // If we weren't provided audiences, then we aren't checking for a specific audience.
+            Ok(())
+        }
+    }
+
+    /// Returns Ok(()) if the token-owning pod is hosted on our target node.
+    async fn check_requester_is_from_correct_node(
+        &self,
+        token_review_status: &TokenReviewStatus,
+        node_selector: &BottlerocketNodeSelector,
+    ) -> Result<(), AuthorizationError> {
+        let pod_name = token_review_status
+            .user
+            .as_ref()
+            .and_then(|user| user.extra.as_ref())
+            .and_then(|extra| extra.get(POD_NAME_INFO_KEY))
+            .and_then(|pod_names| pod_names.first())
+            .context(TokenReviewMissingPodName)?;
+
+        let pod_node_name = self
+            .pod_reader
+            .get(&ObjectRef::new(pod_name).within(&self.namespace))
+            .and_then(|pod| pod.spec)
+            .and_then(|pod_spec| pod_spec.node_name)
+            .context(NoSuchPod {
+                pod_name: pod_name.to_string(),
+            })?;
+
+        if pod_node_name == node_selector.node_name {
+            Ok(())
+        } else {
+            Err(AuthorizationError::RequesterTargetMismatch {
+                requesting_node: pod_node_name,
+                target_node: node_selector.node_name.clone(),
+            })
+        }
+    }
+}
+
+/// A trait for posting token reviews to kubernetes.
+///
+/// Useful for creating fakes in test cases.
+#[async_trait]
+pub trait TokenReviewer: Clone + Sync + Send {
+    async fn create_token_review(
+        &self,
+        token_review_req: TokenReview,
+    ) -> Result<TokenReviewStatus, AuthorizationError>;
+}
+
+#[derive(Clone)]
+pub struct K8STokenReviewer {
+    pub k8s_client: kube::Client,
+}
+
+impl K8STokenReviewer {
+    pub fn new(k8s_client: kube::Client) -> Self {
+        Self { k8s_client }
+    }
+}
+
+impl From<kube::Client> for K8STokenReviewer {
+    fn from(k8s_client: kube::Client) -> Self {
+        K8STokenReviewer::new(k8s_client)
+    }
+}
+
+#[async_trait]
+impl TokenReviewer for K8STokenReviewer {
+    async fn create_token_review(
+        &self,
+        token_review_req: TokenReview,
+    ) -> Result<TokenReviewStatus, AuthorizationError> {
+        Ok(Api::all(self.k8s_client.clone())
+            .create(&PostParams::default(), &token_review_req)
+            .await
+            .map_err(|err| AuthorizationError::TokenReviewCreate {
+                err_msg: format!("{}", err),
+            })?
+            .status
+            .context(TokenReviewMissingStatus {})?)
+    }
+}
+
+#[cfg(any(feature = "mockall", test))]
+pub mod mock {
+    use super::*;
+    use mockall::{mock, predicate::*};
+
+    mock! {
+        pub TokenReviewer {}
+        #[async_trait]
+        impl TokenReviewer for TokenReviewer {
+            async fn create_token_review(
+                &self,
+                token_review_req: TokenReview,
+            ) -> Result<TokenReviewStatus, AuthorizationError>;
+        }
+
+        impl Clone for TokenReviewer {
+            fn clone(&self) -> Self;
+        }
+    }
+
+    mock! {
+        /// A Mock APIServerClient for use in tests.
+        pub TokenAuthorizor {}
+        #[async_trait]
+        impl TokenAuthorizor for TokenAuthorizor {
+            async fn check_request_authorized(
+                &self,
+                node_selector: &BottlerocketNodeSelector,
+                auth_token: &str,
+            ) -> Result<(), AuthorizationError>;
+        }
+
+        impl Clone for TokenAuthorizor {
+            fn clone(&self) -> Self;
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use super::mock::MockTokenReviewer;
+    use super::*;
+
+    use k8s_openapi::api::authentication::v1::UserInfo;
+    use k8s_openapi::api::core::v1::PodSpec;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    use kube::runtime::reflector;
+    use kube::runtime::watcher::Event;
+    use maplit::btreemap;
+
+    pub(crate) fn fake_token_authorizor(
+        reviewer: MockTokenReviewer,
+        namespace: &str,
+        pods: Vec<Pod>,
+        audiences: Option<Vec<String>>,
+    ) -> K8STokenAuthorizor<MockTokenReviewer> {
+        let mut pod_store = reflector::store::Writer::<Pod>::default();
+        let pod_reader = pod_store.as_reader();
+        pod_store.apply_watcher_event(&Event::Restarted(pods));
+
+        K8STokenAuthorizor::new(reviewer, namespace.to_string(), pod_reader, audiences)
+    }
+
+    #[tokio::test]
+    async fn test_token_has_authenticated() {
+        let authorizor = fake_token_authorizor(MockTokenReviewer::new(), "namespace", vec![], None);
+        let mut test_cases = vec![
+            (
+                TokenReviewStatus {
+                    authenticated: Some(true),
+                    ..Default::default()
+                },
+                true,
+            ),
+            (
+                TokenReviewStatus {
+                    authenticated: Some(false),
+                    ..Default::default()
+                },
+                false,
+            ),
+            (
+                TokenReviewStatus {
+                    authenticated: None,
+                    ..Default::default()
+                },
+                false,
+            ),
+        ];
+
+        for (review_status, success) in test_cases.drain(..) {
+            let result = authorizor.check_token_has_authenticated(&review_status);
+            if success {
+                assert!(result.is_ok());
+            } else {
+                assert!(result.is_err());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_audiences_are_compatible() {
+        let authorizor = fake_token_authorizor(
+            MockTokenReviewer::new(),
+            "namespace",
+            vec![],
+            Some(vec![
+                "test-audience1".to_string(),
+                "test-audience2".to_string(),
+            ]),
+        );
+
+        let mut test_cases = vec![
+            (
+                TokenReviewStatus {
+                    audiences: Some(vec!["test-audience1".to_string()]),
+                    ..Default::default()
+                },
+                true,
+            ),
+            (
+                TokenReviewStatus {
+                    ..Default::default()
+                },
+                false,
+            ),
+            (
+                TokenReviewStatus {
+                    audiences: Some(vec!["nomatch".to_string()]),
+                    ..Default::default()
+                },
+                false,
+            ),
+            (
+                TokenReviewStatus {
+                    audiences: Some(vec!["test-audience2".to_string()]),
+                    ..Default::default()
+                },
+                true,
+            ),
+            (
+                TokenReviewStatus {
+                    audiences: Some(vec![
+                        "test-audience2".to_string(),
+                        "test-audience1".to_string(),
+                    ]),
+                    ..Default::default()
+                },
+                true,
+            ),
+        ];
+
+        for (review_status, success) in test_cases.drain(..) {
+            let result = authorizor.check_audiences_are_compatible(&review_status);
+            if success {
+                assert!(result.is_ok());
+            } else {
+                assert!(result.is_err());
+            }
+        }
+    }
+
+    pub(crate) fn fake_pod_named(name: String, node_name: String) -> Pod {
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(name),
+                ..Default::default()
+            },
+            spec: Some(PodSpec {
+                node_name: Some(node_name),
+                ..Default::default()
+            }),
+            status: None,
+        }
+    }
+
+    fn review_for_pod(name: &str) -> TokenReviewStatus {
+        TokenReviewStatus {
+            user: Some(UserInfo {
+                extra: Some(btreemap! {
+                    POD_NAME_INFO_KEY.to_string() => vec![name.to_string()],
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn selector_with_name(name: &str) -> BottlerocketNodeSelector {
+        BottlerocketNodeSelector {
+            node_name: name.to_string(),
+            node_uid: "fake".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_requester_from_correct_node() {
+        let pods: Vec<Pod> = (1..5)
+            .map(|ndx| fake_pod_named(format!("pod{}", ndx), format!("node{}", ndx)))
+            .collect();
+
+        let authorizor = fake_token_authorizor(MockTokenReviewer::new(), "namespace", pods, None);
+
+        let mut test_cases = vec![
+            (review_for_pod("pod1"), selector_with_name("node1"), true),
+            (review_for_pod("pod1"), selector_with_name("node3"), false),
+            (review_for_pod("pod4"), selector_with_name("node4"), true),
+        ];
+
+        for (review_status, node_selector, success) in test_cases.drain(..) {
+            let result = authorizor
+                .check_requester_is_from_correct_node(&review_status, &node_selector)
+                .await;
+            if success {
+                assert!(result.is_ok());
+            } else {
+                assert!(result.is_err());
+            }
+        }
+    }
+}

--- a/apiserver/src/auth/error.rs
+++ b/apiserver/src/auth/error.rs
@@ -1,0 +1,57 @@
+use actix_web::{error::ResponseError, http::StatusCode};
+use snafu::Snafu;
+
+/// Errors that can occur while authorizing a request from a brupop agent against a particular Node.
+#[derive(Debug, Snafu, Clone)]
+#[snafu(visibility(pub(crate)))]
+pub enum AuthorizationError {
+    // kube::Error does not implement clone, so we pull a string message from it.
+    #[snafu(display("Failed to create TokenReview request: '{}'", err_msg))]
+    TokenReviewCreate { err_msg: String },
+
+    #[snafu(display("The TokenReview Server returned a review without a status"))]
+    TokenReviewMissingStatus {},
+
+    #[snafu(display(
+        "The TokenReview Server indicated that an error occurred: '{}'",
+        err_msg
+    ))]
+    TokenReviewServerError { err_msg: String },
+
+    #[snafu(display("The TokenReview Server did not authenticate the provided token."))]
+    TokenNotAuthenticated {},
+
+    #[snafu(display("The TokenReview Server does not appear to be audience aware."))]
+    TokenReviewServerNotAudienceAware {},
+
+    #[snafu(display("APIServer does not seem to be in the audience of the requester's token",))]
+    AudienceMismatch {},
+
+    #[snafu(display(
+        "Returned TokenReview status does not contain pod metadata required to authorize",
+    ))]
+    TokenReviewMissingPodName {},
+
+    #[snafu(display("Could not find reference to Pod owning request token: '{}'", pod_name))]
+    NoSuchPod { pod_name: String },
+
+    #[snafu(display(
+        "Requesting pod's node ('{}') does not match brn selector ('{}')",
+        requesting_node,
+        target_node
+    ))]
+    RequesterTargetMismatch {
+        requesting_node: String,
+        target_node: String,
+    },
+}
+
+impl ResponseError for AuthorizationError {
+    fn status_code(&self) -> StatusCode {
+        match *self {
+            Self::TokenReviewCreate { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::TokenReviewServerError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            _ => StatusCode::FORBIDDEN,
+        }
+    }
+}

--- a/apiserver/src/auth/middleware.rs
+++ b/apiserver/src/auth/middleware.rs
@@ -1,0 +1,371 @@
+//! This module provides middleware for authenticating and authorizing requests from brupop agents to make changes to
+//! their Node's resources (including BottlerocketNode custom resources, or Draining their host Nodes of Pods.)
+use super::TokenAuthorizor;
+use crate::api::ApiserverCommonHeaders;
+
+use actix_web::{
+    body::MessageBody,
+    dev::{Service, ServiceRequest, ServiceResponse, Transform},
+};
+
+use std::{
+    collections::HashSet,
+    convert::TryFrom,
+    future::{ready, Future, Ready},
+    pin::Pin,
+    rc::Rc,
+};
+
+// Per the actix-web documentation, there are two steps in middleware processing:
+// * Middleware is initialized. A middleware factory is called with the next service in the chain as a parameter.
+// * The middleware's call method is called with the request.
+
+/// Middleware which checks that callers are brupop agents originating from the Nodes for which they are trying to make requests.
+#[derive(Clone)]
+pub struct TokenAuthMiddleware<T: TokenAuthorizor> {
+    authorizor: T,
+    exclude_paths: Rc<HashSet<String>>,
+}
+
+impl<T: TokenAuthorizor> TokenAuthMiddleware<T> {
+    pub fn new(authorizor: T) -> Self {
+        Self {
+            authorizor,
+            exclude_paths: Rc::new(HashSet::new()),
+        }
+    }
+
+    pub fn exclude<S: Into<String>>(mut self, path: S) -> Self {
+        // `exclude_paths` is a non-public member and cannot have multiple concurrent mutable references. This unwrap is safe.
+        Rc::get_mut(&mut self.exclude_paths)
+            .unwrap()
+            .insert(path.into());
+        self
+    }
+}
+
+// Middlware factory is `Transform` trait.
+// `S` - type of the next service
+// `B` - type of response's body
+impl<S, B, T> Transform<S, ServiceRequest> for TokenAuthMiddleware<T>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+    T: TokenAuthorizor + 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = actix_web::Error;
+    type InitError = ();
+    type Transform = InnerTokenAuthMiddleware<S, T>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(InnerTokenAuthMiddleware {
+            service,
+            authorizor: self.authorizor.clone(),
+            exclude_paths: self.exclude_paths.clone(),
+        }))
+    }
+}
+
+pub struct InnerTokenAuthMiddleware<S, T: TokenAuthorizor> {
+    service: S,
+    authorizor: T,
+    exclude_paths: Rc<HashSet<String>>,
+}
+
+impl<S, B, T> Service<ServiceRequest> for InnerTokenAuthMiddleware<S, T>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+    T: TokenAuthorizor + 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = actix_web::Error;
+    #[allow(clippy::type_complexity)]
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
+
+    actix_web::dev::forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        // The future we return must be `static, so we need to pull information from self now.
+        let maybe_apiserver_headers = ApiserverCommonHeaders::try_from(req.headers());
+
+        // Clone the request path out of the request, since we're going to move it to our future.
+        let request_path = req.path().to_string();
+
+        let fut = self.service.call(req);
+        let authorizor = self.authorizor.clone();
+
+        if self.exclude_paths.get(&request_path).is_some() {
+            Box::pin(async move { fut.await })
+        } else {
+            Box::pin(async move {
+                let apiserver_headers = maybe_apiserver_headers?;
+                authorizor
+                    .check_request_authorized(
+                        &apiserver_headers.node_selector,
+                        &apiserver_headers.k8s_auth_token,
+                    )
+                    .await?;
+                fut.await
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::authorizor::{
+        mock::MockTokenReviewer,
+        test::{fake_pod_named, fake_token_authorizor},
+        POD_NAME_INFO_KEY,
+    };
+    use super::*;
+    use crate::constants::{
+        HEADER_BRUPOP_K8S_AUTH_TOKEN, HEADER_BRUPOP_NODE_NAME, HEADER_BRUPOP_NODE_UID,
+    };
+
+    use actix_web::{test, web, App, HttpResponse, Responder};
+    use k8s_openapi::api::{
+        authentication::v1::{TokenReview, TokenReviewSpec, TokenReviewStatus, UserInfo},
+        core::v1::Pod,
+    };
+    use maplit::btreemap;
+
+    async fn test_route() -> impl Responder {
+        HttpResponse::Ok().body("Hello, world")
+    }
+
+    const TEST_URI: &str = "/hello";
+
+    // Generates pods1-5
+    // All pods live on a node with the same number, e.g. pod1 lives on node1.
+    fn fake_pods() -> Vec<Pod> {
+        (1..5)
+            .map(|ndx| fake_pod_named(format!("pod{}", ndx), format!("node{}", ndx)))
+            .collect()
+    }
+
+    // Mockall doesn't allow for `Clone` implementations appropriately, so we define our own cloner here.
+    fn mock_reviewer_gen(
+        expected_review: &TokenReview,
+        ret_status: &TokenReviewStatus,
+    ) -> MockTokenReviewer {
+        let mut token_reviewer = MockTokenReviewer::new();
+
+        // Middleware gets cloned by actix. When it's called, just replicate our existing expectations into the clone.
+        let clone_review = expected_review.clone();
+        let clone_status = ret_status.clone();
+        token_reviewer
+            .expect_clone()
+            .returning(move || mock_reviewer_gen(&clone_review, &clone_status));
+
+        let create_review = expected_review.clone();
+        let create_status = ret_status.clone();
+        token_reviewer
+            .expect_create_token_review()
+            .with(mockall::predicate::eq(create_review.clone()))
+            .return_const(Ok(create_status.clone()));
+
+        token_reviewer
+    }
+
+    #[tokio::test]
+    async fn test_middleware_successful_auth() {
+        // Set up a fake cluster environment and some mock adapters to connect to it.
+        let requester_audiences = vec!["api-server".to_string()];
+        let server_audiences = vec!["api-server".to_string()];
+
+        // Our TokenReviewer assumes we have used the auth key for "pod1"
+        let test_pod_name = "pod1";
+        let node_name = "node1";
+        let node_uid = "node1uid";
+        let auth_token = "authy";
+
+        // Assert that we're called with our server audiences and the given auth key
+        let token_reviewer = mock_reviewer_gen(
+            &TokenReview {
+                spec: TokenReviewSpec {
+                    token: Some(auth_token.to_string()),
+                    audiences: Some(server_audiences.clone()),
+                },
+                ..Default::default()
+            },
+            // Return a status containing our reference pod + TokenReview metadata
+            &TokenReviewStatus {
+                audiences: Some(requester_audiences.clone()),
+                authenticated: Some(true),
+                error: None,
+                user: Some(UserInfo {
+                    extra: Some(btreemap! {
+                        POD_NAME_INFO_KEY.to_string() => vec![test_pod_name.to_string()],
+                    }),
+                    ..Default::default()
+                }),
+            },
+        );
+
+        let authorizor = fake_token_authorizor(
+            token_reviewer,
+            "namespace",
+            fake_pods(),
+            Some(server_audiences.clone()),
+        );
+
+        let app = test::init_service(
+            App::new()
+                .route(TEST_URI, web::get().to(test_route))
+                .wrap(TokenAuthMiddleware::new(authorizor)),
+        )
+        .await;
+
+        // auth_token is configured to return being owned by `pod1`
+        // `pod1` lives on `node1`
+        // Our audiences are configured to intersect
+        // No errors configured.
+        // This should succeed.
+        let req = test::TestRequest::get()
+            .uri(TEST_URI)
+            .insert_header((HEADER_BRUPOP_K8S_AUTH_TOKEN, auth_token))
+            .insert_header((HEADER_BRUPOP_NODE_NAME, node_name))
+            .insert_header((HEADER_BRUPOP_NODE_UID, node_uid))
+            .to_request();
+
+        let resp = app.call(req).await;
+        assert!(resp.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_middleware_unsuccessful_wrong_node() {
+        // Set up a fake cluster environment and some mock adapters to connect to it.
+        let requester_audiences = vec!["api-server".to_string()];
+        let server_audiences = vec!["api-server".to_string()];
+
+        // Our TokenReviewer assumes we have used the auth key for "pod1"
+        // But our request will be comeing from "node2"
+        let test_pod_name = "pod1";
+        let node_name = "node2";
+        let node_uid = "node2uid";
+        let auth_token = "authy";
+
+        // Assert that we're called with our server audiences and the given auth key
+        let token_reviewer = mock_reviewer_gen(
+            &TokenReview {
+                spec: TokenReviewSpec {
+                    token: Some(auth_token.to_string()),
+                    audiences: Some(server_audiences.clone()),
+                },
+                ..Default::default()
+            },
+            // Return a status containing our reference pod + TokenReview metadata
+            &TokenReviewStatus {
+                audiences: Some(requester_audiences.clone()),
+                authenticated: Some(true),
+                error: None,
+                user: Some(UserInfo {
+                    extra: Some(btreemap! {
+                        POD_NAME_INFO_KEY.to_string() => vec![test_pod_name.to_string()],
+                    }),
+                    ..Default::default()
+                }),
+            },
+        );
+
+        let authorizor = fake_token_authorizor(
+            token_reviewer,
+            "namespace",
+            fake_pods(),
+            Some(server_audiences.clone()),
+        );
+
+        let app = test::init_service(
+            App::new()
+                .route(TEST_URI, web::get().to(test_route))
+                .wrap(TokenAuthMiddleware::new(authorizor)),
+        )
+        .await;
+
+        // auth_token is configured to return being owned by `pod1`
+        // `pod1` lives on `node1`
+        // our request comes from `node2`
+        // Our audiences are configured to intersect
+        // No errors configured.
+        // This should fail due to node mismatch.
+        let req = test::TestRequest::get()
+            .uri(TEST_URI)
+            .insert_header((HEADER_BRUPOP_K8S_AUTH_TOKEN, auth_token))
+            .insert_header((HEADER_BRUPOP_NODE_NAME, node_name))
+            .insert_header((HEADER_BRUPOP_NODE_UID, node_uid))
+            .to_request();
+
+        let resp = app.call(req).await;
+
+        assert!(resp.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_middleware_unsuccessful_server_error() {
+        // Set up a fake cluster environment and some mock adapters to connect to it.
+        let requester_audiences = vec!["api-server".to_string()];
+        let server_audiences = vec!["api-server".to_string()];
+
+        // Our TokenReviewer assumes we have used the auth key for "pod1"
+        // But our request will be comeing from "node2"
+        let test_pod_name = "pod1";
+        let node_name = "node1";
+        let node_uid = "node1uid";
+        let auth_token = "authy";
+
+        // Assert that we're called with our server audiences and the given auth key
+        let token_reviewer = mock_reviewer_gen(
+            &TokenReview {
+                spec: TokenReviewSpec {
+                    token: Some(auth_token.to_string()),
+                    audiences: Some(server_audiences.clone()),
+                },
+                ..Default::default()
+            },
+            // Return a status containing our reference pod + TokenReview metadata
+            &TokenReviewStatus {
+                audiences: Some(requester_audiences.clone()),
+                authenticated: Some(true),
+                error: Some("ERROR".to_string()),
+                user: Some(UserInfo {
+                    extra: Some(btreemap! {
+                        POD_NAME_INFO_KEY.to_string() => vec![test_pod_name.to_string()],
+                    }),
+                    ..Default::default()
+                }),
+            },
+        );
+
+        let authorizor = fake_token_authorizor(
+            token_reviewer,
+            "namespace",
+            fake_pods(),
+            Some(server_audiences.clone()),
+        );
+
+        let app = test::init_service(
+            App::new()
+                .route(TEST_URI, web::get().to(test_route))
+                .wrap(TokenAuthMiddleware::new(authorizor)),
+        )
+        .await;
+
+        // The TokenReviewer is returning an error. This will fail.
+        let req = test::TestRequest::get()
+            .uri(TEST_URI)
+            .insert_header((HEADER_BRUPOP_K8S_AUTH_TOKEN, auth_token))
+            .insert_header((HEADER_BRUPOP_NODE_NAME, node_name))
+            .insert_header((HEADER_BRUPOP_NODE_UID, node_uid))
+            .to_request();
+
+        let resp = app.call(req).await;
+
+        assert!(resp.is_err());
+    }
+}

--- a/apiserver/src/auth/mod.rs
+++ b/apiserver/src/auth/mod.rs
@@ -1,0 +1,10 @@
+pub(crate) mod authorizor;
+pub(crate) mod error;
+pub(crate) mod middleware;
+
+pub use authorizor::{K8STokenAuthorizor, K8STokenReviewer, TokenAuthorizor};
+pub use error::AuthorizationError;
+pub use middleware::TokenAuthMiddleware;
+
+#[cfg(any(mockall, test))]
+pub use authorizor::mock;

--- a/apiserver/src/client/error.rs
+++ b/apiserver/src/client/error.rs
@@ -29,4 +29,10 @@ pub enum ClientError {
         source: Box<dyn std::error::Error>,
         selector: BottlerocketNodeSelector,
     },
+
+    #[snafu(display(
+        "IO error occurred while attempting to use APIServerClient: '{}'",
+        source
+    ))]
+    IOError { source: Box<dyn std::error::Error> },
 }

--- a/apiserver/src/error.rs
+++ b/apiserver/src/error.rs
@@ -1,6 +1,6 @@
 use models::node::BottlerocketNodeError;
 
-use actix_web::error;
+use actix_web::error::ResponseError;
 use snafu::Snafu;
 
 /// The crate-wide result type.
@@ -29,6 +29,9 @@ pub enum Error {
     TracingConfiguration {
         source: tracing::subscriber::SetGlobalDefaultError,
     },
+
+    #[snafu(display("The Kubernetes WATCH on Pod objects has failed."))]
+    KubernetesWatcherFailed {},
 }
 
-impl error::ResponseError for Error {}
+impl ResponseError for Error {}

--- a/apiserver/src/lib.rs
+++ b/apiserver/src/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "server")]
 pub mod api;
 #[cfg(feature = "server")]
+mod auth;
+#[cfg(feature = "server")]
 pub mod error;
 #[cfg(feature = "server")]
 pub mod telemetry;

--- a/apiserver/src/main.rs
+++ b/apiserver/src/main.rs
@@ -37,9 +37,9 @@ async fn run_server() -> Result<()> {
         .context(error::ClientCreate)?;
 
     let settings = APIServerSettings {
-        node_client: K8SBottlerocketNodeClient::new(k8s_client),
+        node_client: K8SBottlerocketNodeClient::new(k8s_client.clone()),
         server_port: 8080,
     };
 
-    api::run_server(settings).await
+    api::run_server(settings, k8s_client).await
 }

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -11,7 +11,7 @@ models = { path = "../models", version = "0.1.0" }
 futures = "0.3"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_20"] }
-kube = { version = "0.62.0", default-features = true, features = [ "derive", "runtime" ] }
+kube = { version = "0.63.2", default-features = true, features = [ "derive", "runtime" ] }
 
 snafu = "0.6"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = "0.1"
 chrono = "0.4"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_20"] }
-kube = { version = "0.62.0", default-features = true, features = [ "derive"] }
+kube = { version = "0.63.2", default-features = true, features = [ "derive"] }
 
 lazy_static = "1.4"
 maplit = "1.0"

--- a/models/src/agent.rs
+++ b/models/src/agent.rs
@@ -1,5 +1,5 @@
 use crate::constants::{
-    AGENT, AGENT_NAME, APP_COMPONENT, APP_MANAGED_BY, APP_PART_OF, BRUPOP,
+    AGENT, AGENT_NAME, APISERVER_SERVICE_NAME, APP_COMPONENT, APP_MANAGED_BY, APP_PART_OF, BRUPOP,
     BRUPOP_INTERFACE_VERSION, LABEL_BRUPOP_INTERFACE_NAME, LABEL_COMPONENT, NAMESPACE,
 };
 use k8s_openapi::api::apps::v1::{DaemonSet, DaemonSetSpec};
@@ -17,6 +17,9 @@ use maplit::btreemap;
 
 const BRUPOP_AGENT_SERVICE_ACCOUNT: &str = "brupop-agent-service-account";
 const BRUPOP_AGENT_CLUSTER_ROLE: &str = "brupop-agent-role";
+
+pub const TOKEN_PROJECTION_MOUNT_PATH: &str = "/var/run/secrets/tokens/";
+pub const AGENT_TOKEN_PATH: &str = "bottlerocket-agent-service-account-token";
 
 /// Defines the brupop-agent service account
 pub fn agent_service_account() -> ServiceAccount {
@@ -199,7 +202,7 @@ pub fn agent_daemonset(agent_image: String, image_pull_secret: Option<String>) -
                             },
                             VolumeMount {
                                 name: "bottlerocket-agent-service-account-token".to_string(),
-                                mount_path: "/var/run/secrets/tokens".to_string(),
+                                mount_path: TOKEN_PROJECTION_MOUNT_PATH.to_string(),
                                 ..Default::default()
                             },
                         ]),
@@ -233,8 +236,8 @@ pub fn agent_daemonset(agent_image: String, image_pull_secret: Option<String>) -
                             projected: Some(ProjectedVolumeSource {
                                 sources: Some(vec![VolumeProjection {
                                     service_account_token: Some(ServiceAccountTokenProjection {
-                                        path: "bottlerocket-agent-service-account-token"
-                                            .to_string(),
+                                        path: AGENT_TOKEN_PATH.to_string(),
+                                        audience: Some(APISERVER_SERVICE_NAME.to_string()),
                                         ..Default::default()
                                     }),
                                     ..Default::default()

--- a/yamlgen/Cargo.toml
+++ b/yamlgen/Cargo.toml
@@ -8,5 +8,5 @@ license = "Apache-2.0 OR MIT"
 [build-dependencies]
 models = { path = "../models", version = "0.1.0" }
 dotenv = "0.15"
-kube = { version = "0.62.0", default-features = true, features = ["derive"] }
+kube = { version = "0.63.2", default-features = true, features = ["derive"] }
 serde_yaml = "0.8"

--- a/yamlgen/build.rs
+++ b/yamlgen/build.rs
@@ -11,8 +11,9 @@ use models::{
         agent_cluster_role, agent_cluster_role_binding, agent_daemonset, agent_service_account,
     },
     apiserver::{
-        apiserver_cluster_role, apiserver_cluster_role_binding, apiserver_deployment,
-        apiserver_service, apiserver_service_account,
+        apiserver_auth_delegator_cluster_role_binding, apiserver_cluster_role,
+        apiserver_cluster_role_binding, apiserver_deployment, apiserver_service,
+        apiserver_service_account,
     },
     controller::{
         controller_cluster_role, controller_cluster_role_binding, controller_deployment,
@@ -61,6 +62,11 @@ fn main() {
     serde_yaml::to_writer(&brupop_resources, &apiserver_service_account()).unwrap();
     serde_yaml::to_writer(&brupop_resources, &apiserver_cluster_role()).unwrap();
     serde_yaml::to_writer(&brupop_resources, &apiserver_cluster_role_binding()).unwrap();
+    serde_yaml::to_writer(
+        &brupop_resources,
+        &apiserver_auth_delegator_cluster_role_binding(),
+    )
+    .unwrap();
     serde_yaml::to_writer(
         &brupop_resources,
         &apiserver_deployment(brupop_image.clone(), brupop_image_pull_secrets.clone()),

--- a/yamlgen/deploy/brupop-resources.yaml
+++ b/yamlgen/deploy/brupop-resources.yaml
@@ -67,6 +67,20 @@ subjects:
     name: brupop-apiserver-service-account
     namespace: brupop-bottlerocket-aws
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: brupop-apiserver-auth-delegator-role-binding
+  namespace: brupop-bottlerocket-aws
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "system:auth-delegator"
+subjects:
+  - kind: ServiceAccount
+    name: brupop-apiserver-service-account
+    namespace: brupop-bottlerocket-aws
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -253,7 +267,7 @@ spec:
               name: bottlerocket-api-socket
             - mountPath: /bin/apiclient
               name: bottlerocket-apiclient
-            - mountPath: /var/run/secrets/tokens
+            - mountPath: /var/run/secrets/tokens/
               name: bottlerocket-agent-service-account-token
       imagePullSecrets:
         - name: brupop
@@ -271,6 +285,7 @@ spec:
           projected:
             sources:
               - serviceAccountToken:
+                  audience: brupop-apiserver
                   path: bottlerocket-agent-service-account-token
 ---
 apiVersion: v1


### PR DESCRIPTION
**Issue number:** #80 #76



**Description of changes:**
For all write operations on nodes, the apiserver now checks that the requester
lives on the Node to which it is attempting to write. This means that
brupop agents will be incapable of changing the brn objects of other nodes,
or draining pods from nodes they are not running on.

This is done using the `TokenReview` API in kubernetes. An auth token provided by clients is used to authenticate that client's identity, and then ensure that the client lives on the node that it is attempting to augment.


**Testing done:**
Unit tests pass. I've also run the controller using this code, with successful node updates occurring.

Logs a succesfully authenticated request appear like so:

```
{"v":0,"name":"apiserver","msg":"[HTTP REQUEST - START]","level":30,"hostname":"brupop-apiserver-7c66b5c45f-69fqw","pid":1,"time":"2021-11-06T03:17:40.461609704+00:00","target":"apiserver::telemetry","line":22,"file":"apiserver/src/telemetry.rs","http.scheme":"http","http.host":"brupop-apiserver.brupop-bottlerocket-aws.svc.cluster.local","http.flavor":"1.1","http.user_agent":"","http.method":"POST","http.route":"/bottlerocket-node-resource","http.target":"/bottlerocket-node-resource","http.client_ip":"192.168.15.25:59276","otel.kind":"server","request_id":"bfa88277-ed00-42b0-9da0-2ded3bf98634","node_name":"ip-192-168-27-1.us-west-2.compute.internal"}
{"v":0,"name":"apiserver","msg":"[CHECK_REQUEST_AUTHORIZED - START]","level":30,"hostname":"brupop-apiserver-7c66b5c45f-69fqw","pid":1,"time":"2021-11-06T03:17:40.461810565+00:00","target":"apiserver::auth","line":153,"file":"apiserver/src/auth.rs","http.scheme":"http","http.host":"brupop-apiserver.brupop-bottlerocket-aws.svc.cluster.local","http.flavor":"1.1","k8s_audiences":"Some([\"brupop-apiserver\"])","namespace":"brupop-bottlerocket-aws","http.user_agent":"","http.method":"POST","http.route":"/bottlerocket-node-resource","http.target":"/bottlerocket-node-resource","http.client_ip":"192.168.15.25:59276","otel.kind":"server","request_id":"bfa88277-ed00-42b0-9da0-2ded3bf98634","node_name":"ip-192-168-27-1.us-west-2.compute.internal","node_selector":"BottlerocketNodeSelector { node_name: \"ip-192-168-27-1.us-west-2.compute.internal\", node_uid: \"c17427b2-b3d7-4908-86de-9d389ae86391\" }"}
{"v":0,"name":"apiserver","msg":"[CHECK_REQUEST_AUTHORIZED - END]","level":30,"hostname":"brupop-apiserver-7c66b5c45f-69fqw","pid":1,"time":"2021-11-06T03:17:40.464345025+00:00","target":"apiserver::auth","line":153,"file":"apiserver/src/auth.rs","http.scheme":"http","http.host":"brupop-apiserver.brupop-bottlerocket-aws.svc.cluster.local","http.flavor":"1.1","http.method":"POST","otel.kind":"server","node_name":"ip-192-168-27-1.us-west-2.compute.internal","namespace":"brupop-bottlerocket-aws","elapsed_milliseconds":2,"http.user_agent":"","http.route":"/bottlerocket-node-resource","http.target":"/bottlerocket-node-resource","k8s_audiences":"Some([\"brupop-apiserver\"])","http.client_ip":"192.168.15.25:59276","request_id":"bfa88277-ed00-42b0-9da0-2ded3bf98634","node_selector":"BottlerocketNodeSelector { node_name: \"ip-192-168-27-1.us-west-2.compute.internal\", node_uid: \"c17427b2-b3d7-4908-86de-9d389ae86391\" }"}
{"v":0,"name":"apiserver","msg":"[CREATE_NODE - START]","level":30,"hostname":"brupop-apiserver-7c66b5c45f-69fqw","pid":1,"time":"2021-11-06T03:17:40.464378674+00:00","target":"models::node::client","line":146,"file":"models/src/node/client.rs","http.scheme":"http","http.host":"brupop-apiserver.brupop-bottlerocket-aws.svc.cluster.local","http.flavor":"1.1","selector":"BottlerocketNodeSelector { node_name: \"ip-192-168-27-1.us-west-2.compute.internal\", node_uid: \"c17427b2-b3d7-4908-86de-9d389ae86391\" }","http.user_agent":"","http.method":"POST","http.route":"/bottlerocket-node-resource","http.target":"/bottlerocket-node-resource","http.client_ip":"192.168.15.25:59276","otel.kind":"server","request_id":"bfa88277-ed00-42b0-9da0-2ded3bf98634","node_name":"ip-192-168-27-1.us-west-2.compute.internal"}
{"v":0,"name":"apiserver","msg":"[CREATE_NODE - END]","level":30,"hostname":"brupop-apiserver-7c66b5c45f-69fqw","pid":1,"time":"2021-11-06T03:17:40.470734253+00:00","target":"models::node::client","line":146,"file":"models/src/node/client.rs","http.scheme":"http","http.host":"brupop-apiserver.brupop-bottlerocket-aws.svc.cluster.local","http.flavor":"1.1","elapsed_milliseconds":6,"selector":"BottlerocketNodeSelector { node_name: \"ip-192-168-27-1.us-west-2.compute.internal\", node_uid: \"c17427b2-b3d7-4908-86de-9d389ae86391\" }","http.user_agent":"","http.method":"POST","http.route":"/bottlerocket-node-resource","http.target":"/bottlerocket-node-resource","http.client_ip":"192.168.15.25:59276","otel.kind":"server","request_id":"bfa88277-ed00-42b0-9da0-2ded3bf98634","node_name":"ip-192-168-27-1.us-west-2.compute.internal"}
{"v":0,"name":"apiserver","msg":"[HTTP REQUEST - END]","level":30,"hostname":"brupop-apiserver-7c66b5c45f-69fqw","pid":1,"time":"2021-11-06T03:17:40.470779521+00:00","target":"apiserver::telemetry","line":22,"file":"apiserver/src/telemetry.rs","http.scheme":"http","http.host":"brupop-apiserver.brupop-bottlerocket-aws.svc.cluster.local","http.flavor":"1.1","otel.status_code":"OK","http.status_code":200,"elapsed_milliseconds":8,"http.user_agent":"","http.method":"POST","http.route":"/bottlerocket-node-resource","http.target":"/bottlerocket-node-resource","http.client_ip":"192.168.15.25:59276","otel.kind":"server","request_id":"bfa88277-ed00-42b0-9da0-2ded3bf98634","node_name":"ip-192-168-27-1.us-west-2.compute.internal"}
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
