### PR TITLE
0.2.0 agentclient: use reflector to watch and cache event.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
+ "tokio-retry",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -25,3 +25,4 @@ snafu = "0.6"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 reqwest = { version = "0.11", features =  [ "json" ] }
 chrono = { version = "0.4.11", features = [ "serde" ] }
+tokio-retry = "0.3"

--- a/agent/src/apiclient.rs
+++ b/agent/src/apiclient.rs
@@ -329,24 +329,24 @@ pub mod apiclient_error {
         #[snafu(display("Failed to deserialize update status: {}", source))]
         UpdateStatusContent { source: serde_json::Error },
 
-        #[snafu(display("failed to refresh updates or update action performed out of band"))]
+        #[snafu(display("Failed to refresh updates or update action performed out of band"))]
         RefreshUpdate {},
 
-        #[snafu(display("failed to prepare update or update action performed out of band"))]
+        #[snafu(display("Failed to prepare update or update action performed out of band"))]
         PrepareUpdate {},
 
-        #[snafu(display("failed to activate update or update action performed out of band"))]
+        #[snafu(display("Failed to activate update or update action performed out of band"))]
         Update {},
 
         #[snafu(display(
-        "unexpected update state: {:?}, expecting state to be {}. update action performed out of band?",
+        "Unexpected update state: {:?}, expecting state to be {}. Update action performed out of band?",
          update_state, expect_state
     ))]
         UpdateStage {
             expect_state: String,
             update_state: UpdateState,
         },
-        #[snafu(display("bad http response, status code: {}", statuscode))]
+        #[snafu(display("Bad http response, status code: {}", statuscode))]
         BadHttpResponse { statuscode: String },
 
         #[snafu(display("Unable to process command apiclient {}: update API unavailable: retries exhausted", args.join(" ")))]

--- a/agent/src/error.rs
+++ b/agent/src/error.rs
@@ -11,42 +11,33 @@ pub enum Error {
     #[snafu(display("Unable to create client: '{}'", source))]
     ClientCreate { source: kube::Error },
 
-    #[snafu(display(
-        "Unable to fetch the Kubernetes custom resource associated with this node: '{}'",
-        source
-    ))]
-    FetchCustomResource { source: kube::Error },
-
-    #[snafu(display("Unable to get associated node name: '{}'", source))]
+    #[snafu(display("Unable to get associated node name: {}", source))]
     GetNodeName { source: std::env::VarError },
-
-    #[snafu(display(
-        "Unable to fetch the Kubernetes node associated with this pod: '{}'",
-        source
-    ))]
-    FetchNode { source: kube::Error },
 
     #[snafu(display("Unable to get Node uid because of missing Node `uid` value"))]
     MissingNodeUid {},
 
-    #[snafu(display("Fail to get Node selector value: Node selector value is None"))]
-    NodeSelectorIsNone {},
-
-    #[snafu(display("Unable to get Bottlerocket Node {}: '{}'", node_name, source))]
-    BottlerocketNodeNotExist {
+    #[snafu(display(
+        "Error {} when sending to fetch Bottlerocket Node {}",
+        source,
+        node_name
+    ))]
+    UnableFetchBottlerocketNode {
         node_name: String,
         source: kube::Error,
     },
+    #[snafu(display(
+        "ErrorResponse code '{}' when sending to fetch Bottlerocket Node",
+        code
+    ))]
+    FetchBottlerocketNodeErrorCode { code: u16 },
 
     #[snafu(display(
         "Unable to get Bottlerocket node 'status' because of missing 'status' value"
     ))]
     MissingBottlerocketNodeStatus,
 
-    #[snafu(display("Unable to get Bottlerocket node 'spec' because of missing 'spec' value"))]
-    MissingBottlerocketNodeSpec,
-
-    #[snafu(display("Unable to gather system version metadata: '{}'", source))]
+    #[snafu(display("Unable to gather system version metadata: {}", source))]
     BottlerocketNodeStatusVersion { source: apiclient_error::Error },
 
     #[snafu(display("Unable to gather system available versions metadata: '{}'", source))]
@@ -95,4 +86,10 @@ pub enum Error {
     // we know cannot be Err. This lets us bubble up to our error handler which writes to the termination log.
     #[snafu(display("Agent failed due to internal assertion issue: '{}'", message))]
     Assertion { message: String },
+
+    #[snafu(display(
+        "Unable to fetch {} store: Store unavailable: retries exhausted",
+        object
+    ))]
+    ReflectorUnavailable { object: String },
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,7 +1,18 @@
 use agent::agentclient::BrupopAgent;
 use agent::error::{self, Result};
 use apiserver::client::K8SAPIServerClient;
+use k8s_openapi::api::core::v1::Node;
+use kube::Api;
 use models::agent::{AGENT_TOKEN_PATH, TOKEN_PROJECTION_MOUNT_PATH};
+
+use futures::StreamExt;
+use kube::api::ListParams;
+use kube::runtime::reflector;
+use kube::runtime::utils::try_flatten_touched;
+use kube::runtime::watcher::watcher;
+use models::constants::NAMESPACE;
+
+use models::node::BottlerocketNode;
 
 use snafu::{OptionExt, ResultExt};
 
@@ -37,17 +48,61 @@ async fn run_agent() -> Result<()> {
     })?;
     let apiserver_client = K8SAPIServerClient::new(token_path.to_string());
 
-    let mut agent = BrupopAgent::new(k8s_client, apiserver_client);
+    // Get node and bottlerocketnode names
+    let associated_node_name = env::var("MY_NODE_NAME").context(error::GetNodeName)?;
+    let associated_bottlerocketnode_name = format!("brn-{}", associated_node_name);
 
-    // Create a bottlerocketnode (custom resource) if associated bottlerocketnode does not exist
-    if !agent.check_node_custom_resource_exists().await? {
-        agent.create_metadata_custom_resource().await?;
-    }
+    // Generate reflector to watch and cache BottlerocketNodes
+    let brns = Api::<BottlerocketNode>::namespaced(k8s_client.clone(), NAMESPACE);
+    let brn_lp = ListParams::default()
+        .fields(format!("metadata.name={}", associated_bottlerocketnode_name).as_str());
+    let brn_store = reflector::store::Writer::<BottlerocketNode>::default();
+    let brn_reader = brn_store.as_reader();
+    let brn_reflector = reflector::reflector(brn_store, watcher(brns, brn_lp));
+    let brn_drainer = try_flatten_touched(brn_reflector)
+        .filter_map(|x| async move { std::result::Result::ok(x) })
+        .for_each(|_brn| {
+            // TODO: utilize tracing event
+            log::debug!("Processed event for BottlerocketNodes");
+            futures::future::ready(())
+        });
 
-    // Initialize bottlerocketnode (custom resource) `status` if associated bottlerocketnode does not have `status`
-    if !agent.check_custom_resource_status_exists().await? {
-        agent.initialize_metadata_custom_resource().await?;
-    }
+    // Generate reflector to watch and cache Nodes
+    let node_lp =
+        ListParams::default().fields(format!("metadata.name={}", associated_node_name).as_str());
+    let nodes: Api<Node> = Api::all(k8s_client.clone());
+    let nodes_store = reflector::store::Writer::<Node>::default();
+    let node_reader = nodes_store.as_reader();
+    let node_reflector = reflector::reflector(nodes_store, watcher(nodes, node_lp));
+    let node_drainer = try_flatten_touched(node_reflector)
+        .filter_map(|x| async move { std::result::Result::ok(x) })
+        .for_each(|_node| {
+            // TODO: utilize tracing event
+            log::debug!("Processed event for node");
+            futures::future::ready(())
+        });
 
-    agent.run().await
+    let mut agent = BrupopAgent::new(
+        k8s_client.clone(),
+        apiserver_client,
+        brn_reader,
+        node_reader,
+        associated_node_name,
+        associated_bottlerocketnode_name,
+    );
+
+    let agent_runner = agent.run();
+
+    tokio::select! {
+        _ = brn_drainer => {
+            log::error!("Processed event for brn");
+        },
+        _ = node_drainer => {
+            log::error!("Processed event for node");
+        },
+        _ = agent_runner => {
+            log::error!("runner exited");
+        },
+    };
+    Ok(())
 }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = "0.1"
 chrono = "0.4"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_20"] }
-kube = { version = "0.63.2", default-features = true, features = [ "derive"] }
+kube = { version = "0.63.2", default-features = true, features = [ "derive", "runtime" ] }
 
 lazy_static = "1.4"
 maplit = "1.0"

--- a/yamlgen/Cargo.toml
+++ b/yamlgen/Cargo.toml
@@ -8,5 +8,5 @@ license = "Apache-2.0 OR MIT"
 [build-dependencies]
 models = { path = "../models", version = "0.1.0" }
 dotenv = "0.15"
-kube = { version = "0.63.2", default-features = true, features = ["derive"] }
+kube = { version = "0.63.2", default-features = true, features = [ "derive", "runtime" ] }
 serde_yaml = "0.8"


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#100 #103


**Description of changes:**

1. add creation of the BRN and status objects to the start of the loop{} in agent.run()
2. using reflector to talk with customer resource and nodes instead of polling etcd
3. fix some typods

**Testing done:**
Apply agent component to EKS cluster and verify if it create BRNs accurately.
```
NAME                                           READY   STATUS             RESTARTS   AGE
brupop-agent-9nskt                             1/1     Running            1          35m
brupop-agent-lb7wn                             0/1     Running   1          35m
brupop-agent-nfkw7                             1/1     Running            3          35m
brupop-apiserver-677496b7c4-6kq6q              1/1     Running            1          35m
brupop-apiserver-677496b7c4-cstt4              1/1     Running            1          35m
brupop-apiserver-677496b7c4-rw5m8              1/1     Running            0          35m
brupop-controller-deployment-dbb96dcdd-f9vmv   1/1     Running            0          35m
```
```
NAME                                               STATE   VERSION   TARGET STATE   TARGET VERSION
brn-ip-192-168-70-212.us-west-2.compute.internal   Idle    1.4.2     Idle           <no value>
brn-ip-192-168-71-122.us-west-2.compute.internal   Idle    1.1.1     StagedUpdate   1.4.1
brn-ip-192-168-75-219.us-west-2.compute.internal   Idle    1.4.1     Idle
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
