### PR TITLE
Add prometheus metrics for apiserver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "sha-1",
  "smallvec",
  "tokio",
+ "zstd",
 ]
 
 [[package]]
@@ -200,6 +201,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-opentelemetry"
+version = "0.11.0-beta.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777a4e1306865f5eabc5c778e232dd2f7c1b8782e37dbf0d57644db9abc53695"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "awc",
+ "futures",
+ "opentelemetry",
+ "opentelemetry-prometheus",
+ "opentelemetry-semantic-conventions",
+ "prometheus",
+ "serde",
+]
+
+[[package]]
 name = "agent"
 version = "0.1.0"
 dependencies = [
@@ -255,6 +273,7 @@ name = "apiserver"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "actix-web-opentelemetry",
  "async-trait",
  "futures",
  "http",
@@ -266,6 +285,7 @@ dependencies = [
  "mockall",
  "models",
  "opentelemetry",
+ "opentelemetry-prometheus",
  "reqwest",
  "schemars",
  "serde",
@@ -307,6 +327,32 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "awc"
+version = "3.0.0-beta.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774d647a23d085bf35c83b6da5a6bd966fdc4af92ffce865befa9f3a8cf73015"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-rt",
+ "actix-service",
+ "base64",
+ "bytes",
+ "cfg-if",
+ "derive_more",
+ "futures-core",
+ "itoa",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+]
 
 [[package]]
 name = "base64"
@@ -355,6 +401,9 @@ name = "cc"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -962,6 +1011,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1443,8 @@ checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
+ "dashmap",
+ "fnv",
  "futures",
  "js-sys",
  "lazy_static",
@@ -1394,6 +1454,26 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee9c06c1366665e7d4dba6540a42ea48900a9c92dc5b963f3ae05fbba76dc63"
+dependencies = [
+ "opentelemetry",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffeac823339e8b0f27b961f4385057bf9f97f2863bc745bd015fd6091f2270e9"
+dependencies = [
+ "opentelemetry",
 ]
 
 [[package]]
@@ -1599,6 +1679,27 @@ checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
 
 [[package]]
 name = "quote"
@@ -2630,4 +2731,33 @@ dependencies = [
  "kube",
  "models",
  "serde_yaml",
+]
+
+[[package]]
+name = "zstd"
+version = "0.7.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9428752481d8372e15b1bf779ea518a179ad6c771cca2d2c60e4fbff3cc2cd52"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "3.1.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa1926623ad7fe406e090555387daf73db555b948134b4d73eac5eb08fb666d"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.5.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e6c094340240369025fc6b731b054ee2a834328fa584310ac96aa4baebdc465"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -16,11 +16,13 @@ models = { path = "../models", version = "0.1.0" }
 
 # tracing-actix-web version must align with actix-web version
 actix-web = { version = "4.0.0-beta.9", default-features = false }
+actix-web-opentelemetry = { version = "0.11.0-beta.5", features = ["metrics"] }
+opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"]}
+opentelemetry-prometheus = "0.9"
 tracing = "0.1"
 tracing-actix-web = "0.4.0-beta.14"
 tracing-bunyan-formatter = "0.3"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
-opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"]}
 tracing-opentelemetry = "0.16"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature

--- a/apiserver/src/main.rs
+++ b/apiserver/src/main.rs
@@ -32,6 +32,7 @@ async fn main() {
 
 async fn run_server() -> Result<()> {
     init_telemetry()?;
+    let prometheus_exporter = opentelemetry_prometheus::exporter().init();
 
     let k8s_client = kube::client::Client::try_default()
         .await
@@ -42,5 +43,5 @@ async fn run_server() -> Result<()> {
         server_port: 8080,
     };
 
-    api::run_server(settings, k8s_client).await
+    api::run_server(settings, k8s_client, Some(prometheus_exporter)).await
 }


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #89



**Description of changes:**
Using actix-web-opentelemetry to add prometheus metrics to any request send to apiserver.

The metrics can be scraped via $apiserver_ip:8080/metrics



**Testing done:**
Deployed the new apiserver on kubernetes and checked the metrics from the cluster.  

Sample metrics:
```
$ curl 192.168.22.184:8080/metrics
# HELP http_requests_duration HTTP request duration per route
# TYPE http_requests_duration histogram
http_requests_duration_bucket{method="GET",route="/ping",status="200",le="0.5"} 4
http_requests_duration_bucket{method="GET",route="/ping",status="200",le="0.9"} 4
http_requests_duration_bucket{method="GET",route="/ping",status="200",le="0.99"} 4
http_requests_duration_bucket{method="GET",route="/ping",status="200",le="+Inf"} 4
http_requests_duration_sum{method="GET",route="/ping",status="200"} 0.00007168699999999999
http_requests_duration_count{method="GET",route="/ping",status="200"} 4
http_requests_duration_bucket{method="PUT",route="/bottlerocket-node-resource",status="200",le="0.5"} 2
http_requests_duration_bucket{method="PUT",route="/bottlerocket-node-resource",status="200",le="0.9"} 2
http_requests_duration_bucket{method="PUT",route="/bottlerocket-node-resource",status="200",le="0.99"} 2
http_requests_duration_bucket{method="PUT",route="/bottlerocket-node-resource",status="200",le="+Inf"} 2
http_requests_duration_sum{method="PUT",route="/bottlerocket-node-resource",status="200"} 0.028294012
http_requests_duration_count{method="PUT",route="/bottlerocket-node-resource",status="200"} 2
# HELP http_requests_total HTTP requests per route
# TYPE http_requests_total counter
http_requests_total{method="GET",route="/ping",status="200"} 4
http_requests_total{method="PUT",route="/bottlerocket-node-resource",status="200"} 2
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
