### PR TITLE
add integration test for brupop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,341 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-config"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f072f0d08f62093e2a38603307e368bf90d5acd3e3b54b60292cba4698bba38b"
+dependencies = [
+ "aws-http",
+ "aws-hyper",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-endpoint"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4d939891f640c013bbae11180e767470d75c9d61b48d85008fbd19a46e6a46"
+dependencies = [
+ "aws-smithy-http",
+ "aws-types",
+ "http",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f685b9441c4e99d478b4e70cd0993ed178029534c296143ae9d37f2a424dde82"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "aws-types",
+ "http",
+ "lazy_static",
+ "tracing",
+]
+
+[[package]]
+name = "aws-hyper"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f0a1a3500ec4b07ba95b56df754dd1a3b0555b1f27f71592bbfa3ee4a8e2a7"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "pin-project 1.0.8",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ec2"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcb23ce57b0686276ceb4786652d1a7e027c1cf88ae43b7d11c613223b11c69"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-hyper",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-query",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http",
+]
+
+[[package]]
+name = "aws-sdk-eks"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2644b14816741b2377a03da528eb64a2dfe86ace10c467f4576c94ec9f27de31"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-hyper",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http",
+]
+
+[[package]]
+name = "aws-sdk-iam"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5207cdd7a4ceee7ff033de796ce4382c8b85e73021d7fc28768bbbc5a764b17b"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-hyper",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-query",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "aws-sdk-ssm"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd01dc825d7cb7ca647f431a91bde748ed752d2d61740a70e22fb07a6ed62af"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-hyper",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8858771f3809ff70b1c9ebc464b86bf2d7c6ce50a0c2f153484abe45ca76f9"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-hyper",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-query",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "aws-sig-auth"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469d7527fc24e3edc32e5edf1b046d7d7c778ed6c4f9c51f869725bb01c101db"
+dependencies = [
+ "aws-sigv4",
+ "aws-smithy-http",
+ "aws-types",
+ "http",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7d4888513285ec13c9b02c9bf8a3cf264251fc4c51270ca35239e39b18cb57"
+dependencies = [
+ "form_urlencoded",
+ "hex",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "ring",
+ "time 0.3.4",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b323275f9a5118ce0c61c1f509d89d97008f4d6e376826bc744b43b553bf33"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda35ddfd69ad9623dbb66aeaac1b85bc03974fdb4054fcd05cdb4ce1a78bf12"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "lazy_static",
+ "pin-project 1.0.8",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8068bb0c3d2f512ec2ff6c4e74e639266f89bb4bd492f747c4290fe41d17a6e"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "percent-encoding",
+ "pin-project 1.0.8",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-tower"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7beb34a340675391abe55d5ab2619ef2b1c85995126ba1706ba2657ccd602be3"
+dependencies = [
+ "aws-smithy-http",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project 1.0.8",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721176eec47b71d3226d61ccaa40cebe83ddc644c8981c7c3b34547a62808eb3"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0c0dc09c61921a2104e1487810bd32274d8b57dd00d878895ebc51e2068d85"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a422c3740103fe67102ecbedffe8318dd6a03a209f7e097d1e00a1f3f4d186ac"
+dependencies = [
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time 0.3.4",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c884d1dc27ccf45763d42b9f58425493b6cd563a95922f92b87a5d92c4060d4"
+dependencies = [
+ "thiserror",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4761c3bc4d965b2a3568eaadbfc85eee3cbaa18ba81665f2f472004cb8bb34e9"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "rustc_version 0.4.0",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +721,16 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e314712951c43123e5920a446464929adc667a5eade7f8fb3997776c9df6e54"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bytestring"
@@ -423,6 +768,32 @@ dependencies = [
  "serde",
  "time 0.1.44",
  "winapi",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "console_log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
+dependencies = [
+ "log",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -494,6 +865,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,7 +893,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -558,7 +938,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.3.3",
  "syn",
 ]
 
@@ -654,6 +1034,15 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -859,6 +1248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +1264,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -929,6 +1333,23 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
 ]
 
 [[package]]
@@ -996,6 +1417,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "integ"
+version = "0.1.0"
+dependencies = [
+ "aws-config",
+ "aws-sdk-ec2",
+ "aws-sdk-eks",
+ "aws-sdk-iam",
+ "aws-sdk-ssm",
+ "base64",
+ "console_log",
+ "env_logger",
+ "hex",
+ "lazy_static",
+ "log",
+ "maplit",
+ "serde",
+ "serde_json",
+ "snafu",
+ "structopt",
+ "tokio",
+ "tokio-retry",
+ "uuid",
 ]
 
 [[package]]
@@ -1840,12 +2286,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
  "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1893,6 +2388,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -2098,10 +2603,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "structopt"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -2142,6 +2683,15 @@ name = "termtree"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -2268,6 +2818,17 @@ dependencies = [
  "pin-project 1.0.8",
  "rand",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -2501,10 +3062,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -2519,12 +3098,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a1f0175e03a0973cf4afd476bef05c26e228520400eb1fd473ad417b1c00ffb"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]
@@ -2575,6 +3161,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -2675,6 +3267,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,6 +3317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmlparser"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,6 +3340,12 @@ dependencies = [
  "models",
  "serde_yaml",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "apiserver",
     "controller",
     "models",
-    "yamlgen"
+    "yamlgen",
+    "integ"
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -15,9 +15,9 @@ allow = [
     "BSD-3-Clause",
     "BSL-1.0",
     #"CC0-1.0",  # OK but currently unused; commenting to prevent warning
-    #"ISC",  # OK but currently unused; commenting to prevent warning
+    "ISC",
     "MIT",
-    #"OpenSSL",  # OK but currently unused; commenting to prevent warning
+    "OpenSSL",
     "Unlicense",
     "Zlib"
 ]
@@ -33,9 +33,25 @@ skip-tree = [
     { name = "actix-http", version = "3.0.0-beta.10" },
     # chrono uses an older version of time, which clashes with the one used by actix-web.
     { name = "chrono", version = "0.4.19" },
+    # clap uses an older version or strsim, which clashed with the one used by darling_core.
+    { name = "clap", version = "2.34.0" },
 ]
 
 [sources]
 # Deny crates from unknown registries or git repositories.
 unknown-registry = "deny"
 unknown-git = "deny"
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c }
+]

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "integ"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+
+[dependencies]
+aws-config = "0.0.26-alpha"
+aws-sdk-ec2 = "0.0.26-alpha"
+aws-sdk-eks = "0.0.26-alpha"
+aws-sdk-iam = "0.0.26-alpha"
+aws-sdk-ssm = "0.0.26-alpha"
+base64 = "0.13.0"
+console_log = { version = "0.2", features = ["color"] }
+env_logger = "0.9"
+hex ="0.4.3"
+lazy_static = "1.4"
+log = "0.4"
+maplit = "1.0.2"
+serde = { version = "1", features = [ "derive" ] }
+serde_json = "1"
+snafu = "0.6"
+structopt = "0.3.17"
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio-retry = "0.3"
+uuid = { version = "0.8", default-features = false, features = ["serde", "v4"] }

--- a/integ/src/ec2_provider.rs
+++ b/integ/src/ec2_provider.rs
@@ -1,0 +1,305 @@
+/*!
+  ec2 provider helps launching bottlerocket nodes and connect to EKS cluster.
+  Meanwhile, terminating all created ec2 instances when integration test is running 'clean' subcommand.
+!*/
+
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_ec2::model::{
+    ArchitectureValues, Filter, IamInstanceProfileSpecification, InstanceType, ResourceType, Tag,
+    TagSpecification,
+};
+use aws_sdk_ec2::Region;
+
+use crate::eks_provider::ClusterInfo;
+use crate::error::{IntoProviderError, ProviderError, ProviderResult};
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::iter::FromIterator;
+use std::time::Duration;
+
+/// The default number of instances to spin up.
+const DEFAULT_INSTANCE_COUNT: i32 = 3;
+/// The tag name used to create instances.
+const INSTANCE_TAG_NAME: &str = "brupop";
+const INSTANCE_TAG_VALUE: &str = "integration-test";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct CreatedEc2Instances {
+    /// The ids of all created instances
+    pub instance_ids: HashSet<String>,
+
+    /// The private dns name (node name) of all created instances
+    pub private_dns_name: Vec<String>,
+}
+
+pub struct Ec2Creator {}
+
+impl Ec2Creator {}
+
+pub async fn create_ec2_instance(
+    cluster: ClusterInfo,
+    node_ami: &str,
+) -> ProviderResult<CreatedEc2Instances> {
+    // Setup aws_sdk_config and clients.
+    let region_provider = RegionProviderChain::first_try(Some(Region::new(cluster.region.clone())));
+    let shared_config = aws_config::from_env().region(region_provider).load().await;
+    let ec2_client = aws_sdk_ec2::Client::new(&shared_config);
+
+    // Prepare security groups
+    let mut security_groups = vec![];
+    security_groups.append(&mut cluster.nodegroup_sg.clone());
+    security_groups.append(&mut cluster.clustershared_sg.clone());
+
+    // Prepare instance type
+    let instance_type = instance_type(&ec2_client, &node_ami).await?;
+
+    // Run the ec2 instances
+    let run_instances = ec2_client
+        .run_instances()
+        .min_count(DEFAULT_INSTANCE_COUNT)
+        .max_count(DEFAULT_INSTANCE_COUNT)
+        .subnet_id(first_subnet_id(&cluster.private_subnet_ids)?)
+        .set_security_group_ids(Some(security_groups))
+        .image_id(node_ami)
+        .instance_type(InstanceType::from(instance_type.as_str()))
+        .tag_specifications(tag_specifications(&cluster.name))
+        .user_data(userdata(
+            &cluster.endpoint,
+            &cluster.name,
+            &cluster.certificate,
+        ))
+        .iam_instance_profile(
+            IamInstanceProfileSpecification::builder()
+                .arn(&cluster.iam_instance_profile_arn)
+                .build(),
+        );
+
+    let instances = run_instances
+        .send()
+        .await
+        .context("Failed to create instances")?
+        .instances
+        .context("Results missing instances field")?;
+    let mut instance_ids = HashSet::new();
+    let mut private_dns_name: Vec<String> = Vec::new();
+    for instance in instances {
+        instance_ids.insert(instance.instance_id.clone().ok_or_else(|| {
+            ProviderError::new_with_context("Instance missing instance_id field")
+        })?);
+        private_dns_name.push(instance.private_dns_name.clone().ok_or_else(|| {
+            ProviderError::new_with_context("Instance missing private_dns_name field")
+        })?);
+    }
+
+    // Ensure the instances reach a running state.
+    tokio::time::timeout(
+        Duration::from_secs(60),
+        wait_for_conforming_instances(&ec2_client, &instance_ids, DesiredInstanceState::Running),
+    )
+    .await
+    .context("Timed-out waiting for instances to reach the `running` state.")??;
+
+    // Return the ids for the created instances.
+    Ok(CreatedEc2Instances {
+        instance_ids: instance_ids,
+        private_dns_name: private_dns_name,
+    })
+}
+
+pub async fn terminate_ec2_instance(cluster: ClusterInfo) -> ProviderResult<()> {
+    // Setup aws_sdk_config and clients.
+    let region_provider = RegionProviderChain::first_try(Some(Region::new(cluster.region.clone())));
+    let shared_config = aws_config::from_env().region(region_provider).load().await;
+    let ec2_client = aws_sdk_ec2::Client::new(&shared_config);
+
+    let running_instance_ids = get_instances_by_tag(&ec2_client).await?;
+
+    let _terminate_results = ec2_client
+        .terminate_instances()
+        .set_instance_ids(Some(Vec::from_iter(running_instance_ids.clone())))
+        .send()
+        .await
+        .map_err(|e| {
+            ProviderError::new_with_source_and_context("Failed to terminate instances", e)
+        })?;
+    // Ensure the instances reach a terminated state.
+    tokio::time::timeout(
+        Duration::from_secs(300),
+        wait_for_conforming_instances(
+            &ec2_client,
+            &running_instance_ids,
+            DesiredInstanceState::Terminated,
+        ),
+    )
+    .await
+    .context("Timed-out waiting for instances to reach the `terminated` state.")??;
+    Ok(())
+}
+
+/// Determine the instance type to use. If provided use that one. Otherwise, for `x86_64` use `m5.large`
+/// and for `aarch64` use `m6g.large`
+async fn instance_type(ec2_client: &aws_sdk_ec2::Client, node_ami: &str) -> ProviderResult<String> {
+    let arch = ec2_client
+        .describe_images()
+        .image_ids(node_ami)
+        .send()
+        .await
+        .context("Unable to get ami architecture")?
+        .images
+        .context("Unable to get ami architecture")?
+        .get(0)
+        .context("Unable to get ami architecture")?
+        .architecture
+        .clone()
+        .context("Ami has no architecture")?;
+
+    Ok(match arch {
+        ArchitectureValues::X8664 => "m5.large",
+        ArchitectureValues::Arm64 => "m6g.large",
+        _ => "m6g.large",
+    }
+    .to_string())
+}
+
+fn first_subnet_id(subnet_ids: &[String]) -> ProviderResult<String> {
+    subnet_ids
+        .get(0)
+        .map(|id| id.to_string())
+        .context("There are no private subnet ids")
+}
+
+fn tag_specifications(cluster_name: &str) -> TagSpecification {
+    TagSpecification::builder()
+        .resource_type(ResourceType::Instance)
+        .tags(
+            Tag::builder()
+                .key("Name")
+                .value(format!("{}_node", cluster_name))
+                .build(),
+        )
+        .tags(
+            Tag::builder()
+                .key(format!("kubernetes.io/cluster/{}", cluster_name))
+                .value("owned")
+                .build(),
+        )
+        .tags(
+            Tag::builder()
+                .key(INSTANCE_TAG_NAME)
+                .value(INSTANCE_TAG_VALUE)
+                .build(),
+        )
+        .build()
+}
+
+fn userdata(endpoint: &str, cluster_name: &str, certificate: &str) -> String {
+    base64::encode(format!(
+        r#"[settings.updates]
+ignore-waves = true
+    
+[settings.kubernetes]
+api-server = "{}"
+cluster-name = "{}"
+cluster-certificate = "{}""#,
+        endpoint, cluster_name, certificate
+    ))
+}
+
+#[derive(Debug)]
+enum DesiredInstanceState {
+    Running,
+    Terminated,
+}
+
+impl DesiredInstanceState {
+    fn filter(&self) -> Filter {
+        let filter = Filter::builder()
+            .name("instance-state-name")
+            .values("pending")
+            .values("shutting-down")
+            .values("stopping")
+            .values("stopped")
+            .values(match self {
+                DesiredInstanceState::Running => "terminated",
+                DesiredInstanceState::Terminated => "running",
+            });
+
+        filter.build()
+    }
+}
+
+async fn wait_for_conforming_instances(
+    ec2_client: &aws_sdk_ec2::Client,
+    instance_ids: &HashSet<String>,
+    desired_instance_state: DesiredInstanceState,
+) -> ProviderResult<()> {
+    loop {
+        if !non_conforming_instances(ec2_client, instance_ids, &desired_instance_state)
+            .await?
+            .is_empty()
+        {
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+            continue;
+        }
+        return Ok(());
+    }
+}
+
+async fn non_conforming_instances(
+    ec2_client: &aws_sdk_ec2::Client,
+    instance_ids: &HashSet<String>,
+    desired_instance_state: &DesiredInstanceState,
+) -> ProviderResult<Vec<String>> {
+    let mut describe_result = ec2_client
+        .describe_instance_status()
+        .filters(desired_instance_state.filter())
+        .set_instance_ids(Some(Vec::from_iter(instance_ids.clone())))
+        .include_all_instances(true)
+        .send()
+        .await
+        .context(format!(
+            "Unable to list instances in the '{:?}' state.",
+            desired_instance_state
+        ))?;
+    let non_conforming_instances = describe_result
+        .instance_statuses
+        .as_mut()
+        .context("No instance statuses were provided.")?;
+
+    Ok(non_conforming_instances
+        .iter_mut()
+        .filter_map(|instance_status| instance_status.instance_id.clone())
+        .collect())
+}
+
+// Find all running instances with the tag for this resource.
+async fn get_instances_by_tag(ec2_client: &aws_sdk_ec2::Client) -> ProviderResult<HashSet<String>> {
+    let mut describe_result = ec2_client
+        .describe_instances()
+        .filters(
+            Filter::builder()
+                .name("tag-key")
+                .values(INSTANCE_TAG_NAME)
+                .build(),
+        )
+        .send()
+        .await
+        .context("Unable to get instances.")?;
+    let instances = describe_result
+        .reservations
+        .as_mut()
+        .context("No instances were provided.")?;
+
+    Ok(instances
+        .iter_mut()
+        // Extract the vec of `Instance`s from each `Reservation`
+        .filter_map(|reservation| reservation.instances.as_ref())
+        // Combine all `Instance`s into one iterator no matter which `Reservation` they
+        // came from.
+        .flatten()
+        // Extract the instance id from each `Instance`.
+        .filter_map(|instance| instance.instance_id.clone())
+        .collect())
+}

--- a/integ/src/eks_provider.rs
+++ b/integ/src/eks_provider.rs
@@ -1,0 +1,351 @@
+/*!
+  eks provider helps extracting target cluster all info, which integration test can use
+  to add bottlerocket nodes to cluster and install brupop on cluster
+!*/
+
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_ec2::model::{Filter, SecurityGroup, Subnet};
+use aws_sdk_ec2::Region;
+
+use crate::error::{IntoProviderError, ProviderError, ProviderResult};
+
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct ClusterInfo {
+    pub name: String,
+    pub region: String,
+    pub endpoint: String,
+    pub certificate: String,
+    pub public_subnet_ids: Vec<String>,
+    pub private_subnet_ids: Vec<String>,
+    pub nodegroup_sg: Vec<String>,
+    pub controlplane_sg: Vec<String>,
+    pub clustershared_sg: Vec<String>,
+    pub iam_instance_profile_arn: String,
+}
+
+pub fn write_kubeconfig(
+    cluster_name: &str,
+    region: &str,
+    kubeconfig_dir: &str,
+) -> ProviderResult<()> {
+    let status = Command::new("eksctl")
+        .args([
+            "utils",
+            "write-kubeconfig",
+            "-r",
+            region,
+            &format!("--cluster={}", cluster_name),
+            &format!("--kubeconfig={}", kubeconfig_dir),
+        ])
+        .status()
+        .context("Unable to generate and write kubeconfig")?;
+
+    if !status.success() {
+        return Err(ProviderError::new_with_context(format!(
+            "Failed write kubeconfig with status code {}",
+            status
+        )));
+    }
+
+    Ok(())
+}
+
+pub async fn get_cluster_info(cluster_name: &str, region: &str) -> ProviderResult<ClusterInfo> {
+    let region_provider = RegionProviderChain::first_try(Some(Region::new(region.to_string())));
+    let shared_config = aws_config::from_env().region(region_provider).load().await;
+    let eks_client = aws_sdk_eks::Client::new(&shared_config);
+    let ec2_client = aws_sdk_ec2::Client::new(&shared_config);
+    let iam_client = aws_sdk_iam::Client::new(&shared_config);
+
+    let eks_subnet_ids = eks_subnet_ids(&eks_client, cluster_name).await?;
+    let endpoint = endpoint(&eks_client, cluster_name).await?;
+    let certificate = certificate(&eks_client, cluster_name).await?;
+
+    let public_subnet_ids = subnet_ids(
+        &ec2_client,
+        cluster_name,
+        eks_subnet_ids.clone(),
+        SubnetType::Public,
+    )
+    .await?
+    .into_iter()
+    .filter_map(|subnet| subnet.subnet_id)
+    .collect();
+
+    let private_subnet_ids = subnet_ids(
+        &ec2_client,
+        cluster_name,
+        eks_subnet_ids.clone(),
+        SubnetType::Private,
+    )
+    .await?
+    .into_iter()
+    .filter_map(|subnet| subnet.subnet_id)
+    .collect();
+
+    let nodegroup_sg = security_group(&ec2_client, cluster_name, SecurityGroupType::NodeGroup)
+        .await?
+        .into_iter()
+        .filter_map(|security_group| security_group.group_id)
+        .collect();
+
+    let controlplane_sg =
+        security_group(&ec2_client, cluster_name, SecurityGroupType::ControlPlane)
+            .await?
+            .into_iter()
+            .filter_map(|security_group| security_group.group_id)
+            .collect();
+
+    let clustershared_sg =
+        security_group(&ec2_client, cluster_name, SecurityGroupType::ClusterShared)
+            .await?
+            .into_iter()
+            .filter_map(|security_group| security_group.group_id)
+            .collect();
+
+    let node_instance_role = cluster_iam_identity_mapping(cluster_name, region)?;
+    let iam_instance_profile_arn =
+        instance_profile(&iam_client, cluster_name, &node_instance_role).await?;
+
+    Ok(ClusterInfo {
+        name: cluster_name.to_string(),
+        region: region.to_string(),
+        endpoint,
+        certificate,
+        public_subnet_ids,
+        private_subnet_ids,
+        nodegroup_sg,
+        controlplane_sg,
+        clustershared_sg,
+        iam_instance_profile_arn,
+    })
+}
+
+async fn eks_subnet_ids(
+    eks_client: &aws_sdk_eks::Client,
+    cluster_name: &str,
+) -> ProviderResult<Vec<String>> {
+    let describe_results = eks_client
+        .describe_cluster()
+        .name(cluster_name)
+        .send()
+        .await
+        .context("Unable to get eks describe cluster")?;
+
+    // Extract the subnet ids from the cluster.
+    describe_results
+        .cluster
+        .as_ref()
+        .context("Response missing cluster field")?
+        .resources_vpc_config
+        .as_ref()
+        .context("Cluster missing resources_vpc_config field")?
+        .subnet_ids
+        .as_ref()
+        .context("resources_vpc_config missing subnet ids")
+        .map(|ids| ids.clone())
+}
+
+async fn endpoint(eks_client: &aws_sdk_eks::Client, cluster_name: &str) -> ProviderResult<String> {
+    let describe_results = eks_client
+        .describe_cluster()
+        .name(cluster_name)
+        .send()
+        .await
+        .context("Unable to get eks describe cluster")?;
+    // Extract the apiserver endpoint from the cluster.
+    describe_results
+        .cluster
+        .as_ref()
+        .context("Results missing cluster field")?
+        .endpoint
+        .as_ref()
+        .context("Cluster missing endpoint field")
+        .map(|ids| ids.clone())
+}
+
+async fn certificate(
+    eks_client: &aws_sdk_eks::Client,
+    cluster_name: &str,
+) -> ProviderResult<String> {
+    let describe_results = eks_client
+        .describe_cluster()
+        .name(cluster_name)
+        .send()
+        .await
+        .context("Unable to get eks describe cluster")?;
+
+    // Extract the certificate authority from the cluster.
+    describe_results
+        .cluster
+        .as_ref()
+        .context("Results missing cluster field")?
+        .certificate_authority
+        .as_ref()
+        .context("Cluster missing certificate_authority field")?
+        .data
+        .as_ref()
+        .context("Certificate authority missing data")
+        .map(|ids| ids.clone())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+enum SubnetType {
+    Public,
+    Private,
+}
+
+impl SubnetType {
+    fn tag(&self, cluster_name: &str) -> String {
+        let subnet_type = match self {
+            SubnetType::Public => "Public",
+            SubnetType::Private => "Private",
+        };
+        format!("eksctl-{}-cluster/Subnet{}*", cluster_name, subnet_type)
+    }
+}
+
+async fn subnet_ids(
+    ec2_client: &aws_sdk_ec2::Client,
+    cluster_name: &str,
+    eks_subnet_ids: Vec<String>,
+    subnet_type: SubnetType,
+) -> ProviderResult<Vec<Subnet>> {
+    let describe_results = ec2_client
+        .describe_subnets()
+        .set_subnet_ids(Some(eks_subnet_ids))
+        .filters(
+            Filter::builder()
+                .name("tag:Name")
+                .values(subnet_type.tag(cluster_name))
+                .build(),
+        )
+        .send()
+        .await
+        .context("Unable to get private subnet ids")?;
+    describe_results
+        .subnets
+        .context("Results missing subnets field")
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+enum SecurityGroupType {
+    NodeGroup,
+    ClusterShared,
+    ControlPlane,
+}
+
+impl SecurityGroupType {
+    fn tag(&self, cluster_name: &str) -> String {
+        let sg = match self {
+            SecurityGroupType::NodeGroup => "nodegroup",
+            SecurityGroupType::ClusterShared => "ClusterSharedNodeSecurityGroup",
+            SecurityGroupType::ControlPlane => "ControlPlaneSecurityGroup",
+        };
+        format!("*{}-{}*", cluster_name, sg)
+    }
+}
+
+async fn security_group(
+    ec2_client: &aws_sdk_ec2::Client,
+    cluster_name: &str,
+    security_group_type: SecurityGroupType,
+) -> ProviderResult<Vec<SecurityGroup>> {
+    // Extract the security groups.
+    let describe_results = ec2_client
+        .describe_security_groups()
+        .filters(
+            Filter::builder()
+                .name("tag:Name")
+                .values(security_group_type.tag(cluster_name))
+                .build(),
+        )
+        .send()
+        .await
+        .context(format!(
+            "Unable to get {:?} security group",
+            security_group_type
+        ))?;
+
+    describe_results
+        .security_groups
+        .context("Results missing security_groups field")
+}
+
+async fn instance_profile(
+    iam_client: &aws_sdk_iam::Client,
+    cluster_name: &str,
+    node_instance_role: &str,
+) -> ProviderResult<String> {
+    let list_result = iam_client
+        .list_instance_profiles()
+        .send()
+        .await
+        .context("Unable to list instance profiles")?;
+    let eksctl_prefix = format!("eksctl-{}", cluster_name);
+    list_result
+        .instance_profiles
+        .as_ref()
+        .context("No instance profiles found")?
+        .iter()
+        .filter(|x| {
+            x.instance_profile_name
+                .as_ref()
+                .unwrap_or(&"".to_string())
+                .contains("NodeInstanceProfile")
+        })
+        .filter(|x| {
+            x.instance_profile_name
+                .as_ref()
+                .unwrap_or(&"".to_string())
+                .contains(&eksctl_prefix)
+        })
+        .find(|instance_profile| {
+            instance_profile
+                .roles
+                .as_ref()
+                .map(|roles| {
+                    roles
+                        .iter()
+                        .any(|role| role.arn == Some(node_instance_role.to_string()))
+                })
+                .unwrap_or_default()
+        })
+        .context("Node instance profile not found")?
+        .arn
+        .as_ref()
+        .context("Node instance profile missing arn field")
+        .map(|profile| profile.clone())
+}
+
+fn cluster_iam_identity_mapping(cluster_name: &str, region: &str) -> ProviderResult<String> {
+    let iam_identity_output = Command::new("eksctl")
+        .args([
+            "get",
+            "iamidentitymapping",
+            "--cluster",
+            cluster_name,
+            "--region",
+            region,
+            "--output",
+            "json",
+        ])
+        .output()
+        .context("Unable to get iam identity mapping.")?;
+
+    let iam_identity: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&iam_identity_output.stdout))
+            .context("Unable to deserialize iam identity mapping")?;
+
+    iam_identity
+        .get(0)
+        .context("No profiles found.")?
+        .get("rolearn")
+        .context("Profile does not contain rolearn.")?
+        .as_str()
+        .context("Rolearn is not a string.")
+        .map(|arn| arn.to_string())
+}

--- a/integ/src/error.rs
+++ b/integ/src/error.rs
@@ -1,0 +1,106 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug)]
+pub struct ProviderError {
+    /// Any message to be included with the error. This will be included in the formatted display
+    /// before `inner`.
+    context: Option<String>,
+    /// The error that caused this error.
+    inner: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+}
+
+/// The result type returned by instance create and termiante operations.
+pub type ProviderResult<T> = std::result::Result<T, ProviderError>;
+
+impl ProviderError {
+    pub fn new_with_source_and_context<S, E>(context: S, source: E) -> Self
+    where
+        S: Into<String>,
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self {
+            context: Some(context.into()),
+            inner: Some(source.into()),
+        }
+    }
+
+    pub fn new_with_source<E>(source: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self {
+            context: None,
+            inner: Some(source.into()),
+        }
+    }
+
+    pub fn new_with_context<S>(context: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self {
+            context: Some(context.into()),
+            inner: None,
+        }
+    }
+
+    pub fn context(&self) -> Option<&str> {
+        self.context.as_deref()
+    }
+
+    pub fn inner(&self) -> Option<&(dyn std::error::Error + Send + Sync + 'static)> {
+        self.inner.as_ref().map(|some| some.as_ref())
+    }
+}
+
+impl Display for ProviderError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if let Some(context) = self.context() {
+            write!(f, ", {}", context)?;
+        }
+        if let Some(inner) = self.inner() {
+            write!(f, ": {}", inner)?;
+        }
+        Ok(())
+    }
+}
+
+// Make `ProviderError` function as a standard error.
+impl std::error::Error for ProviderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner()
+            .map(|e| e as &(dyn std::error::Error + 'static))
+    }
+}
+
+/// A trait that makes it possible to convert error types to `ProviderError` using a familiar
+/// `context` function.
+pub trait IntoProviderError<T> {
+    /// Convert `self` into a `ProviderError`.
+    fn context<S>(self, message: S) -> ProviderResult<T>
+    where
+        S: Into<String>;
+}
+
+// Implement `IntoProviderError` for all standard `Error + Send + Sync + 'static` types.
+impl<T, E> IntoProviderError<T> for std::result::Result<T, E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn context<S>(self, message: S) -> ProviderResult<T>
+    where
+        S: Into<String>,
+    {
+        self.map_err(|e| ProviderError::new_with_source_and_context(message, e))
+    }
+}
+
+// Implement `IntoProviderError` for options where `None` is converted into an error.
+impl<T> IntoProviderError<T> for std::option::Option<T> {
+    fn context<S>(self, m: S) -> Result<T, ProviderError>
+    where
+        S: Into<String>,
+    {
+        self.ok_or_else(|| ProviderError::new_with_context(m))
+    }
+}

--- a/integ/src/lib.rs
+++ b/integ/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod ec2_provider;
+pub mod eks_provider;
+pub mod error;
+pub mod updater;

--- a/integ/src/main.rs
+++ b/integ/src/main.rs
@@ -1,0 +1,191 @@
+use log::info;
+use snafu::{OptionExt, ResultExt};
+use std::env::temp_dir;
+use std::fs;
+use std::process;
+use structopt::StructOpt;
+use tokio::time::{sleep, Duration};
+
+use integ::ec2_provider::{create_ec2_instance, terminate_ec2_instance};
+use integ::eks_provider::{get_cluster_info, write_kubeconfig};
+use integ::error::ProviderError;
+use integ::updater::{delete_cluster_resources, label_node, run_brupop};
+
+type Result<T> = std::result::Result<T, error::Error>;
+
+/// The default path for kubeconfig file
+const DEFAULT_KUBECONFIG_FILE_NAME: &str = "kubeconfig.yaml";
+
+/// The default region for the cluster.
+const DEFAULT_REGION: &str = "us-west-2";
+const CLUSTER_NAME: &str = "brupop-integration-test";
+
+/// This value configure how long it sleeps between create instance and label instance.
+const INTEGRATION_TEST_DELAY: Duration = Duration::from_secs(60);
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    if let Err(e) = run().await {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub(crate) struct Arguments {
+    #[structopt(global = true, long = "--cluster-name", default_value = CLUSTER_NAME)]
+    cluster_name: String,
+
+    #[structopt(global = true, long = "--region", default_value = DEFAULT_REGION)]
+    region: String,
+
+    #[structopt(
+        long = "--kube-config-path",
+        default_value = DEFAULT_KUBECONFIG_FILE_NAME
+    )]
+    kube_config_path: String,
+
+    #[structopt(subcommand)]
+    subcommand: SubCommand,
+}
+
+#[derive(StructOpt, Debug)]
+enum SubCommand {
+    IntegrationTest(IntegrationTestArgs),
+    Clean,
+}
+
+// Stores user-supplied arguments for the 'integration-test' subcommand.
+#[derive(StructOpt, Debug)]
+struct IntegrationTestArgs {
+    #[structopt(long = "--instance-ami-id")]
+    instance_ami_id: String,
+}
+
+async fn generate_kube_config_path(args_kube_config_path: &str) -> Result<String> {
+    // default kube config path is /temp/kubeconfig.yaml
+    let kube_config_path = match args_kube_config_path {
+        DEFAULT_KUBECONFIG_FILE_NAME => format!(
+            "{}/{}",
+            temp_dir().to_str().context(error::FindTmpDir)?,
+            DEFAULT_KUBECONFIG_FILE_NAME
+        ),
+        res => res.to_string(),
+    };
+
+    Ok(kube_config_path)
+}
+
+async fn run() -> Result<()> {
+    // Parse and store the args passed to the program
+    let args = Arguments::from_args();
+
+    // generate kube config path if no input value for argument `kube_config_path`
+    let kube_config_path = generate_kube_config_path(&args.kube_config_path).await?;
+
+    let cluster_info = get_cluster_info(&args.cluster_name, &args.region)
+        .await
+        .context(error::GetClusterInfo)?;
+
+    match &args.subcommand {
+        SubCommand::IntegrationTest(integ_test_args) => {
+            // create instances and add nodes to eks cluster
+            info!("Creating EC2 instances ...");
+            let created_instances =
+                create_ec2_instance(cluster_info, &integ_test_args.instance_ami_id)
+                    .await
+                    .context(error::CreateEc2Instances)?;
+            info!("EC2 instances have been created");
+
+            // decode and write kubeconfig
+            info!("decoding and writing kubeconfig ...");
+
+            write_kubeconfig(&args.cluster_name, &DEFAULT_REGION, &kube_config_path)
+                .context(error::WriteKubeconfig)?;
+            info!(
+                "kubeconfig has been written and store at {:?}",
+                kube_config_path
+            );
+
+            info!("Sleeping 60 secs to wait Nodes be ready ...");
+            sleep(INTEGRATION_TEST_DELAY).await;
+
+            // label created nodes. To start Bottlerocket updater operator agent on your nodes,
+            // you need to add the bottlerocket.aws/updater-interface-version label
+            info!(
+                "labeling ec2 instances (nodes) ...
+            "
+            );
+            label_node(created_instances.private_dns_name, &kube_config_path)
+                .await
+                .context(error::LabelNode)?;
+            info!("EC2 instances (nodes) have been labelled");
+
+            // install brupop on EKS cluster
+            info!("Running brupop on existing EKS cluster ...");
+            run_brupop(&kube_config_path)
+                .await
+                .context(error::RunBrupop)?;
+        }
+        SubCommand::Clean => {
+            // terminate all instances which created by integration test.
+            info!("Terminating EC2 instance ...");
+            terminate_ec2_instance(cluster_info)
+                .await
+                .context(error::TerminateEc2Instance)?;
+
+            // clean up all resources like namespace, deployment on brupop test
+            info!("Deleting all cluster resources which created by integration test ...");
+            delete_cluster_resources(&kube_config_path)
+                .await
+                .context(error::DeleteClusterResources)?;
+
+            // delete tmp directory and kubeconfig.yaml
+            info!("Deleting tmp directory and kubeconfig.yaml ...");
+            fs::remove_file(kube_config_path).context(error::DeleteTmpDir)?;
+        }
+    }
+    Ok({})
+}
+
+mod error {
+    use crate::ProviderError;
+    use integ::updater::update_error;
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    pub(super) enum Error {
+        #[snafu(display("Failed to get eks cluster info: {}", source))]
+        GetClusterInfo { source: ProviderError },
+
+        #[snafu(display("Failed to create ec2 instances: {}", source))]
+        CreateEc2Instances { source: ProviderError },
+
+        #[snafu(display("Failed to label ec2 instances: {}", source))]
+        LabelNode { source: update_error::Error },
+
+        #[snafu(display("Failed to install brupop on eks cluster: {}", source))]
+        RunBrupop { source: update_error::Error },
+
+        #[snafu(display("Failed to terminate ec2 instances: {}", source))]
+        TerminateEc2Instance { source: ProviderError },
+
+        #[snafu(display("Failed to delete created eks cluster resources: {}", source))]
+        DeleteClusterResources { source: update_error::Error },
+
+        #[snafu(display("Failed to delete tmp directory and kubeconfig.yaml: {}", source))]
+        DeleteTmpDir { source: std::io::Error },
+
+        #[snafu(display("Unable to find temp directory"))]
+        FindTmpDir {},
+
+        #[snafu(display("Failed to write content to kubeconfig: {}", source))]
+        WriteKubeconfig { source: ProviderError },
+
+        #[snafu(display("Logger setup error: {}", source))]
+        Logger { source: log::SetLoggerError },
+    }
+}

--- a/integ/src/updater.rs
+++ b/integ/src/updater.rs
@@ -1,0 +1,200 @@
+/*!
+  updater helps running brupop on existing EKS cluster and clean up all
+  resources once completing integration test
+!*/
+
+use lazy_static::lazy_static;
+use snafu::{ensure, ResultExt};
+use std::process::Command;
+
+use tokio::time::Duration;
+use tokio_retry::{
+    strategy::{jitter, ExponentialBackoff},
+    Retry,
+};
+
+const BRUPOP_NODE_LABEL: &str = "bottlerocket.aws/updater-interface-version=2.0.0";
+const BRUPOP_NAMESPACE: &str = "brupop-bottlerocket-aws";
+
+lazy_static! {
+    static ref BRUPOP_CLUSTER_ROLES: Vec<&'static str> = {
+        let mut m = Vec::new();
+        m.push("brupop-apiserver-role");
+        m.push("brupop-agent-role");
+        m.push("brupop-controller-role");
+        m
+    };
+}
+
+lazy_static! {
+    static ref BRUPOP_CLUSTER_ROLE_BINDINGS: Vec<&'static str> = {
+        let mut m = Vec::new();
+        m.push("brupop-apiserver-role-binding");
+        m.push("brupop-agent-role-binding");
+        m.push("brupop-controller-role-binding");
+        m
+    };
+}
+
+// The reflector uses exponential backoff.
+// These values configure how long to delay between tries.
+const RETRY_BASE_DELAY: Duration = Duration::from_secs(20);
+const RETRY_MAX_DELAY: Duration = Duration::from_secs(60);
+const NUM_RETRIES: usize = 5;
+
+// label node with `bottlerocket.aws/updater-interface-version=2.0.0`, so brupop can find right nodes
+// to run updater
+pub async fn label_node(node_names: Vec<String>, kube_config_path: &str) -> UpdaterResult<()> {
+    // When integration test creates and add nodes to EKS cluster, nodes usually need few mins to be ready.
+    // Label process will be failed if nodes aren't ready. Therefore, add retry strategy here to avoid this situation,
+    // and give nodes more time to be ready.
+    Retry::spawn(retry_strategy(), || async {
+        for node in &node_names {
+            let status = Command::new("kubectl")
+                .args([
+                    "label",
+                    "node",
+                    node,
+                    BRUPOP_NODE_LABEL,
+                    "--kubeconfig",
+                    kube_config_path,
+                    "--overwrite=true",
+                ])
+                .status()
+                .context(update_error::LabelNode)?;
+            if status.success() {
+                continue;
+            } else {
+                return Err(update_error::Error::BrupopRun);
+            }
+        }
+        Ok(())
+    })
+    .await
+}
+
+// installing brupop on EKS cluster
+pub async fn run_brupop(kube_config_path: &str) -> UpdaterResult<()> {
+    let brn_status = Command::new("kubectl")
+        .args([
+            "apply",
+            "-f",
+            "yamlgen/deploy/bottlerocket-node-crd.yaml",
+            "--kubeconfig",
+            kube_config_path,
+        ])
+        .status()
+        .context(update_error::BrupopProcess)?;
+
+    ensure!(brn_status.success(), update_error::BrupopRun);
+
+    let brupop_resource_status = Command::new("kubectl")
+        .args([
+            "apply",
+            "-f",
+            "yamlgen/deploy/brupop-resources.yaml",
+            "--kubeconfig",
+            kube_config_path,
+        ])
+        .status()
+        .context(update_error::BrupopProcess)?;
+
+    ensure!(brupop_resource_status.success(), update_error::BrupopRun);
+
+    Ok(())
+}
+
+fn retry_strategy() -> impl Iterator<Item = Duration> {
+    ExponentialBackoff::from_millis(RETRY_BASE_DELAY.as_millis() as u64)
+        .max_delay(RETRY_MAX_DELAY)
+        .map(jitter)
+        .take(NUM_RETRIES)
+}
+
+// destroy all resources which were created when integration test installed brupop
+pub async fn delete_cluster_resources(kube_config_path: &str) -> UpdaterResult<()> {
+    // delete namespaces brupop-bottlerocket-aws. This can clean all resources under this namespace like daemonsets.apps
+    let namespace_deletion_status = Command::new("kubectl")
+        .args([
+            "delete",
+            "namespaces",
+            BRUPOP_NAMESPACE,
+            "--kubeconfig",
+            kube_config_path,
+        ])
+        .status()
+        .context(update_error::BrupopCleanUp {
+            cluster_resource: "namespaces",
+        })?;
+    ensure!(namespace_deletion_status.success(), update_error::BrupopRun);
+
+    // delete clusterrolebinding.rbac.authorization.k8s.io
+    for cluster_role_binding in BRUPOP_CLUSTER_ROLE_BINDINGS.iter() {
+        let clusterrolebinding_deletion_status = Command::new("kubectl")
+            .args([
+                "delete",
+                "clusterrolebinding.rbac.authorization.k8s.io",
+                cluster_role_binding,
+                "--kubeconfig",
+                kube_config_path,
+            ])
+            .status()
+            .context(update_error::BrupopCleanUp {
+                cluster_resource: "clusterrolebinding.rbac.authorization.k8s.io",
+            })?;
+        ensure!(
+            clusterrolebinding_deletion_status.success(),
+            update_error::BrupopRun
+        );
+    }
+
+    // delete clusterrole.rbac.authorization.k8s.io
+    for cluster_role in BRUPOP_CLUSTER_ROLES.iter() {
+        let clusterrole_deletion_status = Command::new("kubectl")
+            .args([
+                "delete",
+                "clusterrole.rbac.authorization.k8s.io",
+                cluster_role,
+                "--kubeconfig",
+                kube_config_path,
+            ])
+            .status()
+            .context(update_error::BrupopCleanUp {
+                cluster_resource: "clusterrole.rbac.authorization.k8s.io",
+            })?;
+        ensure!(
+            clusterrole_deletion_status.success(),
+            update_error::BrupopRun
+        );
+    }
+
+    Ok(())
+}
+
+/// The result type returned by instance create and termiante operations.
+type UpdaterResult<T> = std::result::Result<T, update_error::Error>;
+
+pub mod update_error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub")]
+    pub enum Error {
+        #[snafu(display("Failed to label node: {}", source))]
+        LabelNode { source: std::io::Error },
+
+        #[snafu(display("Failed to install brupop: {}", source))]
+        BrupopProcess { source: std::io::Error },
+
+        #[snafu(display("Failed to run brupop test"))]
+        BrupopRun,
+
+        #[snafu(display("Failed to deleted resource {}: {}", cluster_resource, source))]
+        BrupopCleanUp {
+            cluster_resource: String,
+            source: std::io::Error,
+        },
+        #[snafu(display("Unable to convert kubeconfig path to string path"))]
+        ConvertPathToStr {},
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#91


**Description of changes:**
Add integration testing automation that uses an existing cluster 

RUNBOOK:
```
 cargo run --bin integ XXXX

        r"Usage: [SUBCOMMAND] [OPTION]...

        Global options:
            --cluster-name            Exiting eks cluster name Default: brupop-integration-test
            --region                  The region that exiting eks cluster is running on. Default: us-west-2
        
        Subcommands:
            integrationtest           Starts a Brupop to manage created Bottlerocket instances in a given cluster
            clean                     Cleans up resources started for integration testing
            
        integ-test options:
            --instance-ami-id AMI-ID
            --kube-config PATH
            
         "
```

**Testing done:**
Running on existing cluster: 
`RUST_LOG=info cargo run --bin integ integrationtest --instance-ami-id ami-026c14d3e67a22dc6 --cluster-name bottlerocket-test --region us-west-2`

```
2021-12-07T05:20:31Z INFO  integ] EC2 instances have been created
[2021-12-07T05:20:31Z INFO  integ] decoding and writing kubeconfig ...
2021-12-07 05:20:31 [ℹ]  eksctl version 0.51.0
2021-12-07 05:20:31 [ℹ]  using region us-west-2
2021-12-07 05:20:31 [✔]  saved kubeconfig as "/tmp/kubeconfig.yaml"
[2021-12-07T05:20:31Z INFO  integ] kubeconfig has been written and store at /tmp/kubeconfig.yaml
[2021-12-07T05:20:31Z INFO  integ] Sleeping 60 secs to wait Nodes be ready ...
[2021-12-07T05:21:31Z INFO  integ] labeling ec2 instances (nodes) ...

node/ip-192-168-140-82.us-west-2.compute.internal labeled
node/ip-192-168-143-82.us-west-2.compute.internal labeled
[2021-12-07T05:21:33Z INFO  integ] EC2 instances (nodes) have been labelled
[2021-12-07T05:21:33Z INFO  integ] Running brupop on existing EKS cluster ...
namespace/brupop-bottlerocket-aws created
serviceaccount/brupop-apiserver-service-account created
clusterrole.rbac.authorization.k8s.io/brupop-apiserver-role created
clusterrolebinding.rbac.authorization.k8s.io/brupop-apiserver-role-binding created
deployment.apps/brupop-apiserver created
service/brupop-apiserver created
serviceaccount/brupop-agent-service-account created
clusterrole.rbac.authorization.k8s.io/brupop-agent-role created
clusterrolebinding.rbac.authorization.k8s.io/brupop-agent-role-binding created
daemonset.apps/brupop-agent created
serviceaccount/brupop-controller-service-account created
clusterrole.rbac.authorization.k8s.io/brupop-controller-role created
clusterrolebinding.rbac.authorization.k8s.io/brupop-controller-role-binding created
deployment.apps/brupop-controller-deployment created

[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get pods --kubeconfig /tmp/kubeconfig.yaml
NAME                                           READY   STATUS             RESTARTS   AGE
brupop-agent-p6dpl                             1/1     Running            0          104s
brupop-agent-zsqss                             1/1     Running            0          116s
brupop-apiserver-677496b7c4-bz2vj              1/1     Running            0          2m2s
brupop-apiserver-677496b7c4-ffrmf              1/1     Running            0          2m2s
brupop-apiserver-677496b7c4-hpnqx              1/1     Running            0          2m2s
brupop-controller-deployment-dbb96dcdd-g554r   1/1     Running            0          2m2s
```
```
[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get brn
NAME                                                STATE   VERSION   TARGET STATE   TARGET VERSION
brn-ip-192-168-135-130.us-west-2.compute.internal   Idle    1.1.1     Idle           <no value>
brn-ip-192-168-137-161.us-west-2.compute.internal   Idle    1.1.1     StagedUpdate   1.4.2
brn-ip-192-168-159-49.us-west-2.compute.internal    Idle    1.1.1     Idle           <no value>
```

`RUST_LOG=info cargo run --bin integ clean --cluster-name bottlerocket-test --region us-west-2`

```
[2021-12-07T05:25:18Z INFO  integ] Terminating EC2 instance ...
2021-12-07T05:26:19Z INFO  integ] Deleting all cluster resources which created by integration test ...
namespace "brupop-bottlerocket-aws" deleted
clusterrolebinding.rbac.authorization.k8s.io "brupop-apiserver-role-binding" deleted
clusterrolebinding.rbac.authorization.k8s.io "brupop-agent-role-binding" deleted
clusterrolebinding.rbac.authorization.k8s.io "brupop-controller-role-binding" deleted
clusterrole.rbac.authorization.k8s.io "brupop-apiserver-role" deleted
clusterrole.rbac.authorization.k8s.io "brupop-agent-role" deleted
clusterrole.rbac.authorization.k8s.io "brupop-controller-role" deleted
[2021-12-07T05:27:11Z INFO  integ] Deleting tmp directory and kubeconfig.yaml ...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
