### PR TITLE
use chosen_update suggested by bottlerocket API

### DIFF
--- a/agent/src/apiclient.rs
+++ b/agent/src/apiclient.rs
@@ -76,9 +76,9 @@ pub struct CommandResult {
 
 #[derive(Debug, Deserialize)]
 pub struct UpdateImage {
-    arch: String,
-    version: String,
-    variant: String,
+    pub(super) arch: String,
+    pub(super) version: Version,
+    pub(super) variant: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -225,8 +225,8 @@ pub async fn reboot() -> Result<Output> {
     Ok(invoke_apiclient(get_raw_args(raw_args)).await?)
 }
 
-// List all available versions which current Bottlerocket OS can update to.
-pub async fn list_available() -> Result<Vec<Version>> {
+// get chosen update which contains latest Bottlerocket OS can update to.
+pub async fn get_chosen_update() -> Result<Option<UpdateImage>> {
     // Refresh list of updates and check if there are any available
     refresh_updates().await?;
 
@@ -239,7 +239,7 @@ pub async fn list_available() -> Result<Vec<Version>> {
         apiclient_error::RefreshUpdate
     );
 
-    Ok(update_status.available_updates)
+    Ok(update_status.chosen_update)
 }
 
 pub async fn prepare() -> Result<()> {

--- a/agent/src/error.rs
+++ b/agent/src/error.rs
@@ -49,8 +49,8 @@ pub enum Error {
     #[snafu(display("Unable to gather system version metadata: '{}'", source))]
     BottlerocketNodeStatusVersion { source: apiclient_error::Error },
 
-    #[snafu(display("Unable to gather system available versions metadata: '{}'", source))]
-    BottlerocketNodeStatusAvailableVersions { source: apiclient_error::Error },
+    #[snafu(display("Unable to gather system chosen update metadata: '{}'", source))]
+    BottlerocketNodeStatusChosenUpdate { source: apiclient_error::Error },
 
     #[snafu(display(
         "Unable to update the custom resource associated with this node: '{}'",

--- a/apiserver/src/api.rs
+++ b/apiserver/src/api.rs
@@ -284,7 +284,7 @@ mod tests {
         };
         let node_status = BottlerocketNodeStatus::new(
             Version::new(1, 2, 1),
-            vec![Version::new(1, 3, 0)],
+            Version::new(1, 3, 0),
             BottlerocketNodeState::default(),
         );
 

--- a/controller/src/statemachine.rs
+++ b/controller/src/statemachine.rs
@@ -14,19 +14,13 @@ pub fn determine_next_node_spec(brn: &BottlerocketNode) -> BottlerocketNodeSpec 
         Some(node_status) => {
             match brn.spec.state {
                 BottlerocketNodeState::Idle => {
-                    // TODO replace this with logic which just accepts the suggested version from the target host.
-                    // If there's a newer version available, then begin updating to that version.
-                    let mut available_versions = node_status.available_versions();
-                    available_versions.sort();
-                    available_versions
-                        .last()
-                        .filter(|latest_available| {
-                            &&node_status.current_version() < latest_available
-                        })
-                        .map(|latest_available| {
+                    let target_version = node_status.target_version();
+                    Some(target_version)
+                        .filter(|target_version| &node_status.current_version() != target_version)
+                        .map(|target_version| {
                             BottlerocketNodeSpec::new_starting_now(
                                 BottlerocketNodeState::StagedUpdate,
-                                Some(latest_available.clone()),
+                                Some(target_version.clone()),
                             )
                         })
                         .unwrap_or_else(BottlerocketNodeSpec::default)

--- a/models/src/node/mod.rs
+++ b/models/src/node/mod.rs
@@ -196,20 +196,20 @@ impl BottlerocketNodeSpec {
 pub struct BottlerocketNodeStatus {
     #[validate(regex = "SEMVER_RE")]
     current_version: String,
-    // TODO We haven't configured validations against `available_versions`, but we are planning to remove this field.
-    available_versions: Vec<String>,
+    #[validate(regex = "SEMVER_RE")]
+    target_version: String,
     pub current_state: BottlerocketNodeState,
 }
 
 impl BottlerocketNodeStatus {
     pub fn new(
         current_version: Version,
-        available_versions: Vec<Version>,
+        target_version: Version,
         current_state: BottlerocketNodeState,
     ) -> Self {
         BottlerocketNodeStatus {
             current_version: current_version.to_string(),
-            available_versions: available_versions.iter().map(|v| v.to_string()).collect(),
+            target_version: target_version.to_string(),
             current_state,
         }
     }
@@ -219,13 +219,10 @@ impl BottlerocketNodeStatus {
         Version::from_str(&self.current_version).unwrap()
     }
 
-    pub fn available_versions(&self) -> Vec<Version> {
+    pub fn target_version(&self) -> Version {
         // TODO This could panic if a custom `brn` is created with improperly specified versions; however, we are removing this
         // attribute in an impending iteration, so we won't fix it.
-        self.available_versions
-            .iter()
-            .map(|v| Version::from_str(v).unwrap())
-            .collect()
+        Version::from_str(&self.target_version).unwrap()
     }
 }
 

--- a/yamlgen/deploy/bottlerocket-node-crd.yaml
+++ b/yamlgen/deploy/bottlerocket-node-crd.yaml
@@ -61,10 +61,6 @@ spec:
               description: "`BottlerocketNodeStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent, while the spec is updated by the brupop controller."
               nullable: true
               properties:
-                available_versions:
-                  items:
-                    type: string
-                  type: array
                 current_state:
                   description: "BottlerocketNodeState represents a node's state in the update state machine."
                   enum:
@@ -77,10 +73,13 @@ spec:
                 current_version:
                   pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
                   type: string
+                target_version:
+                  pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+                  type: string
               required:
-                - available_versions
                 - current_state
                 - current_version
+                - target_version
               type: object
           required:
             - spec


### PR DESCRIPTION
We should implement this by doing away with available_versions on
 the BottlerocketNode custom resource status, and replacing it
instead with an atrribute indicating a single version

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#108


**Description of changes:**
use chosen_update suggested by bottlerocket API instead of using available_versions on the BottlerocketNode custom resource status


**Testing done:**
```
[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get brn
NAME                                               STATE                VERSION   TARGET STATE       TARGET VERSION
brn-ip-192-168-88-132.us-west-2.compute.internal   Idle                 1.1.1     Idle               <no value>
brn-ip-192-168-90-159.us-west-2.compute.internal   RebootedIntoUpdate   1.4.2     MonitoringUpdate   1.4.2
brn-ip-192-168-93-153.us-west-2.compute.internal   Idle                 1.1.1     Idle               <no value>
```

brn status
```
tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws describe brn brn-ip-192-168-90-159.us-west-2.compute.internal
Name:         brn-ip-192-168-90-159.us-west-2.compute.internal
Namespace:    brupop-bottlerocket-aws
Labels:       <none>
Annotations:  <none>
API Version:  brupop.bottlerocket.aws/v1
Kind:         BottlerocketNode
Metadata:
  Creation Timestamp:  2021-12-09T21:46:04Z
  Generation:          6
  Managed Fields:
    API Version:  brupop.bottlerocket.aws/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"cce33698-7872-4490-b55d-6d89f1698b04"}:
            .:
            f:apiVersion:
            f:kind:
            f:name:
            f:uid:
      f:spec:
        .:
        f:state:
        f:state_transition_timestamp:
        f:version:
      f:status:
        .:
        f:current_state:
        f:current_version:
        f:target_version:
    Manager:    unknown
    Operation:  Update
    Time:       2021-12-09T21:46:24Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            ip-192-168-90-159.us-west-2.compute.internal
    UID:             cce33698-7872-4490-b55d-6d89f1698b04
  Resource Version:  63176371
  UID:               242409e4-c468-42bb-8dec-9f8174eeb1a6
Spec:
  State:                       Idle
  state_transition_timestamp:  2021-12-09T21:50:50.718336680+00:00
  Version:                     1.4.2
Status:
  current_state:    MonitoringUpdate
  current_version:  1.4.2
  target_version:   1.4.2
Events:             <none>

```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
