### PR TITLE
Controller metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,11 +429,15 @@ dependencies = [
 name = "controller"
 version = "0.1.0"
 dependencies = [
+ "actix-web",
  "futures",
+ "http",
  "k8s-openapi",
  "kube",
  "models",
  "opentelemetry",
+ "opentelemetry-prometheus",
+ "prometheus",
  "snafu",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
  "prometheus",
+ "serde_plain",
  "snafu",
  "tokio",
  "tracing",
@@ -1998,6 +1999,15 @@ dependencies = [
  "indexmap",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95455e7e29fada2052e72170af226fbe368a4ca33dee847875325d9fdb133858"
+dependencies = [
  "serde",
 ]
 

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -15,8 +15,13 @@ kube = { version = "0.63.2", default-features = true, features = [ "derive", "ru
 
 snafu = "0.6"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
-tracing-bunyan-formatter = "0.3"
+
+actix-web = { version = "4.0.0-beta.9", default-features = false }
+http = "0.2.5"
 opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"] }
+opentelemetry-prometheus = "0.9"
+prometheus = "0.12.0"
+tracing = "0.1"
+tracing-bunyan-formatter = "0.3"
 tracing-opentelemetry = "0.16"
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -21,6 +21,7 @@ http = "0.2.5"
 opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"] }
 opentelemetry-prometheus = "0.9"
 prometheus = "0.12.0"
+serde_plain = "1.0.0"
 tracing = "0.1"
 tracing-bunyan-formatter = "0.3"
 tracing-opentelemetry = "0.16"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -6,22 +6,19 @@ publish = false
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-models = { path = "../models", version = "0.1.0" }
-
+actix-web = { version = "4.0.0-beta.9", default-features = false }
 futures = "0.3"
+http = "0.2.5"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_20"] }
 kube = { version = "0.63.2", default-features = true, features = [ "derive", "runtime" ] }
-
-snafu = "0.6"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-
-actix-web = { version = "4.0.0-beta.9", default-features = false }
-http = "0.2.5"
+models = { path = "../models", version = "0.1.0" }
 opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"] }
 opentelemetry-prometheus = "0.9"
 prometheus = "0.12.0"
 serde_plain = "1.0.0"
+snafu = "0.6"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1"
 tracing-bunyan-formatter = "0.3"
 tracing-opentelemetry = "0.16"

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -82,9 +82,13 @@ impl<T: BottlerocketNodeClient> BrupopController<T> {
                 .context(error::UpdateNodeSpec);
 
             // Update metrics to guide the next operation
-            let current_operation = desired_spec.operation();
             if let Some(metrics) = &self.metrics {
-                metrics.op(current_operation);
+                if ret.is_ok() {
+                    let current_operation = desired_spec.operation();
+                    metrics.op(current_operation);
+                } else {
+                    metrics.error();
+                }
             }
 
             ret

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -112,6 +112,7 @@ impl<T: BottlerocketNodeClient> BrupopController<T> {
         None
     }
 
+    #[instrument(skip(self))]
     fn init_metrics(&mut self) {
         let meter = global::meter("brupop-controller");
         self.metrics = Some(BrupopControllerMetrics::new(meter));
@@ -135,7 +136,7 @@ impl<T: BottlerocketNodeClient> BrupopController<T> {
 
         for brn in self.all_nodes() {
             if let Some(brn_status) = brn.status {
-                let current_version = brn_status.current_version;
+                let current_version = brn_status.current_version().to_string();
                 let current_state = brn_status.current_state;
 
                 *hosts_version_count_map.entry(current_version).or_default() += 1;

--- a/controller/src/error.rs
+++ b/controller/src/error.rs
@@ -34,4 +34,7 @@ pub enum Error {
 
     #[snafu(display("Error running prometheus HTTP server: '{}'", source))]
     PrometheusServerError { source: std::io::Error },
+
+    #[snafu(display("Controller failed due to internal assertion issue: '{}'", source))]
+    Assertion { source: serde_plain::Error },
 }

--- a/controller/src/error.rs
+++ b/controller/src/error.rs
@@ -31,4 +31,7 @@ pub enum Error {
 
     #[snafu(display("Could not determine selector for node: '{}'", source))]
     NodeSelectorCreation { source: BottlerocketNodeError },
+
+    #[snafu(display("Error running prometheus HTTP server: '{}'", source))]
+    PrometheusServerError { source: std::io::Error },
 }

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -1,5 +1,6 @@
 mod controller;
 pub mod error;
 pub mod statemachine;
+pub mod telemetry;
 
 pub use crate::controller::BrupopController;

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -1,4 +1,6 @@
 mod controller;
+mod metrics;
+
 pub mod error;
 pub mod statemachine;
 pub mod telemetry;

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
     .context(error::PrometheusServerError)?
     .run();
 
-    // TODO if either of these fails, we should write to the k8s termination log and exit.
+    // TODO if any of these fails, we should write to the k8s termination log and exit.
     tokio::select! {
         _ = drainer => {
             event!(Level::ERROR, "reflector drained");

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -1,14 +1,14 @@
 use controller::{
     error::{self, Result},
-    BrupopController,
     telemetry::vending_metrics,
+    BrupopController,
 };
 use models::{
     constants::{CONTROLLER, NAMESPACE},
     node::{BottlerocketNode, K8SBottlerocketNodeClient},
 };
 
-use actix_web::{App, HttpServer, web::Data};
+use actix_web::{web::Data, App, HttpServer};
 
 use futures::StreamExt;
 use kube::{
@@ -23,7 +23,6 @@ use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 
 const DEFAULT_TRACE_LEVEL: &str = "info";
-
 
 #[actix_web::main]
 async fn main() -> Result<()> {

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -4,7 +4,7 @@ use controller::{
     BrupopController,
 };
 use models::{
-    constants::{CONTROLLER, NAMESPACE},
+    constants::{CONTROLLER, CONTROLLER_INTERNAL_PORT, NAMESPACE},
     node::{BottlerocketNode, K8SBottlerocketNodeClient},
 };
 
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
             .app_data(Data::new(exporter.clone()))
             .service(vending_metrics)
     })
-    .bind(format!("0.0.0.0:{}", 8080))
+    .bind(format!("0.0.0.0:{}", CONTROLLER_INTERNAL_PORT))
     .context(error::PrometheusServerError)?
     .run();
 

--- a/controller/src/metrics.rs
+++ b/controller/src/metrics.rs
@@ -24,6 +24,10 @@ impl BrupopControllerMetrics {
         self.op("no_op".to_string());
     }
 
+    pub fn error(&self) {
+        self.op("error".to_string());
+    }
+
     pub fn op(&self, operation: String) {
         let labels = vec![OPERATION_KEY.string(operation)];
         self.brupop_controller_op.add(1, &labels);

--- a/controller/src/metrics.rs
+++ b/controller/src/metrics.rs
@@ -5,14 +5,17 @@ use opentelemetry::{
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
+use tracing::instrument;
 
 const HOST_VERSION_KEY: Key = Key::from_static_str("bottlerocket_version");
 const HOST_STATE_KEY: Key = Key::from_static_str("state");
 
+#[derive(Debug)]
 pub struct BrupopControllerMetrics {
     brupop_shared_hosts_data: Arc<Mutex<BrupopHostsData>>,
 }
 
+#[derive(Debug)]
 pub struct BrupopHostsData {
     hosts_version_count_map: HashMap<String, u64>,
     hosts_state_count_map: HashMap<String, u64>,
@@ -40,7 +43,9 @@ impl Default for BrupopHostsData {
         }
     }
 }
+
 impl BrupopControllerMetrics {
+    #[instrument]
     pub fn new(meter: Meter) -> Self {
         let brupop_shared_hosts_data = Arc::new(Mutex::new(BrupopHostsData::default()));
 

--- a/controller/src/metrics.rs
+++ b/controller/src/metrics.rs
@@ -1,0 +1,31 @@
+use opentelemetry::{
+    metrics::{Counter, Meter},
+    Key,
+};
+
+const OPERATION_KEY: Key = Key::from_static_str("operation");
+
+pub struct BrupopControllerMetrics {
+    brupop_controller_op: Counter<u64>,
+}
+
+impl BrupopControllerMetrics {
+    pub fn new(meter: Meter) -> Self {
+        let brupop_controller_op = meter
+            .u64_counter("brupop_controller_op")
+            .with_description("Brupop controller operations")
+            .init();
+        BrupopControllerMetrics {
+            brupop_controller_op,
+        }
+    }
+
+    pub fn no_op(&self) {
+        self.op("no_op".to_string());
+    }
+
+    pub fn op(&self, operation: String) {
+        let labels = vec![OPERATION_KEY.string(operation)];
+        self.brupop_controller_op.add(1, &labels);
+    }
+}

--- a/controller/src/metrics.rs
+++ b/controller/src/metrics.rs
@@ -1,35 +1,86 @@
 use opentelemetry::{
-    metrics::{Counter, Meter},
+    metrics::{Meter, ObserverResult},
     Key,
 };
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
 
-const OPERATION_KEY: Key = Key::from_static_str("operation");
+const HOST_VERSION_KEY: Key = Key::from_static_str("bottlerocket_version");
+const HOST_STATE_KEY: Key = Key::from_static_str("state");
 
 pub struct BrupopControllerMetrics {
-    brupop_controller_op: Counter<u64>,
+    brupop_shared_hosts_data: Arc<Mutex<BrupopHostsData>>,
 }
 
+pub struct BrupopHostsData {
+    hosts_version_count_map: HashMap<String, u64>,
+    hosts_state_count_map: HashMap<String, u64>,
+}
+
+impl BrupopHostsData {
+    pub fn new(
+        hosts_version_count_map: HashMap<String, u64>,
+        hosts_state_count_map: HashMap<String, u64>,
+    ) -> Self {
+        BrupopHostsData {
+            hosts_version_count_map,
+            hosts_state_count_map,
+        }
+    }
+}
+
+impl Default for BrupopHostsData {
+    fn default() -> Self {
+        let hosts_version_count_map = HashMap::new();
+        let hosts_state_count_map = HashMap::new();
+        BrupopHostsData {
+            hosts_version_count_map,
+            hosts_state_count_map,
+        }
+    }
+}
 impl BrupopControllerMetrics {
     pub fn new(meter: Meter) -> Self {
-        let brupop_controller_op = meter
-            .u64_counter("brupop_controller_op")
-            .with_description("Brupop controller operations")
+        let brupop_shared_hosts_data = Arc::new(Mutex::new(BrupopHostsData::default()));
+
+        let hosts_data_clone_for_version = Arc::clone(&brupop_shared_hosts_data);
+        let hosts_version_callback = move |res: ObserverResult<u64>| {
+            let data = hosts_data_clone_for_version.lock().unwrap();
+            for (host_version, count) in &data.hosts_version_count_map {
+                let labels = vec![HOST_VERSION_KEY.string(host_version.clone())];
+                res.observe(*count, &labels);
+            }
+        };
+        // Observer for cluster host's bottlerocket version
+        let _brupop_hosts_version = meter
+            .u64_value_observer("brupop_hosts_version", hosts_version_callback)
+            .with_description("Brupop host's bottlerocket version")
             .init();
+
+        let hosts_data_clone_for_state = Arc::clone(&brupop_shared_hosts_data);
+        let hosts_state_callback = move |res: ObserverResult<u64>| {
+            let data = hosts_data_clone_for_state.lock().unwrap();
+            for (host_state, count) in &data.hosts_state_count_map {
+                let labels = vec![HOST_STATE_KEY.string(host_state.clone())];
+                res.observe(*count, &labels);
+            }
+        };
+        // Observer for cluster host's brupop state
+        let _brupop_hosts_state = meter
+            .u64_value_observer("brupop_hosts_state", hosts_state_callback)
+            .with_description("Brupop host's state")
+            .init();
+
         BrupopControllerMetrics {
-            brupop_controller_op,
+            brupop_shared_hosts_data,
         }
     }
 
-    pub fn no_op(&self) {
-        self.op("no_op".to_string());
-    }
-
-    pub fn error(&self) {
-        self.op("error".to_string());
-    }
-
-    pub fn op(&self, operation: String) {
-        let labels = vec![OPERATION_KEY.string(operation)];
-        self.brupop_controller_op.add(1, &labels);
+    /// Update shared mut ref to trigger ValueRecorder observe data.
+    pub fn emit_metrics(&self, data: BrupopHostsData) {
+        if let Ok(mut host_data) = self.brupop_shared_hosts_data.try_lock() {
+            *host_data = data;
+        }
     }
 }

--- a/controller/src/telemetry.rs
+++ b/controller/src/telemetry.rs
@@ -3,7 +3,9 @@ use opentelemetry::{global, metrics::MetricsError};
 use prometheus::{Encoder, TextEncoder};
 
 #[get("/metrics")]
-pub async fn vending_metrics(exporter: Data<opentelemetry_prometheus::PrometheusExporter>) -> HttpResponse {
+pub async fn vending_metrics(
+    exporter: Data<opentelemetry_prometheus::PrometheusExporter>,
+) -> HttpResponse {
     let encoder = TextEncoder::new();
     let metric_families = exporter.registry().gather();
     let mut buf = Vec::new();

--- a/controller/src/telemetry.rs
+++ b/controller/src/telemetry.rs
@@ -1,0 +1,18 @@
+use actix_web::{get, web::Data, HttpResponse};
+use opentelemetry::{global, metrics::MetricsError};
+use prometheus::{Encoder, TextEncoder};
+
+#[get("/metrics")]
+pub async fn vending_metrics(exporter: Data<opentelemetry_prometheus::PrometheusExporter>) -> HttpResponse {
+    let encoder = TextEncoder::new();
+    let metric_families = exporter.registry().gather();
+    let mut buf = Vec::new();
+    if let Err(err) = encoder.encode(&metric_families[..], &mut buf) {
+        global::handle_error(MetricsError::Other(err.to_string()));
+    }
+
+    let body = String::from_utf8(buf).unwrap_or_default();
+    HttpResponse::Ok()
+        .insert_header((http::header::CONTENT_TYPE, prometheus::TEXT_FORMAT))
+        .body(body)
+}

--- a/models/src/constants.rs
+++ b/models/src/constants.rs
@@ -44,3 +44,6 @@ pub const AGENT_NAME: &str = "brupop-agent";
 // controller constants
 pub const CONTROLLER: &str = "brupop-controller";
 pub const CONTROLLER_DEPLOYMENT_NAME: &str = "brupop-controller-deployment";
+pub const CONTROLLER_SERVICE_NAME: &str = "brupop-controller-server"; // The name for the `svc` fronting the controller.
+pub const CONTROLLER_INTERNAL_PORT: i32 = 8080; // The internal port on which the the controller service is hosted.
+pub const CONTROLLER_SERVICE_PORT: i32 = 80; // The k8s service port hosting the controller service.

--- a/models/src/node/mod.rs
+++ b/models/src/node/mod.rs
@@ -188,17 +188,6 @@ impl BottlerocketNodeSpec {
         // We know this won't panic because we have a regex requirement on this attribute, which is enforced by the k8s schema.
         self.version.as_ref().map(|v| Version::from_str(v).unwrap())
     }
-
-    /// Returns the operation for current spec.
-    pub fn operation(&self) -> String {
-        match self.state {
-            BottlerocketNodeState::Idle => "Idle".to_string(),
-            BottlerocketNodeState::StagedUpdate => "StagedUpdate".to_string(),
-            BottlerocketNodeState::PerformedUpdate => "PerformedUpdate".to_string(),
-            BottlerocketNodeState::RebootedIntoUpdate => "RebootedIntoUpdate".to_string(),
-            BottlerocketNodeState::MonitoringUpdate => "MonitoringUpdate".to_string(),
-        }
-    }
 }
 
 /// `BottlerocketNodeStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent,
@@ -206,7 +195,7 @@ impl BottlerocketNodeSpec {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
 pub struct BottlerocketNodeStatus {
     #[validate(regex = "SEMVER_RE")]
-    current_version: String,
+    pub current_version: String,
     #[validate(regex = "SEMVER_RE")]
     target_version: String,
     pub current_state: BottlerocketNodeState,

--- a/models/src/node/mod.rs
+++ b/models/src/node/mod.rs
@@ -195,7 +195,7 @@ impl BottlerocketNodeSpec {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
 pub struct BottlerocketNodeStatus {
     #[validate(regex = "SEMVER_RE")]
-    pub current_version: String,
+    current_version: String,
     #[validate(regex = "SEMVER_RE")]
     target_version: String,
     pub current_state: BottlerocketNodeState,

--- a/models/src/node/mod.rs
+++ b/models/src/node/mod.rs
@@ -188,6 +188,17 @@ impl BottlerocketNodeSpec {
         // We know this won't panic because we have a regex requirement on this attribute, which is enforced by the k8s schema.
         self.version.as_ref().map(|v| Version::from_str(v).unwrap())
     }
+
+    /// Returns the operation for current spec.
+    pub fn operation(&self) -> String {
+        match self.state {
+            BottlerocketNodeState::Idle => "Idle".to_string(),
+            BottlerocketNodeState::StagedUpdate => "StagedUpdate".to_string(),
+            BottlerocketNodeState::PerformedUpdate => "PerformedUpdate".to_string(),
+            BottlerocketNodeState::RebootedIntoUpdate => "RebootedIntoUpdate".to_string(),
+            BottlerocketNodeState::MonitoringUpdate => "MonitoringUpdate".to_string(),
+        }
+    }
 }
 
 /// `BottlerocketNodeStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent,

--- a/yamlgen/build.rs
+++ b/yamlgen/build.rs
@@ -17,7 +17,7 @@ use models::{
     },
     controller::{
         controller_cluster_role, controller_cluster_role_binding, controller_deployment,
-        controller_service_account,
+        controller_service, controller_service_account,
     },
     namespace::brupop_namespace,
     node::BottlerocketNode,
@@ -93,4 +93,5 @@ fn main() {
         &controller_deployment(brupop_image.clone(), brupop_image_pull_secrets.clone()),
     )
     .unwrap();
+    serde_yaml::to_writer(&brupop_resources, &controller_service()).unwrap();
 }

--- a/yamlgen/deploy/brupop-resources.yaml
+++ b/yamlgen/deploy/brupop-resources.yaml
@@ -392,3 +392,20 @@ spec:
       imagePullSecrets:
         - name: brupop
       serviceAccountName: brupop-controller-service-account
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: brupop-controller
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: brupop-controller
+  name: brupop-controller-server
+  namespace: brupop-bottlerocket-aws
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    brupop.bottlerocket.aws/component: brupop-controller


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#128


**Description of changes:**
Emitting prometheus metrics for host's bottlerocket version and host's brupop state.
Adding HTTP server in the controller to vend prometheus metrics.

**Testing done:**
Provisioned 5 old bottlerocket hosts in the cluster and run Brupop, curled the controller endpoint to verify the metrics.

Sample metrics during brupop updating hosts.
```
[ec2-user@ip-192-168-53-104 ~]$ curl 10.100.135.35/metrics
# HELP brupop_hosts_state Brupop host's state
# TYPE brupop_hosts_state gauge
brupop_hosts_state{state="Idle"} 6
brupop_hosts_state{state="MonitoringUpdate"} 1
brupop_hosts_state{state="PerformedUpdate"} 1
brupop_hosts_state{state="RebootedIntoUpdate"} 1
brupop_hosts_state{state="StagedUpdate"} 1
# HELP brupop_hosts_version Brupop host's bottlerocket version
# TYPE brupop_hosts_version gauge
brupop_hosts_version{bottlerocket_version="1.2.0"} 4
brupop_hosts_version{bottlerocket_version="1.5.1"} 2
```

Deployed prometheus on the cluster and use port forward  to get he graphic analysis locally.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
