### PR TITLE
Prometheus visualization

### DIFF
--- a/yamlgen/telemetry/prometheus-resources.yaml
+++ b/yamlgen/telemetry/prometheus-resources.yaml
@@ -118,4 +118,3 @@ spec:
           persistentVolumeClaim:
             claimName: prometheus-pvc
       serviceAccountName: prometheus-service-account
-

--- a/yamlgen/telemetry/prometheus-resources.yaml
+++ b/yamlgen/telemetry/prometheus-resources.yaml
@@ -97,7 +97,7 @@ spec:
         image: prom/prometheus
         volumeMounts:
         - name: prometheus-volume
-          mountPath: /prometheus/data
+          mountPath: /prometheus
         - name: config-volume
           mountPath: /etc/prometheus/prometheus.yml
           subPath: prometheus.yml

--- a/yamlgen/telemetry/prometheus-resources.yaml
+++ b/yamlgen/telemetry/prometheus-resources.yaml
@@ -64,6 +64,18 @@ data:
         kubernetes_sd_configs:
           - role: endpoints
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-pvc
+  namespace: brupop-bottlerocket-aws
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,14 +96,26 @@ spec:
       - name: prometheus-container
         image: prom/prometheus
         volumeMounts:
+        - name: prometheus-volume
+          mountPath: /prometheus/data
         - name: config-volume
           mountPath: /etc/prometheus/prometheus.yml
           subPath: prometheus.yml
         ports:
         - containerPort: 9090
+      initContainers:
+      - name: prometheus-data-permission-fix
+        image: busybox
+        command: ["/bin/chmod", "-R", "777", "/data"]
+        volumeMounts:
+        - name: prometheus-volume
+          mountPath: /data
       volumes:
         - name: config-volume
           configMap:
             name: prometheus-config
+        - name: prometheus-volume
+          persistentVolumeClaim:
+            claimName: prometheus-pvc
       serviceAccountName: prometheus-service-account
 

--- a/yamlgen/telemetry/prometheus-resources.yaml
+++ b/yamlgen/telemetry/prometheus-resources.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-service-account
+  namespace: brupop-bottlerocket-aws
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-role
+  namespace: brupop-bottlerocket-aws
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - nonResourceURLs: ["/metrics"]
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-role-binding
+  namespace: brupop-bottlerocket-aws
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-service-account
+    namespace: brupop-bottlerocket-aws
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+      evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+      # scrape_timeout is set to the global default (10s).
+
+    # A scrape configuration
+    scrape_configs:
+      - job_name: "prometheus"
+        static_configs:
+        - targets: ['localhost:9090']
+      - job_name: "kubernetes-service-endpoints"
+        kubernetes_sd_configs:
+          - role: endpoints
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-deployment
+  namespace: brupop-bottlerocket-aws
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+      namespace: brupop-bottlerocket-aws
+    spec:
+      containers:
+      - name: prometheus-container
+        image: prom/prometheus
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/prometheus/prometheus.yml
+          subPath: prometheus.yml
+        ports:
+        - containerPort: 9090
+      volumes:
+        - name: config-volume
+          configMap:
+            name: prometheus-config
+      serviceAccountName: prometheus-service-account
+


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#133 


**Description of changes:**
Add prometheus k8s yaml config to help visualize metrics generated by brupop.



**Testing done:**
Deploy to my cluster and port-forward to my localhost to check the visualization.

To test

1. Deploy prometheus related resources to the cluster
```
cd bottlerocket-update-operator/yamlgen/telemetry
kubectl apply -f prometheus-resources.yaml
```

2. Port forward the prometheus pod to cluster controller host
```
kubectl get pods
prometheus-deployment-5554fd6fb5-zdfzx          1/1     Running   1          34m

kubectl port-forward prometheus-deployment-5554fd6fb5-zdfzx 9090:9090
```

3. Check the graph locally.

On the web browser open the link http://localhost:9090, search for `brupop_controller_op` metrics


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
