### PR TITLE
0.2.0: Fix apiserver perms

### DIFF
--- a/models/src/apiserver.rs
+++ b/models/src/apiserver.rs
@@ -80,7 +80,10 @@ pub fn apiserver_cluster_role() -> ClusterRole {
             PolicyRule {
                 api_groups: Some(vec!["".to_string()]),
                 resources: Some(vec!["pods".to_string()]),
-                verbs: vec!["get", "list"].iter().map(|s| s.to_string()).collect(),
+                verbs: vec!["get", "list", "watch"]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
                 ..Default::default()
             },
         ]),

--- a/yamlgen/deploy/brupop-resources.yaml
+++ b/yamlgen/deploy/brupop-resources.yaml
@@ -52,6 +52,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Description of changes:**
The apiserver was incapable of issuing a `watch` for changes on `Pod` objects. This permission seems to have been lost during a rebase. This commit fixes that issue


**Testing done:**
I allowed my brupop cluster to successfully update hosts to the latest version of Bottlerocket.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
