### PR TITLE
0.2.0-agent Integrate tracing for logging and telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,12 +224,11 @@ dependencies = [
  "apiserver",
  "chrono",
  "dotenv",
- "env_logger",
  "futures",
  "k8s-openapi",
  "kube",
- "log",
  "models",
+ "opentelemetry",
  "reqwest",
  "semver 1.0.4",
  "serde",
@@ -237,6 +236,10 @@ dependencies = [
  "snafu",
  "tokio",
  "tokio-retry",
+ "tracing",
+ "tracing-bunyan-formatter",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -10,14 +10,17 @@ models = { path = "../models", version = "0.1.0" }
 apiserver = { path = "../apiserver", version = "0.1.0", default-features = false, features = ["client"] }
 
 dotenv = "0.15"
-env_logger = "0.9"
 futures = "0.3"
+opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
+tracing-bunyan-formatter = "0.3"
+tracing-opentelemetry = "0.16"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_20"] }
 kube = { version = "0.63.2", default-features = true, features = [ "derive", "runtime" ] }
 
-log = "0.4"
 semver = { version = "1.0", features = [ "serde" ] }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"

--- a/agent/src/apiclient.rs
+++ b/agent/src/apiclient.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use snafu::{ensure, ResultExt};
 use std::process::{Command, Output};
 use tokio::time::{sleep, Duration};
+use tracing::{event, Level};
 
 const API_CLIENT_BIN: &str = "apiclient";
 const UPDATES_STATUS_URI: &str = "/updates/status";
@@ -136,10 +137,7 @@ async fn invoke_apiclient(args: Vec<String>) -> Result<Output> {
 
         match error_statuscode {
             UPDATE_API_BUSY_STATUSCODE => {
-                log::info!(
-                    "API server busy, retrying in {:?} seconds ...",
-                    UPDATE_API_SLEEP_DURATION
-                );
+                event!(Level::INFO, "API server busy, retrying later ...");
                 // Retry after ten seconds if we get a 423 Locked response (update API busy)
                 sleep(UPDATE_API_SLEEP_DURATION).await;
                 attempts += 1;

--- a/agent/src/error.rs
+++ b/agent/src/error.rs
@@ -1,4 +1,4 @@
-use crate::apiclient::apiclient_error;
+use crate::agentclient::agentclient_error;
 use snafu::Snafu;
 
 /// The crate-wide result type.
@@ -8,88 +8,25 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub")]
 pub enum Error {
-    #[snafu(display("Unable to create client: '{}'", source))]
-    ClientCreate { source: kube::Error },
-
-    #[snafu(display("Unable to get associated node name: {}", source))]
-    GetNodeName { source: std::env::VarError },
-
-    #[snafu(display("Unable to get Node uid because of missing Node `uid` value"))]
-    MissingNodeUid {},
-
-    #[snafu(display(
-        "Error {} when sending to fetch Bottlerocket Node {}",
-        source,
-        node_name
-    ))]
-    UnableFetchBottlerocketNode {
-        node_name: String,
-        source: kube::Error,
-    },
-    #[snafu(display(
-        "ErrorResponse code '{}' when sending to fetch Bottlerocket Node",
-        code
-    ))]
-    FetchBottlerocketNodeErrorCode { code: u16 },
-
-    #[snafu(display(
-        "Unable to get Bottlerocket node 'status' because of missing 'status' value"
-    ))]
-    MissingBottlerocketNodeStatus,
-
-    #[snafu(display("Unable to gather system version metadata: {}", source))]
-    BottlerocketNodeStatusVersion { source: apiclient_error::Error },
-
-    #[snafu(display("Unable to gather system chosen update metadata: '{}'", source))]
-    BottlerocketNodeStatusChosenUpdate { source: apiclient_error::Error },
-
-    #[snafu(display(
-        "Unable to update the custom resource associated with this node: '{}'",
-        source
-    ))]
-    UpdateBottlerocketNodeResource {
-        source: apiserver::client::ClientError,
-    },
-
-    #[snafu(display(
-        "Unable to create the custom resource associated with this node: '{}'",
-        source
-    ))]
-    CreateBottlerocketNodeResource {
-        source: apiserver::client::ClientError,
-    },
-
-    #[snafu(display("Unable to take action '{}': '{}'", action, source))]
-    UpdateActions {
-        action: String,
-        source: apiclient_error::Error,
-    },
-
-    #[snafu(display(
-        "Failed to run command 'uptime -s' to get latest system reboot time: '{}'",
-        source
-    ))]
-    GetUptime { source: std::io::Error },
-
-    #[snafu(display("Unable to convert `{} `to datetime: '{}'", uptime, source))]
-    ConvertStringToDatetime {
-        uptime: String,
-        source: chrono::ParseError,
-    },
-    #[snafu(display(
-        "Unable to convert response of interacting with custom resource to readable text: '{}'",
-        source
-    ))]
-    ConvertResponseToText { source: reqwest::Error },
+    #[snafu(display("Error running agent server: '{}'", source))]
+    AgentError { source: agentclient_error::Error },
 
     // The assertion type lets us return a Result in cases where we would otherwise use `unwrap()` on results that
     // we know cannot be Err. This lets us bubble up to our error handler which writes to the termination log.
     #[snafu(display("Agent failed due to internal assertion issue: '{}'", message))]
     Assertion { message: String },
 
-    #[snafu(display(
-        "Unable to fetch {} store: Store unavailable: retries exhausted",
-        object
-    ))]
-    ReflectorUnavailable { object: String },
+    #[snafu(display("Unable to create client: '{}'", source))]
+    ClientCreate { source: kube::Error },
+
+    #[snafu(display("Unable to get associated node name: {}", source))]
+    GetNodeName { source: std::env::VarError },
+
+    #[snafu(display("The Kubernetes WATCH on {} objects has failed.", object))]
+    KubernetesWatcherFailed { object: String },
+
+    #[snafu(display("Error configuring tracing: '{}'", source))]
+    TracingConfiguration {
+        source: tracing::subscriber::SetGlobalDefaultError,
+    },
 }


### PR DESCRIPTION
integrate tracing for logging and telemetry. Meanwhile, improving agent
logging to exit with instrumental error message.

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#105


**Description of changes:**
```
commit 888a4d33181a0d8344ce80197bc293449d3e47cd (HEAD -> 0.2.0, origin/0.2.0)
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Tue Jan 18 02:27:48 2022 +0000

    Add tracing support to agent

    integrate tracing for logging and telemetry. Meanwhile, improving agent
    logging to exit with instrumental error message.
```

**Testing done:**
Burpop integration test 
```
[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get pod
NAME                                           READY   STATUS    RESTARTS   AGE
brupop-agent-4rlf4                             1/1     Running   1          25m
brupop-agent-cp9d5                             1/1     Running   1          24m
brupop-agent-jpg5c                             1/1     Running   1          25m
brupop-apiserver-677496b7c4-78598              1/1     Running   1          25m
brupop-apiserver-677496b7c4-9snxq              1/1     Running   1          25m
brupop-apiserver-677496b7c4-s6tfs              1/1     Running   1          25m
brupop-controller-deployment-dbb96dcdd-xgnln   1/1     Running   1          25m
```
```
[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get brn
NAME                                                STATE   VERSION   TARGET STATE   TARGET VERSION
brn-ip-192-168-134-24.us-west-2.compute.internal    Idle    1.5.2     Idle
brn-ip-192-168-145-103.us-west-2.compute.internal   Idle    1.5.2     Idle
brn-ip-192-168-148-180.us-west-2.compute.internal   Idle    1.5.2     Idle
```

tracing log
```
{"v":0,"name":"agent","msg":"[RUN - START]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.205663092+00:00","target":"agent::agentclient","line":233,"file":"agent/src/agentclient.rs"}
{"v":0,"name":"agent","msg":"[CHECK_NODE_CUSTOM_RESOURCE_EXISTS - START]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.205690755+00:00","target":"agent::agentclient","line":66,"file":"agent/src/agentclient.rs"}
{"v":0,"name":"agent","msg":"[CHECK_NODE_CUSTOM_RESOURCE_EXISTS - END]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.217110536+00:00","target":"agent::agentclient","line":66,"file":"agent/src/agentclient.rs","elapsed_milliseconds":11}
{"v":0,"name":"agent","msg":"[CREATE_METADATA_CUSTOM_RESOURCE - START]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.217134986+00:00","target":"agent::agentclient","line":189,"file":"agent/src/agentclient.rs"}
{"v":0,"name":"agent","msg":"[GET_NODE_SELECTOR - START]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.217146889+00:00","target":"agent::agentclient","line":113,"file":"agent/src/agentclient.rs"}
{"v":0,"name":"agent","msg":"[GET_NODE_SELECTOR - END]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.217337576+00:00","target":"agent::agentclient","line":113,"file":"agent/src/agentclient.rs","elapsed_milliseconds":0}
{"v":0,"name":"agent","msg":"[CREATE_BOTTLEROCKET_NODE - START]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.217369613+00:00","target":"apiserver::client::webclient","line":100,"file":"apiserver/src/client/webclient.rs","self":"K8SAPIServerClient { k8s_projected_token_path: \"/var/run/secrets/tokens/bottlerocket-agent-service-account-token\" }","req":"CreateBottlerocketNodeRequest { node_selector: BottlerocketNodeSelector { node_name: \"ip-192-168-153-244.us-west-2.compute.internal\", node_uid: \"a3cebd9b-6f3f-45a4-a08a-d56a504bfd45\" } }"}
{"v":0,"name":"agent","msg":"[CREATE_BOTTLEROCKET_NODE - END]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.235457808+00:00","target":"apiserver::client::webclient","line":100,"file":"apiserver/src/client/webclient.rs","elapsed_milliseconds":18,"self":"K8SAPIServerClient { k8s_projected_token_path: \"/var/run/secrets/tokens/bottlerocket-agent-service-account-token\" }","req":"CreateBottlerocketNodeRequest { node_selector: BottlerocketNodeSelector { node_name: \"ip-192-168-153-244.us-west-2.compute.internal\", node_uid: \"a3cebd9b-6f3f-45a4-a08a-d56a504bfd45\" } }"}
{"v":0,"name":"agent","msg":"[CREATE_METADATA_CUSTOM_RESOURCE - EVENT] Brn has been created.","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.235493020+00:00","target":"agent::agentclient","line":199,"file":"agent/src/agentclient.rs","brn_name":"\"ip-192-168-153-244.us-west-2.compute.internal\""}
{"v":0,"name":"agent","msg":"[CREATE_METADATA_CUSTOM_RESOURCE - END]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.235505863+00:00","target":"agent::agentclient","line":189,"file":"agent/src/agentclient.rs","elapsed_milliseconds":18}
{"v":0,"name":"agent","msg":"[CHECK_CUSTOM_RESOURCE_STATUS_EXISTS - START]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.235518440+00:00","target":"agent::agentclient","line":108,"file":"agent/src/agentclient.rs"}
{"v":0,"name":"agent","msg":"[FETCH_CUSTOM_RESOURCE - START]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.235529386+00:00","target":"agent::agentclient","line":141,"file":"agent/src/agentclient.rs"}
{"v":0,"name":"agent","msg":"[FETCH_CUSTOM_RESOURCE - END]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.235562192+00:00","target":"agent::agentclient","line":141,"file":"agent/src/agentclient.rs","elapsed_milliseconds":0}
{"v":0,"name":"agent","msg":"[CHECK_CUSTOM_RESOURCE_STATUS_EXISTS - END]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.235574789+00:00","target":"agent::agentclient","line":108,"file":"agent/src/agentclient.rs","elapsed_milliseconds":0}
{"v":0,"name":"agent","msg":"[GATHER_SYSTEM_METADATA - START]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.235584846+00:00","target":"agent::agentclient","line":164,"file":"agent/src/agentclient.rs"}
{"v":0,"name":"agent","msg":"[GATHER_SYSTEM_METADATA - EVENT] API server busy, retrying later ...","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:18.344122370+00:00","target":"agent::apiclient","line":140,"file":"agent/src/apiclient.rs"}
{"v":0,"name":"agent","msg":"[GATHER_SYSTEM_METADATA - EVENT] API server busy, retrying later ...","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:28.354179248+00:00","target":"agent::apiclient","line":140,"file":"agent/src/apiclient.rs"}
{"v":0,"name":"agent","msg":"[GATHER_SYSTEM_METADATA - END]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:38.356936231+00:00","target":"agent::agentclient","line":164,"file":"agent/src/agentclient.rs","elapsed_milliseconds":20121}
{"v":0,"name":"agent","msg":"[UPDATE_METADATA_CUSTOM_RESOURCE - START]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:38.356971230+00:00","target":"agent::agentclient","line":204,"file":"agent/src/agentclient.rs"}
{"v":0,"name":"agent","msg":"[GET_NODE_SELECTOR - START]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:38.356984403+00:00","target":"agent::agentclient","line":113,"file":"agent/src/agentclient.rs"}
{"v":0,"name":"agent","msg":"[GET_NODE_SELECTOR - END]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:38.357160240+00:00","target":"agent::agentclient","line":113,"file":"agent/src/agentclient.rs","elapsed_milliseconds":0}
{"v":0,"name":"agent","msg":"[UPDATE_BOTTLEROCKET_NODE - START]","level":30,"hostname":"brupop-agent-b25gl","pid":1,"time":"2022-01-19T06:25:38.357193318+00:00","target":"apiserver::client::webclient","line":140,"file":"apiserver/src/client/webclient.rs","self":"K8SAPIServerClient { k8s_projected_token_path: \"/var/run/secrets/tokens/bottlerocket-agent-service-account-token\" }","req":"UpdateBottlerocketNodeRequest { node_selector: BottlerocketNodeSelector { node_name: \"ip-192-168-153-244.us-west-2.compute.internal\", node_uid: \"a3cebd9b-6f3f-45a4-a08a-d56a504bfd45\" }, node_status: BottlerocketNodeStatus { current_version: \"1.1.1\", target_version: \"1.5.2\", current_state: Idle } }"}
......
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
