### PR TITLE
0.2.0-integ test: Using single resource file.

### DIFF
--- a/integ/src/updater.rs
+++ b/integ/src/updater.rs
@@ -75,24 +75,11 @@ pub async fn label_node(node_names: Vec<String>, kube_config_path: &str) -> Upda
 
 // installing brupop on EKS cluster
 pub async fn run_brupop(kube_config_path: &str) -> UpdaterResult<()> {
-    let brn_status = Command::new("kubectl")
-        .args([
-            "apply",
-            "-f",
-            "yamlgen/deploy/bottlerocket-node-crd.yaml",
-            "--kubeconfig",
-            kube_config_path,
-        ])
-        .status()
-        .context(update_error::BrupopProcess)?;
-
-    ensure!(brn_status.success(), update_error::BrupopRun);
-
     let brupop_resource_status = Command::new("kubectl")
         .args([
             "apply",
             "-f",
-            "yamlgen/deploy/brupop-resources.yaml",
+            "yamlgen/deploy/bottlerocket-update-operator.yaml",
             "--kubeconfig",
             kube_config_path,
         ])


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
**Description of changes:**
Since we combine Brn and burpop yaml files to single  file, I upgrade integration test to us correct file.

**Testing done:**
```
cargo run --bin integ integration-test --instance-ami-id ami-026c14d3e67a22dc6 --cluster-name bottlerocket-test --region us-west-2

[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get brn
NAME                                                STATE   VERSION   TARGET STATE   TARGET VERSION
brn-ip-192-168-131-5.us-west-2.compute.internal     Idle    1.5.2     Idle
brn-ip-192-168-134-240.us-west-2.compute.internal   Idle    1.5.2     Idle
brn-ip-192-168-151-240.us-west-2.compute.internal   Idle    1.5.2     Idle
```

```
cargo run --bin integ clean --cluster-name bottlerocket-test --region us-west-2

namespace "brupop-bottlerocket-aws" deleted
clusterrolebinding.rbac.authorization.k8s.io "brupop-apiserver-role-binding" deleted
clusterrolebinding.rbac.authorization.k8s.io "brupop-agent-role-binding" deleted
clusterrolebinding.rbac.authorization.k8s.io "brupop-controller-role-binding" deleted
clusterrole.rbac.authorization.k8s.io "brupop-apiserver-role" deleted
clusterrole.rbac.authorization.k8s.io "brupop-agent-role" deleted
clusterrole.rbac.authorization.k8s.io "brupop-controller-role" deleted
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
