### PR TITLE
Remove unneeded permissions granted to agent

### DIFF
--- a/models/src/agent.rs
+++ b/models/src/agent.rs
@@ -48,7 +48,7 @@ pub fn agent_cluster_role() -> ClusterRole {
             PolicyRule {
                 api_groups: Some(vec!["".to_string()]),
                 resources: Some(vec!["nodes".to_string()]),
-                verbs: vec!["create", "get", "list", "patch", "update", "watch"]
+                verbs: vec!["get", "list", "watch"]
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -281,11 +281,8 @@ rules:
     resources:
       - nodes
     verbs:
-      - create
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - brupop.bottlerocket.aws


### PR DESCRIPTION
**Description of changes:**
The brupop agent should not have permissions which allow to mutate objects in Kubernetes.


**Testing done:**
I created a cluster with two Bottlerocket nodes running an older version of Bottlerocket and ensured that brupop successfully updated the cluster.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
