### PR TITLE
rename brn custom resource to BottlerocketShadow and brs

### DIFF
--- a/apiserver/src/api/drain.rs
+++ b/apiserver/src/api/drain.rs
@@ -1,6 +1,6 @@
 use super::{APIServerSettings, ApiserverCommonHeaders};
 use crate::error::{self, Result};
-use models::node::BottlerocketNodeClient;
+use models::node::BottlerocketShadowClient;
 
 use actix_web::{
     web::{self},
@@ -11,7 +11,7 @@ use snafu::ResultExt;
 use std::convert::TryFrom;
 
 /// HTTP endpoint which prevents work from being scheduled to a node, and drains all pods currently running.
-pub(crate) async fn cordon_and_drain<T: BottlerocketNodeClient>(
+pub(crate) async fn cordon_and_drain<T: BottlerocketShadowClient>(
     settings: web::Data<APIServerSettings<T>>,
     http_req: HttpRequest,
 ) -> Result<impl Responder> {
@@ -20,19 +20,19 @@ pub(crate) async fn cordon_and_drain<T: BottlerocketNodeClient>(
         .node_client
         .cordon_node(&headers.node_selector)
         .await
-        .context(error::BottlerocketNodeCordon)?;
+        .context(error::BottlerocketShadowCordon)?;
 
     settings
         .node_client
         .drain_node(&headers.node_selector)
         .await
-        .context(error::BottlerocketNodeDrain)?;
+        .context(error::BottlerocketShadowDrain)?;
 
     Ok(HttpResponse::Ok())
 }
 
 /// HTTP endpoint which re-allows work to be scheduled on a node that has been cordoned.
-pub(crate) async fn uncordon<T: BottlerocketNodeClient>(
+pub(crate) async fn uncordon<T: BottlerocketShadowClient>(
     settings: web::Data<APIServerSettings<T>>,
     http_req: HttpRequest,
 ) -> Result<impl Responder> {
@@ -41,7 +41,7 @@ pub(crate) async fn uncordon<T: BottlerocketNodeClient>(
         .node_client
         .uncordon_node(&headers.node_selector)
         .await
-        .context(error::BottlerocketNodeCordon)?;
+        .context(error::BottlerocketShadowCordon)?;
 
     Ok(HttpResponse::Ok())
 }

--- a/apiserver/src/auth/authorizor.rs
+++ b/apiserver/src/auth/authorizor.rs
@@ -1,7 +1,7 @@
 //! This module provides abstractions for authenticating and authorizing requests from brupop agents to make changes to
-//! the underlying Node's resources (including BottlerocketNode custom resources, or draining the host Nodes of Pods.)
+//! the underlying Node's resources (including BottlerocketShadow custom resources, or draining the host Nodes of Pods.)
 use super::error::*;
-use models::node::BottlerocketNodeSelector;
+use models::node::BottlerocketShadowSelector;
 
 use async_trait::async_trait;
 use k8s_openapi::api::{
@@ -23,7 +23,7 @@ pub trait TokenAuthorizor: Clone {
     /// Determine if the identity represented by the provided auth token has access to the provided node.
     async fn check_request_authorized(
         &self,
-        node_selector: &BottlerocketNodeSelector,
+        node_selector: &BottlerocketShadowSelector,
         auth_token: &str,
     ) -> Result<(), AuthorizationError>;
 }
@@ -49,7 +49,7 @@ impl<T: TokenReviewer> TokenAuthorizor for K8STokenAuthorizor<T> {
     #[instrument(skip(self, auth_token))]
     async fn check_request_authorized(
         &self,
-        node_selector: &BottlerocketNodeSelector,
+        node_selector: &BottlerocketShadowSelector,
         auth_token: &str,
     ) -> Result<(), AuthorizationError> {
         let token_review_req = TokenReview {
@@ -137,7 +137,7 @@ impl<T: TokenReviewer> K8STokenAuthorizor<T> {
     async fn check_requester_is_from_correct_node(
         &self,
         token_review_status: &TokenReviewStatus,
-        node_selector: &BottlerocketNodeSelector,
+        node_selector: &BottlerocketShadowSelector,
     ) -> Result<(), AuthorizationError> {
         let pod_name = token_review_status
             .user
@@ -239,7 +239,7 @@ pub mod mock {
         impl TokenAuthorizor for TokenAuthorizor {
             async fn check_request_authorized(
                 &self,
-                node_selector: &BottlerocketNodeSelector,
+                node_selector: &BottlerocketShadowSelector,
                 auth_token: &str,
             ) -> Result<(), AuthorizationError>;
         }
@@ -400,8 +400,8 @@ pub(crate) mod test {
         }
     }
 
-    fn selector_with_name(name: &str) -> BottlerocketNodeSelector {
-        BottlerocketNodeSelector {
+    fn selector_with_name(name: &str) -> BottlerocketShadowSelector {
+        BottlerocketShadowSelector {
             node_name: name.to_string(),
             node_uid: "fake".to_string(),
         }

--- a/apiserver/src/auth/error.rs
+++ b/apiserver/src/auth/error.rs
@@ -36,7 +36,7 @@ pub enum AuthorizationError {
     NoSuchPod { pod_name: String },
 
     #[snafu(display(
-        "Requesting pod's node ('{}') does not match brn selector ('{}')",
+        "Requesting pod's node ('{}') does not match brs selector ('{}')",
         requesting_node,
         target_node
     ))]

--- a/apiserver/src/auth/middleware.rs
+++ b/apiserver/src/auth/middleware.rs
@@ -1,5 +1,5 @@
 //! This module provides middleware for authenticating and authorizing requests from brupop agents to make changes to
-//! their Node's resources (including BottlerocketNode custom resources, or Draining their host Nodes of Pods.)
+//! their Node's resources (including BottlerocketShadow custom resources, or Draining their host Nodes of Pods.)
 use super::TokenAuthorizor;
 use crate::api::ApiserverCommonHeaders;
 

--- a/apiserver/src/client/error.rs
+++ b/apiserver/src/client/error.rs
@@ -1,4 +1,4 @@
-use models::node::BottlerocketNodeSelector;
+use models::node::BottlerocketShadowSelector;
 
 use snafu::Snafu;
 
@@ -20,24 +20,24 @@ pub enum ClientError {
     },
 
     #[snafu(display(
-        "Unable to create BottlerocketNode ({}, {}): '{}'",
+        "Unable to create BottlerocketShadow ({}, {}): '{}'",
         selector.node_name,
         selector.node_uid,
         source
     ))]
-    CreateBottlerocketNodeResource {
+    CreateBottlerocketShadowResource {
         source: Box<dyn std::error::Error>,
-        selector: BottlerocketNodeSelector,
+        selector: BottlerocketShadowSelector,
     },
     #[snafu(display(
-        "Unable to update BottlerocketNode status ({}, {}): '{}'",
+        "Unable to update BottlerocketShadow status ({}, {}): '{}'",
         selector.node_name,
         selector.node_uid,
         source
     ))]
-    UpdateBottlerocketNodeResource {
+    UpdateBottlerocketShadowResource {
         source: Box<dyn std::error::Error>,
-        selector: BottlerocketNodeSelector,
+        selector: BottlerocketShadowSelector,
     },
 
     #[snafu(display(
@@ -48,7 +48,7 @@ pub enum ClientError {
     ))]
     CordonAndDrainNodeResource {
         source: Box<dyn std::error::Error>,
-        selector: BottlerocketNodeSelector,
+        selector: BottlerocketShadowSelector,
     },
 
     #[snafu(display(
@@ -59,7 +59,7 @@ pub enum ClientError {
     ))]
     UncordonNodeResource {
         source: Box<dyn std::error::Error>,
-        selector: BottlerocketNodeSelector,
+        selector: BottlerocketShadowSelector,
     },
 
     #[snafu(display(

--- a/apiserver/src/client/mock.rs
+++ b/apiserver/src/client/mock.rs
@@ -1,10 +1,10 @@
 /// This module contains client implementations that are useful for testing purposes.
 use super::{error::Result, APIServerClient};
 use crate::{
-    CordonAndDrainBottlerocketNodeRequest, CreateBottlerocketNodeRequest,
-    UncordonBottlerocketNodeRequest, UpdateBottlerocketNodeRequest,
+    CordonAndDrainBottlerocketShadowRequest, CreateBottlerocketShadowRequest,
+    UncordonBottlerocketShadowRequest, UpdateBottlerocketShadowRequest,
 };
-use models::node::{BottlerocketNode, BottlerocketNodeStatus};
+use models::node::{BottlerocketShadow, BottlerocketShadowStatus};
 
 use async_trait::async_trait;
 
@@ -15,16 +15,16 @@ mock! {
     pub APIServerClient {}
     #[async_trait]
     impl APIServerClient for APIServerClient {
-        async fn create_bottlerocket_node(
+        async fn create_bottlerocket_shadow(
             &self,
-            req: CreateBottlerocketNodeRequest,
-        ) -> Result<BottlerocketNode>;
-        async fn update_bottlerocket_node(
+            req: CreateBottlerocketShadowRequest,
+        ) -> Result<BottlerocketShadow>;
+        async fn update_bottlerocket_shadow(
             &self,
-            req: UpdateBottlerocketNodeRequest,
-        ) -> Result<BottlerocketNodeStatus>;
-        async fn cordon_and_drain_node(&self, req: CordonAndDrainBottlerocketNodeRequest)
+            req: UpdateBottlerocketShadowRequest,
+        ) -> Result<BottlerocketShadowStatus>;
+        async fn cordon_and_drain_node(&self, req: CordonAndDrainBottlerocketShadowRequest)
             -> Result<()>;
-        async fn uncordon_node(&self, req: UncordonBottlerocketNodeRequest) -> Result<()>;
+        async fn uncordon_node(&self, req: UncordonBottlerocketShadowRequest) -> Result<()>;
     }
 }

--- a/apiserver/src/error.rs
+++ b/apiserver/src/error.rs
@@ -1,4 +1,4 @@
-use models::node::BottlerocketNodeError;
+use models::node::BottlerocketShadowError;
 
 use actix_web::error::ResponseError;
 use snafu::Snafu;
@@ -16,11 +16,11 @@ pub enum Error {
     #[snafu(display("Unable to parse HTTP header. Missing '{}'", missing_header))]
     HTTPHeaderParse { missing_header: &'static str },
 
-    #[snafu(display("Error creating BottlerocketNode: '{}'", source))]
-    BottlerocketNodeCreate { source: BottlerocketNodeError },
+    #[snafu(display("Error creating BottlerocketShadow: '{}'", source))]
+    BottlerocketShadowCreate { source: BottlerocketShadowError },
 
-    #[snafu(display("Error patching BottlerocketNode: '{}'", source))]
-    BottlerocketNodeUpdate { source: BottlerocketNodeError },
+    #[snafu(display("Error patching BottlerocketShadow: '{}'", source))]
+    BottlerocketShadowUpdate { source: BottlerocketShadowError },
 
     #[snafu(display("Error running HTTP server: '{}'", source))]
     HttpServerError { source: std::io::Error },
@@ -34,10 +34,10 @@ pub enum Error {
     KubernetesWatcherFailed {},
 
     #[snafu(display("Failed to cordon Node: '{}'", source))]
-    BottlerocketNodeCordon { source: BottlerocketNodeError },
+    BottlerocketShadowCordon { source: BottlerocketShadowError },
 
     #[snafu(display("Failed to drain Node: '{}'", source))]
-    BottlerocketNodeDrain { source: BottlerocketNodeError },
+    BottlerocketShadowDrain { source: BottlerocketShadowError },
 }
 
 impl ResponseError for Error {}

--- a/apiserver/src/lib.rs
+++ b/apiserver/src/lib.rs
@@ -12,30 +12,30 @@ pub mod client;
 
 pub(crate) mod constants;
 
-use models::node::{BottlerocketNodeSelector, BottlerocketNodeStatus};
+use models::node::{BottlerocketShadowSelector, BottlerocketShadowStatus};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Describes a node for which a BottlerocketNode custom resource should be constructed.
-pub struct CreateBottlerocketNodeRequest {
-    pub node_selector: BottlerocketNodeSelector,
+/// Describes a node for which a BottlerocketShadow custom resource should be constructed.
+pub struct CreateBottlerocketShadowRequest {
+    pub node_selector: BottlerocketShadowSelector,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Describes updates to a BottlerocketNode object's `status`.
-pub struct UpdateBottlerocketNodeRequest {
-    pub node_selector: BottlerocketNodeSelector,
-    pub node_status: BottlerocketNodeStatus,
+/// Describes updates to a BottlerocketShadow object's `status`.
+pub struct UpdateBottlerocketShadowRequest {
+    pub node_selector: BottlerocketShadowSelector,
+    pub node_status: BottlerocketShadowStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Describes a node which should have its k8s pods drained, and be cordoned to avoid more pods being scheduled..
-pub struct CordonAndDrainBottlerocketNodeRequest {
-    pub node_selector: BottlerocketNodeSelector,
+pub struct CordonAndDrainBottlerocketShadowRequest {
+    pub node_selector: BottlerocketShadowSelector,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Describes a node which should be uncordoned, allowing k8s Pods to be scheduled to it.
-pub struct UncordonBottlerocketNodeRequest {
-    pub node_selector: BottlerocketNodeSelector,
+pub struct UncordonBottlerocketShadowRequest {
+    pub node_selector: BottlerocketShadowSelector,
 }

--- a/apiserver/src/main.rs
+++ b/apiserver/src/main.rs
@@ -1,7 +1,7 @@
 use apiserver::api::{self, APIServerSettings};
 use apiserver::error::{self, Result};
 use apiserver::telemetry::init_telemetry;
-use models::node::K8SBottlerocketNodeClient;
+use models::node::K8SBottlerocketShadowClient;
 use tracing::{event, Level};
 
 use snafu::ResultExt;
@@ -39,7 +39,7 @@ async fn run_server() -> Result<()> {
         .context(error::ClientCreate)?;
 
     let settings = APIServerSettings {
-        node_client: K8SBottlerocketNodeClient::new(k8s_client.clone()),
+        node_client: K8SBottlerocketShadowClient::new(k8s_client.clone()),
         server_port: 8080,
     };
 

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -3,7 +3,7 @@ use super::{
     metrics::{BrupopControllerMetrics, BrupopHostsData},
     statemachine::determine_next_node_spec,
 };
-use models::node::{BottlerocketNode, BottlerocketNodeClient, BottlerocketNodeState};
+use models::node::{BottlerocketShadow, BottlerocketShadowClient, BottlerocketShadowState};
 
 use kube::runtime::reflector::Store;
 use kube::ResourceExt;
@@ -17,56 +17,56 @@ use tracing::{event, instrument, Level};
 const ACTION_INTERVAL: Duration = Duration::from_secs(2);
 
 /// The BrupopController orchestrates updates across a cluster of Bottlerocket nodes.
-pub struct BrupopController<T: BottlerocketNodeClient> {
+pub struct BrupopController<T: BottlerocketShadowClient> {
     node_client: T,
-    brn_reader: Store<BottlerocketNode>,
+    brs_reader: Store<BottlerocketShadow>,
     metrics: BrupopControllerMetrics,
 }
 
-impl<T: BottlerocketNodeClient> BrupopController<T> {
-    pub fn new(node_client: T, brn_reader: Store<BottlerocketNode>) -> Self {
+impl<T: BottlerocketShadowClient> BrupopController<T> {
+    pub fn new(node_client: T, brs_reader: Store<BottlerocketShadow>) -> Self {
         // Creates brupop-controller meter via the configured
         // GlobalMeterProvider which is setup in PrometheusExporter
         let meter = global::meter("brupop-controller");
         let metrics = BrupopControllerMetrics::new(meter);
         BrupopController {
             node_client,
-            brn_reader,
+            brs_reader,
             metrics,
         }
     }
 
-    /// Returns a list of all `BottlerocketNode` objects in the cluster.
-    fn all_nodes(&self) -> Vec<BottlerocketNode> {
-        self.brn_reader.state()
+    /// Returns a list of all `BottlerocketShadow` objects in the cluster.
+    fn all_nodes(&self) -> Vec<BottlerocketShadow> {
+        self.brs_reader.state()
     }
 
-    /// Returns the set of BottlerocketNode objects which is currently being acted upon.
+    /// Returns the set of BottlerocketShadow objects which is currently being acted upon.
     ///
     /// Nodes are being acted upon if they are not in the `WaitingForUpdate` state, or if their desired state does
     /// not match their current state.
     #[instrument(skip(self))]
-    fn active_node_set(&self) -> BTreeMap<String, BottlerocketNode> {
+    fn active_node_set(&self) -> BTreeMap<String, BottlerocketShadow> {
         self.all_nodes()
             .iter()
-            .filter(|brn| {
-                brn.status.as_ref().map_or(false, |brn_status| {
-                    brn_status.current_state != BottlerocketNodeState::Idle
-                        || !brn.has_reached_desired_state()
+            .filter(|brs| {
+                brs.status.as_ref().map_or(false, |brs_status| {
+                    brs_status.current_state != BottlerocketShadowState::Idle
+                        || !brs.has_reached_desired_state()
                 })
             })
             // kube-rs doesn't implement Ord or Hash on ObjectMeta, so we store these in a map indexed by name.
             // (which are unique within a namespace). `name()` is guaranteed not to panic, as these nodes are all populated
             // by our `reflector`.
-            .map(|brn| (brn.name(), brn.clone()))
+            .map(|brs| (brs.name(), brs.clone()))
             .collect()
     }
 
-    /// Determines next actions for a BottlerocketNode and attempts to execute them.
+    /// Determines next actions for a BottlerocketShadow and attempts to execute them.
     ///
-    /// This could include modifying the `spec` of a brn to indicate a new desired state, or handling timeouts.
+    /// This could include modifying the `spec` of a brs to indicate a new desired state, or handling timeouts.
     #[instrument(skip(self), err)]
-    async fn progress_node(&self, node: BottlerocketNode) -> Result<()> {
+    async fn progress_node(&self, node: BottlerocketShadow) -> Result<()> {
         if node.has_reached_desired_state() {
             // Emit metrics to show the existing status
             self.emit_metrics()?;
@@ -76,7 +76,7 @@ impl<T: BottlerocketNodeClient> BrupopController<T> {
             event!(
                 Level::INFO,
                 ?desired_spec,
-                "BottlerocketNode has reached desired status. Modifying spec."
+                "BottlerocketShadow has reached desired status. Modifying spec."
             );
 
             self.node_client
@@ -94,17 +94,17 @@ impl<T: BottlerocketNodeClient> BrupopController<T> {
         }
     }
 
-    /// This function searches all `BottlerocketNode`s for those which can be transitioned to a new state.
+    /// This function searches all `BottlerocketShadow`s for those which can be transitioned to a new state.
     /// The state transition is then attempted. If successful, this node should be detected as part of the active
     /// set during the next iteration of the controller's event loop.
     #[instrument(skip(self))]
-    async fn find_and_update_ready_node(&self) -> Option<BottlerocketNode> {
-        for brn in self.all_nodes() {
+    async fn find_and_update_ready_node(&self) -> Option<BottlerocketShadow> {
+        for brs in self.all_nodes() {
             // If we determine that the spec should change, this node is a candidate to begin updating.
-            let next_spec = determine_next_node_spec(&brn);
-            if next_spec != brn.spec {
-                match self.progress_node(brn.clone()).await {
-                    Ok(_) => return Some(brn),
+            let next_spec = determine_next_node_spec(&brs);
+            if next_spec != brs.spec {
+                match self.progress_node(brs.clone()).await {
+                    Ok(_) => return Some(brs),
                     Err(_) => {
                         // Errors connecting to the k8s API are ignored (and also logged by `progress_node()`).
                         // We'll just move on and try a different node.
@@ -131,10 +131,10 @@ impl<T: BottlerocketNodeClient> BrupopController<T> {
         let mut hosts_version_count_map = HashMap::new();
         let mut hosts_state_count_map = HashMap::new();
 
-        for brn in self.all_nodes() {
-            if let Some(brn_status) = brn.status {
-                let current_version = brn_status.current_version().to_string();
-                let current_state = brn_status.current_state;
+        for brs in self.all_nodes() {
+            if let Some(brs_status) = brs.status {
+                let current_version = brs_status.current_version().to_string();
+                let current_state = brs_status.current_state;
 
                 *hosts_version_count_map.entry(current_version).or_default() += 1;
                 *hosts_state_count_map
@@ -153,7 +153,7 @@ impl<T: BottlerocketNodeClient> BrupopController<T> {
     ///
     /// Because the controller wants to gate the number of simultaneously updating nodes, we can't allow the update state machine
     /// of each individual bottlerocket node to run concurrently and in an event-driven fashion, as is typically done with controllers.
-    /// Instead, we will keep an updated store of `BottlerocketNode` objects based on cluster events, and then periodically make
+    /// Instead, we will keep an updated store of `BottlerocketShadow` objects based on cluster events, and then periodically make
     /// scheduling decisions based on that store.
     ///
     /// The controller is designed to run on a single node in the cluster and rely on the scheduler to ensure there is always one
@@ -169,20 +169,20 @@ impl<T: BottlerocketNodeClient> BrupopController<T> {
 
             if !active_set.is_empty() {
                 // Try to push forward all active nodes, gathering results along the way.
-                let mut nodes: Vec<BottlerocketNode> = active_set.into_values().collect();
+                let mut nodes: Vec<BottlerocketShadow> = active_set.into_values().collect();
 
-                for brn in nodes.drain(..) {
+                for brs in nodes.drain(..) {
                     // Timeouts and errors are logged by instrumentation in `progress_node()`.
                     #[allow(unused_must_use)]
                     {
-                        self.progress_node(brn).await;
+                        self.progress_node(brs).await;
                     }
                 }
             } else {
                 // If there's nothing to operate on, check to see if any other nodes are ready for action.
                 let new_active_node = self.find_and_update_ready_node().await;
-                if let Some(brn) = new_active_node {
-                    event!(Level::INFO, name = %brn.name(), "Began updating new node.")
+                if let Some(brs) = new_active_node {
+                    event!(Level::INFO, name = %brs.name(), "Began updating new node.")
                 }
             }
 

--- a/controller/src/error.rs
+++ b/controller/src/error.rs
@@ -1,4 +1,4 @@
-use models::node::BottlerocketNodeError;
+use models::node::BottlerocketShadowError;
 
 use snafu::Snafu;
 
@@ -24,13 +24,13 @@ pub enum Error {
         "Cannot determine the next node spec based on the current node state: '{}'",
         source
     ))]
-    NodeSpecCannotBeDetermined { source: BottlerocketNodeError },
+    NodeSpecCannotBeDetermined { source: BottlerocketShadowError },
 
     #[snafu(display("Failed to update node spec via kubernetes API: '{}'", source))]
-    UpdateNodeSpec { source: BottlerocketNodeError },
+    UpdateNodeSpec { source: BottlerocketShadowError },
 
     #[snafu(display("Could not determine selector for node: '{}'", source))]
-    NodeSelectorCreation { source: BottlerocketNodeError },
+    NodeSelectorCreation { source: BottlerocketShadowError },
 
     #[snafu(display("Error running prometheus HTTP server: '{}'", source))]
     PrometheusServerError { source: std::io::Error },

--- a/controller/src/statemachine.rs
+++ b/controller/src/statemachine.rs
@@ -1,31 +1,31 @@
-use models::node::{BottlerocketNode, BottlerocketNodeSpec, BottlerocketNodeState};
+use models::node::{BottlerocketShadow, BottlerocketShadowSpec, BottlerocketShadowState};
 
 use tracing::instrument;
 
-/// Constructs a `BottlerocketNodeSpec` to assign to a `BottlerocketNode` resource, assuming the current
+/// Constructs a `BottlerocketShadowSpec` to assign to a `BottlerocketShadow` resource, assuming the current
 /// spec has been successfully achieved.
-#[instrument(skip(brn))]
-pub fn determine_next_node_spec(brn: &BottlerocketNode) -> BottlerocketNodeSpec {
-    match brn.status.as_ref() {
+#[instrument(skip(brs))]
+pub fn determine_next_node_spec(brs: &BottlerocketShadow) -> BottlerocketShadowSpec {
+    match brs.status.as_ref() {
         // If no status is present, just keep waiting for an update.
-        None => BottlerocketNodeSpec::default(),
+        None => BottlerocketShadowSpec::default(),
         // If we've not actualized the current spec, then don't bother computing a new one.
-        Some(node_status) if node_status.current_state != brn.spec.state => brn.spec.clone(),
+        Some(node_status) if node_status.current_state != brs.spec.state => brs.spec.clone(),
         Some(node_status) => {
-            match brn.spec.state {
-                BottlerocketNodeState::Idle => {
+            match brs.spec.state {
+                BottlerocketShadowState::Idle => {
                     let target_version = node_status.target_version();
                     Some(target_version)
                         .filter(|target_version| &node_status.current_version() != target_version)
                         .map(|target_version| {
-                            BottlerocketNodeSpec::new_starting_now(
-                                BottlerocketNodeState::StagedUpdate,
+                            BottlerocketShadowSpec::new_starting_now(
+                                BottlerocketShadowState::StagedUpdate,
                                 Some(target_version.clone()),
                             )
                         })
-                        .unwrap_or_else(BottlerocketNodeSpec::default)
+                        .unwrap_or_else(BottlerocketShadowSpec::default)
                 }
-                BottlerocketNodeState::MonitoringUpdate => {
+                BottlerocketShadowState::MonitoringUpdate => {
                     // We're ready to wait for a new update.
                     // For now, we just proceed right away.
                     // TODO implement a monitoring protocol
@@ -33,15 +33,15 @@ pub fn determine_next_node_spec(brn: &BottlerocketNode) -> BottlerocketNodeSpec 
                     //   * specify a k8s job which checks for success
                     //   * allow a default job to test for success
                     //   * proceed right away
-                    BottlerocketNodeSpec::new_starting_now(
-                        brn.spec.state.on_success(),
-                        brn.spec.version(),
+                    BottlerocketShadowSpec::new_starting_now(
+                        brs.spec.state.on_success(),
+                        brs.spec.version(),
                     )
                 }
                 // In any other circumstance, we just proceed to the next step.
-                _ => BottlerocketNodeSpec::new_starting_now(
-                    brn.spec.state.on_success(),
-                    brn.spec.version(),
+                _ => BottlerocketShadowSpec::new_starting_now(
+                    brs.spec.state.on_success(),
+                    brs.spec.version(),
                 ),
             }
         }

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -32,9 +32,9 @@ Customers with disruption-sensitive workloads should utilize [PodDisruptionBudge
 
 Brupop will continue to utilize a DaemonSet of agents on each Bottlerocket node.
 Each of these nodes will also behave as a control loop, operating solely on the target node.
-Instead of having the independent controller and agent cooperate and pass messages via RPC, we will associate a [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (called BottlerocketNode) with each Bottlerocket node containing status information about the node, as well as a desired state.
-The `controller` will utilize state information in the `BottlerocketNode` resource to determine what the desired state of the node should be, setting that desired state back into the `spec` of the `BottlerocketNode` resource.
-The agent on each host will be responsible for updating the `BottlerocketNode` metadata, and driving the local system towards the desired spec set by the controller.
+Instead of having the independent controller and agent cooperate and pass messages via RPC, we will associate a [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (called BottlerocketShadow) with each Bottlerocket node containing status information about the node, as well as a desired state.
+The `controller` will utilize state information in the `BottlerocketShadow` resource to determine what the desired state of the node should be, setting that desired state back into the `spec` of the `BottlerocketShadow` resource.
+The agent on each host will be responsible for updating the `BottlerocketShadow` metadata, and driving the local system towards the desired spec set by the controller.
 
 So, as before, each node in the system flows through a state machine.
 The brupop controller can page through relevant nodes and determine its next action or check on the status of ongoing actions.
@@ -132,9 +132,9 @@ metadata:
 Kubernetes will garbage collect these custom resources when the associated node is removed from the cluster.
 
 ### Appendix C. Authorization of Bottlerocket Node Behavior
-Usage of the usual kubernetes [rbac](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) system for authorization will lead to a situation in which any Bottlerocket node will have sufficient permissions to modify the BottlerocketNode custom resource for any other node, as a role would be shared by all pods.
+Usage of the usual kubernetes [rbac](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) system for authorization will lead to a situation in which any Bottlerocket node will have sufficient permissions to modify the BottlerocketShadow custom resource for any other node, as a role would be shared by all pods.
 In order to authorize custom resource updates, each DaemonSet pod will utilize [Service Account Token Volume Projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) to receive a token which uniquely identifies that pod.
-Update requests for BottlerocketNode custom resources will be sent to the Brupop controller via a web API, in which the kubernetes TokenReview will be used to validate the token.
+Update requests for BottlerocketShadow custom resources will be sent to the Brupop controller via a web API, in which the kubernetes TokenReview will be used to validate the token.
 The controller will check that the calling pod resides on the node associated with the target custom resource before making the requested update.
 
 In order to handle requests from each Bottlerocket node with high availability, the Brupop controller will need to run with multiple replicas, using leader election to determine which node will be responsible for orchestrating node updates.

--- a/design/brupop-demo.md
+++ b/design/brupop-demo.md
@@ -38,25 +38,25 @@ class:
 
 ---
 
-## `BottlerocketNode` Custom Resource
+## `BottlerocketShadow` Custom Resource
 * k8s uses a declarative API
     * Create objects describing state and add them to the cluster
 * Custom Resources -- Manage your own objects with k8s APIs!
 * Update status of each k8s `Node` running Bottlerocket is tracked in a "shadow" custom resource
-* `BottlerocketNode` or `brn` for short
+* `BottlerocketShadow` or `brs` for short
 
 ---
 
-### `BottlerocketNode` Custom Resource
+### `BottlerocketShadow` Custom Resource
 
-![bg 90% 60%](./brn-resource.png)
+![bg 90% 60%](./brs-resource.png)
 
 ---
 
 ## *`controller`* Component
 * All state derived from k8s API during each loop
-* Uses the `status` of all `brn`s to determine state
-* Sets `spec` of `brn`s to drive updates
+* Uses the `status` of all `brs`s to determine state
+* Sets `spec` of `brs`s to drive updates
 * One update at a time (for now)
 
 ---
@@ -65,24 +65,24 @@ class:
 * k8s `watch` functionality
     * Long-polling to get all updates to an object or list of objects
     * Controller runtimes (like `kube-rs`) provide abstractions to squash `watch` events into a cache
-* The controller uses a `watch` + `Store<BottlerocketNode>`
-    * Efficiently keep a up-to-date reference to all `brn` in memory
+* The controller uses a `watch` + `Store<BottlerocketShadow>`
+    * Efficiently keep a up-to-date reference to all `brs` in memory
 
 ---
 
 ## *`controller`* Component
 * Control Loop:
-    * Use in-memory cache to determine *active* `brn` set
-    * Check to see if active `brn` have reached desired state
+    * Use in-memory cache to determine *active* `brs` set
+    * Check to see if active `brs` have reached desired state
     * Any that have get the next state in `spec`
-    * If no active `brn`, check inactive for any which are ready to update and *activate* one by pushing it forward
+    * If no active `brs`, check inactive for any which are ready to update and *activate* one by pushing it forward
 
 ---
 
 ## *`agent`* Component
 * All state derived from k8s & Bottlerocket APIs
-* Gathers OS info & updates `brn.status`
-* Uses `brn.spec` to decide when to update
+* Gathers OS info & updates `brs.status`
+* Uses `brs.spec` to decide when to update
 * Drain k8s Pods & cordon Node prior to reboot
 
 ![](./state-diagram.png)
@@ -91,11 +91,11 @@ class:
 
 ## *`agent`* Component
 * Control Loop
-    * Create shadow `brn` object if needed
+    * Create shadow `brs` object if needed
     * Check current `spec` and `status`
     * If they differ, perform needed action to move forward
     * Gather update information from Bottlerocket API
-    * Update `brn` object with current `status`
+    * Update `brs` object with current `status`
 
 
 ---
@@ -103,7 +103,7 @@ class:
 ## *`apiserver`* Component
 * k8s uses role-based authN/authZ
 * All brupop `agent`s have the same role
-    * This means they can modify `brn` objects for other nodes!
-* Solution: channel `brn` writes through a priveleged web API
+    * This means they can modify `brs` objects for other nodes!
+* Solution: channel `brs` writes through a priveleged web API
 * guarantees requests are coming from the associated k8s `Node` using k8s `token` API
 * Only the `agent`s consume the `apiserver`

--- a/models/src/agent.rs
+++ b/models/src/agent.rs
@@ -57,8 +57,8 @@ pub fn agent_cluster_role() -> ClusterRole {
             PolicyRule {
                 api_groups: Some(vec!["brupop.bottlerocket.aws".to_string()]),
                 resources: Some(vec![
-                    "bottlerocketnodes".to_string(),
-                    "bottlerocketnodes/status".to_string(),
+                    "bottlerocketshadows".to_string(),
+                    "bottlerocketshadows/status".to_string(),
                 ]),
                 verbs: vec!["get", "list", "watch"]
                     .iter()

--- a/models/src/node/error.rs
+++ b/models/src/node/error.rs
@@ -1,4 +1,4 @@
-use super::{BottlerocketNode, BottlerocketNodeSelector, BottlerocketNodeState};
+use super::{BottlerocketShadow, BottlerocketShadowSelector, BottlerocketShadowState};
 
 use kube::ResourceExt;
 use snafu::Snafu;
@@ -9,98 +9,100 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[snafu(visibility = "pub")]
 pub enum Error {
     #[snafu(display(
-        "Unable to create BottlerocketNode ({}, {}): '{}'",
+        "Unable to create BottlerocketShadow ({}, {}): '{}'",
         selector.node_name,
         selector.node_uid,
         source
     ))]
-    CreateBottlerocketNode {
+    CreateBottlerocketShadow {
         source: Box<dyn std::error::Error>,
-        selector: BottlerocketNodeSelector,
+        selector: BottlerocketShadowSelector,
     },
 
     #[snafu(display(
-        "Unable to update BottlerocketNode status ({}, {}): '{}'",
+        "Unable to update BottlerocketShadow status ({}, {}): '{}'",
         selector.node_name,
         selector.node_uid,
         source
     ))]
-    UpdateBottlerocketNodeStatus {
+    UpdateBottlerocketShadowStatus {
         source: Box<dyn std::error::Error>,
-        selector: BottlerocketNodeSelector,
+        selector: BottlerocketShadowSelector,
     },
 
     #[snafu(display(
-        "Unable to update BottlerocketNode spec ({}, {}): '{}'",
+        "Unable to update BottlerocketShadow spec ({}, {}): '{}'",
         selector.node_name,
         selector.node_uid,
         source
     ))]
-    UpdateBottlerocketNodeSpec {
+    UpdateBottlerocketShadowSpec {
         source: Box<dyn std::error::Error>,
-        selector: BottlerocketNodeSelector,
+        selector: BottlerocketShadowSelector,
     },
 
     #[snafu(display(
-        "Unable to cordon BottlerocketNode ({}, {}): '{}'",
+        "Unable to cordon BottlerocketShadow ({}, {}): '{}'",
         selector.node_name,
         selector.node_uid,
         source
     ))]
-    CordonBottlerocketNode {
+    CordonBottlerocketShadow {
         source: Box<dyn std::error::Error>,
-        selector: BottlerocketNodeSelector,
+        selector: BottlerocketShadowSelector,
     },
 
     #[snafu(display(
-        "Unable to drain BottlerocketNode ({}, {}): '{}'",
+        "Unable to drain BottlerocketShadow ({}, {}): '{}'",
         selector.node_name,
         selector.node_uid,
         source
     ))]
-    DrainBottlerocketNode {
+    DrainBottlerocketShadow {
         source: Box<dyn std::error::Error>,
-        selector: BottlerocketNodeSelector,
+        selector: BottlerocketShadowSelector,
     },
 
     #[snafu(display(
-        "Unable to uncordon BottlerocketNode ({}, {}): '{}'",
+        "Unable to uncordon BottlerocketShadow ({}, {}): '{}'",
         selector.node_name,
         selector.node_uid,
         source
     ))]
-    UncordonBottlerocketNode {
+    UncordonBottlerocketShadow {
         source: Box<dyn std::error::Error>,
-        selector: BottlerocketNodeSelector,
+        selector: BottlerocketShadowSelector,
     },
 
     #[snafu(display(
-        "BottlerocketNode does not have a k8s spec ({}, {}).'",
+        "BottlerocketShadow does not have a k8s spec ({}, {}).'",
         selector.node_name,
         selector.node_uid
     ))]
-    NodeWithoutSpec { selector: BottlerocketNodeSelector },
+    NodeWithoutSpec {
+        selector: BottlerocketShadowSelector,
+    },
 
     #[snafu(display("Unable to create patch to send to Kubernetes API: '{}'", source))]
     CreateK8SPatch { source: serde_json::error::Error },
 
     #[snafu(display("Attempted to progress node state machine without achieving current desired state. Current state: '{:?}'. Desired state: '{:?}'", current_state, desired_state))]
     NodeSpecNotAchieved {
-        current_state: BottlerocketNodeState,
-        desired_state: BottlerocketNodeState,
+        current_state: BottlerocketShadowState,
+        desired_state: BottlerocketShadowState,
     },
 
     #[snafu(display(
         "Attempted to perform an operation on a statusless node ({}) which requires a status.",
-        brn.metadata.name.as_ref().unwrap_or(&"<no name set>".to_string())
+        brs.metadata.name.as_ref().unwrap_or(&"<no name set>".to_string())
     ))]
-    NodeWithoutStatus { brn: BottlerocketNode },
+    NodeWithoutStatus { brs: BottlerocketShadow },
 
-    #[snafu(display("BottlerocketNode object ('{}') is missing a reference to the owning Node.", brn.name()))]
-    MissingOwnerReference { brn: BottlerocketNode },
+    #[snafu(display("BottlerocketShadow object ('{}') is missing a reference to the owning Node.", brs.name()))]
+    MissingOwnerReference { brs: BottlerocketShadow },
 
     #[snafu(display(
-        "BottlerocketNode object must have valid rfc3339 timestamp: '{}'",
+        "BottlerocketShadow object must have valid rfc3339 timestamp: '{}'",
         source
     ))]
     TimestampFormat { source: chrono::ParseError },

--- a/yamlgen/build.rs
+++ b/yamlgen/build.rs
@@ -20,7 +20,7 @@ use models::{
         controller_service, controller_service_account,
     },
     namespace::brupop_namespace,
-    node::BottlerocketNode,
+    node::BottlerocketShadow,
 };
 use std::env;
 use std::fs::File;
@@ -45,7 +45,7 @@ fn main() {
 
     // testsys-crd related K8S manifest
     brupop_resources.write_all(HEADER.as_bytes()).unwrap();
-    serde_yaml::to_writer(&brupop_resources, &BottlerocketNode::crd()).unwrap();
+    serde_yaml::to_writer(&brupop_resources, &BottlerocketShadow::crd()).unwrap();
 
     let brupop_image = env::var("BRUPOP_CONTAINER_IMAGE").ok().unwrap();
     let brupop_image_pull_secrets = env::var("BRUPOP_CONTAINER_IMAGE_PULL_SECRET").ok();

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -3,16 +3,16 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: bottlerocketnodes.brupop.bottlerocket.aws
+  name: bottlerocketshadows.brupop.bottlerocket.aws
 spec:
   group: brupop.bottlerocket.aws
   names:
     categories: []
-    kind: BottlerocketNode
-    plural: bottlerocketnodes
+    kind: BottlerocketShadow
+    plural: bottlerocketshadows
     shortNames:
-      - brn
-    singular: bottlerocketnode
+      - brs
+    singular: bottlerocketshadow
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
@@ -31,13 +31,13 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: "Auto-generated derived type for BottlerocketNodeSpec via `CustomResource`"
+          description: "Auto-generated derived type for BottlerocketShadowSpec via `CustomResource`"
           properties:
             spec:
-              description: "The `BottlerocketNodeSpec` can be used to drive a node through the update state machine. A node linearly drives towards the desired state. The brupop controller updates the spec to specify a node's desired state, and the host agent drives state changes forward and updates the `BottlerocketNodeStatus`."
+              description: "The `BottlerocketShadowSpec` can be used to drive a node through the update state machine. A node linearly drives towards the desired state. The brupop controller updates the spec to specify a node's desired state, and the host agent drives state changes forward and updates the `BottlerocketShadowStatus`."
               properties:
                 state:
-                  description: "Records the desired state of the `BottlerocketNode`"
+                  description: "Records the desired state of the `BottlerocketShadow`"
                   enum:
                     - Idle
                     - StagedUpdate
@@ -58,11 +58,11 @@ spec:
                 - state
               type: object
             status:
-              description: "`BottlerocketNodeStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent, while the spec is updated by the brupop controller."
+              description: "`BottlerocketShadowStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent, while the spec is updated by the brupop controller."
               nullable: true
               properties:
                 current_state:
-                  description: "BottlerocketNodeState represents a node's state in the update state machine."
+                  description: "BottlerocketShadowState represents a node's state in the update state machine."
                   enum:
                     - Idle
                     - StagedUpdate
@@ -83,7 +83,7 @@ spec:
               type: object
           required:
             - spec
-          title: BottlerocketNode
+          title: BottlerocketShadow
           type: object
       served: true
       storage: true
@@ -114,8 +114,8 @@ rules:
   - apiGroups:
       - brupop.bottlerocket.aws
     resources:
-      - bottlerocketnodes
-      - bottlerocketnodes/status
+      - bottlerocketshadows
+      - bottlerocketshadows/status
     verbs:
       - create
       - get
@@ -287,8 +287,8 @@ rules:
   - apiGroups:
       - brupop.bottlerocket.aws
     resources:
-      - bottlerocketnodes
-      - bottlerocketnodes/status
+      - bottlerocketshadows
+      - bottlerocketshadows/status
     verbs:
       - get
       - list
@@ -407,8 +407,8 @@ rules:
   - apiGroups:
       - brupop.bottlerocket.aws
     resources:
-      - bottlerocketnodes
-      - bottlerocketnodes/status
+      - bottlerocketshadows
+      - bottlerocketshadows/status
     verbs:
       - get
       - list
@@ -416,7 +416,7 @@ rules:
   - apiGroups:
       - brupop.bottlerocket.aws
     resources:
-      - bottlerocketnodes
+      - bottlerocketshadows
     verbs:
       - create
       - patch


### PR DESCRIPTION
rename custom recource BottlerocketNode 'brn' to BottlerocketShadow
brs for avoiding colliding with k8s abstraction names

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#122

**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Wed Jan 26 23:37:06 2022 +0000

    rename brn custom resource to BottlerocketShadow and brs

    rename custom recource BottlerocketNode 'brn' to BottlerocketShadow
    brs for avoiding colliding with k8s abstraction names
```


**Testing done:**
Brupop integration test
```
[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get pods
NAME                                           READY   STATUS    RESTARTS   AGE
brupop-agent-pt54z                             1/1     Running   2          16m
brupop-agent-sqgck                             1/1     Running   1          16m
brupop-agent-zlqrl                             1/1     Running   1          16m
brupop-apiserver-677496b7c4-66nfq              1/1     Running   0          5m
brupop-apiserver-677496b7c4-llfgv              1/1     Running   0          10m
brupop-apiserver-677496b7c4-t6bx6              1/1     Running   0          5m
brupop-controller-deployment-dbb96dcdd-jm4vp   1/1     Running   0          10m

kubectl -n brupop-bottlerocket-aws get brs
NAME                                                STATE   VERSION   TARGET STATE   TARGET VERSION
brs-ip-192-168-129-124.us-west-2.compute.internal   Idle    1.5.3     Idle
brs-ip-192-168-135-177.us-west-2.compute.internal   Idle    1.5.3     Idle
brs-ip-192-168-142-107.us-west-2.compute.internal   Idle    1.5.3     Idle
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
