### PR TITLE
Refactor agent run to support crash loop handle

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -83,7 +83,7 @@ async fn run_agent() -> Result<()> {
             futures::future::ready(())
         });
 
-    let mut agent = BrupopAgent::new(
+    let agent = BrupopAgent::new(
         k8s_client.clone(),
         apiserver_client,
         brs_reader,


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**



**Description of changes:**
Refactor the agent run method with a wrapper over Bottlerocket Update API call for later support crash loop handle. Changes include:
* Make agent readonly
* Abstract few methods in run()

**Testing done:**
Provisioned two hosts with old bottlerocket version and installed Brupop. Monitored the update on the hosts.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
