### PR TITLE
Add reset algorithm to better handle crash loop.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ name = "controller"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "chrono",
  "futures",
  "http",
  "k8s-openapi",

--- a/apiserver/src/api/node.rs
+++ b/apiserver/src/api/node.rs
@@ -132,6 +132,8 @@ mod tests {
             Version::new(1, 2, 1),
             Version::new(1, 3, 0),
             BottlerocketShadowState::default(),
+            0,
+            None,
         );
 
         let settings = test_settings(|node_client| {

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 actix-web = { version = "4.0.0-beta.9", default-features = false }
+chrono = "0.4"
 futures = "0.3"
 http = "0.2.5"
 # k8s-openapi must match the version required by kube and enable a k8s version feature

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -28,6 +28,9 @@ spec:
         - jsonPath: ".spec.version"
           name: Target Version
           type: string
+        - jsonPath: ".status.crash_count"
+          name: Crash Count
+          type: string
       name: v1
       schema:
         openAPIV3Schema:
@@ -44,6 +47,7 @@ spec:
                     - PerformedUpdate
                     - RebootedIntoUpdate
                     - MonitoringUpdate
+                    - ErrorReset
                   type: string
                 state_transition_timestamp:
                   description: The time at which the most recent state was set as the desired state.
@@ -61,6 +65,10 @@ spec:
               description: "`BottlerocketShadowStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent, while the spec is updated by the brupop controller."
               nullable: true
               properties:
+                crash_count:
+                  format: uint32
+                  minimum: 0.0
+                  type: integer
                 current_state:
                   description: "BottlerocketShadowState represents a node's state in the update state machine."
                   enum:
@@ -69,14 +77,19 @@ spec:
                     - PerformedUpdate
                     - RebootedIntoUpdate
                     - MonitoringUpdate
+                    - ErrorReset
                   type: string
                 current_version:
                   pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+                  type: string
+                state_transition_failure_timestamp:
+                  nullable: true
                   type: string
                 target_version:
                   pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
                   type: string
               required:
+                - crash_count
                 - current_state
                 - current_version
                 - target_version


### PR DESCRIPTION
Exponential backoff in retry with ~24 hours counter reset to prevent
the agent crashes infinitely. With each retry starting in Idle state,
this algorithm allows the agent to fetch the latest Bottlerocket for
each retry. By waiting the agent going back to Idle for recovery, this
algorithm prevents the controller brown out the cluster.

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#123 


**Description of changes:**
* The agent shall signal that it has encountered an error while attempting a state transition before crashing by setting its state to ErrorReset.
* When the controller progress node, if the controller detects that the agent has crashed, it shall set the spec state to Idle, record the current time as a timestamp variable in Bottlerocket update circle, increment the crash_count variable and emit failure metrics. The controller shall wait for the agent to uncordon the node if needed and set state to Idle before moving forward.
* When find_and_update_ready_node, the controller shall tend to find and update nodes with lower crash_count.
* When progress a node crashed before, the controller shall treat the node as usual node if it has reached 2^crash_count seconds since the first crash. Otherwise, the controller shall check if it reached 24 hours for reset. If it has been more than 24 hours since the first crash, the controller shall reset crash_count to 0 and crash timestamp to None, then treat the node as usual node. Otherwise the controller shall skip.
* When the agent restarts, if the state is ErrorReset and spec is Idle, the agent shall uncordon the node based on the recorded previous state, and set the current status to Idle, else the agent shall try to process as usual.
* Upon a successful Bottlerocket update circle, the crash_count variable shall be reset to 0 and crash time stamp shall be set to None.


**Testing done:**
#### Without crash
Provisioned 3 old hosts with Brupop installed, monitored cluster's update.

#### With crash
Intentionally make `update()` error to make sure StagedUpdate->PerformedUpdate always fails. Montoring the cluster to confirm the following feature:
* Agent set the status to ErrorReset when something failed
* Controller guide the agent to recover
* Controller tend to pick the node with lower crash time
* Controller retry using exponential backoff

#### Not covered in test
* Controller reset the crash ~24 hours since the first crash.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
