### PR TITLE
update agent permission

### DIFF
--- a/models/src/agent.rs
+++ b/models/src/agent.rs
@@ -6,8 +6,9 @@ use k8s_openapi::api::apps::v1::{DaemonSet, DaemonSetSpec};
 use k8s_openapi::api::core::v1::{
     Affinity, Container, EnvVar, EnvVarSource, HostPathVolumeSource, LocalObjectReference,
     NodeAffinity, NodeSelector, NodeSelectorRequirement, NodeSelectorTerm, ObjectFieldSelector,
-    PodSpec, PodTemplateSpec, ProjectedVolumeSource, ResourceRequirements, SecurityContext,
-    ServiceAccount, ServiceAccountTokenProjection, Volume, VolumeMount, VolumeProjection,
+    PodSpec, PodTemplateSpec, ProjectedVolumeSource, ResourceRequirements, SELinuxOptions,
+    SecurityContext, ServiceAccount, ServiceAccountTokenProjection, Volume, VolumeMount,
+    VolumeProjection,
 };
 use k8s_openapi::api::rbac::v1::{ClusterRole, ClusterRoleBinding, PolicyRule, RoleRef, Subject};
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
@@ -207,7 +208,12 @@ pub fn agent_daemonset(agent_image: String, image_pull_secret: Option<String>) -
                             },
                         ]),
                         security_context: Some(SecurityContext {
-                            privileged: Some(true),
+                            se_linux_options: Some(SELinuxOptions {
+                                role: Some("system_r".to_string()),
+                                type_: Some("super_t".to_string()),
+                                user: Some("system_u".to_string()),
+                                level: Some("s0".to_string()),
+                            }),
                             ..Default::default()
                         }),
                         ..Default::default()

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -361,7 +361,11 @@ spec:
               cpu: 10m
               memory: 50Mi
           securityContext:
-            privileged: true
+            seLinuxOptions:
+              level: s0
+              role: system_r
+              type: super_t
+              user: system_u
           volumeMounts:
             - mountPath: /run/api.sock
               name: bottlerocket-api-socket


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Update needed permissions on agent


**Testing done:**
integration test 
```
[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get pods
NAME                                            READY   STATUS    RESTARTS   AGE
brupop-agent-7x6hf                              1/1     Running   2          22m
brupop-agent-cns7q                              1/1     Running   2          22m
brupop-agent-n722x                              1/1     Running   1          22m
brupop-apiserver-65679d5c85-5j66t               1/1     Running   0          16m
brupop-apiserver-65679d5c85-7stfb               1/1     Running   0          16m
brupop-apiserver-65679d5c85-mjdcq               1/1     Running   0          11m
brupop-controller-deployment-8545559bc7-h2j5w   1/1     Running   0          11m
[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ kubectl -n brupop-bottlerocket-aws get brs
NAME                                                STATE   VERSION   TARGET STATE   TARGET VERSION
brs-ip-192-168-141-207.us-west-2.compute.internal   Idle    1.6.1     Idle
brs-ip-192-168-145-126.us-west-2.compute.internal   Idle    1.6.1     Idle
brs-ip-192-168-152-18.us-west-2.compute.internal    Idle    1.6.1     Idle
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
