### PR TITLE
Use versioned links for installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ Updates to Bottlerocket are rolled out in [waves](https://github.com/bottlerocke
 
 ### Installation
 
-We can install the Bottlerocket update operator using the recommended configuration defined in [bottlerocket-update-operator.yaml](./bottlerocket-update-operator.yaml):
+We can install the Bottlerocket update operator using the recommended configuration defined in [bottlerocket-update-operator.yaml](https://github.com/bottlerocket-os/bottlerocket-update-operator/blob/v0.2.0/yamlgen/deploy/bottlerocket-update-operator.yaml):
 
 ```sh
 kubectl apply -f ./bottlerocket-update-operator.yaml
 ```
 
 This will create the required namespace, custom resource definition, roles, deployments, etc., and use the latest update operator image available in [Amazon ECR Public](https://gallery.ecr.aws/bottlerocket/bottlerocket-update-operator).
+
+Note: The above link is set to use the configuration for the latest version of the Update Operator, `v0.2.0`.
+Be sure to use the git tag for the Update Operator release that you plan to deploy.
 
 ### Label nodes
 
@@ -184,7 +187,7 @@ Example regional image URI:
 
 ## Troubleshooting
 
-When installed with the [default deployment](./bottlerocket-update-operator.yaml), the logs can be fetched through Kubernetes deployment logs.
+When installed with the [default deployment](https://github.com/bottlerocket-os/bottlerocket-update-operator/blob/v0.2.0/yamlgen/deploy/bottlerocket-update-operator.yaml), the logs can be fetched through Kubernetes deployment logs.
 Because mutations to a node are orchestrated through the API server component, searching those deployment logs for a node ID can be useful.
 To get logs for the API server, run the following:
 


### PR DESCRIPTION
**Issue number:** #179 



**Description of changes:** Doc change. This uses a versioned link to Brupop's YAML documents for installation instructions, which should prevent issues of pulling mismatched CRD definitions from the latest released version of Brupop.




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
