### PR TITLE
Improve Integration-test to support testing to test with pods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1471,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "structopt",
+ "strum_macros",
  "tokio",
  "tokio-retry",
  "uuid",
@@ -2354,6 +2361,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,10 +2677,23 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -33,8 +33,10 @@ skip-tree = [
     { name = "actix-http", version = "3.0.0-beta.10" },
     # chrono uses an older version of time, which clashes with the one used by actix-web.
     { name = "chrono", version = "0.4.19" },
-    # clap uses an older version or strsim, which clashed with the one used by darling_core.
+    # clap uses an older version of strsim, which clashed with the one used by darling_core.
     { name = "clap", version = "2.34.0" },
+    # structopt-derive uses an older version of heck, which clashed with the one used by strum_macros.
+    { name = "structopt-derive", version = "0.4.18"},
 ]
 
 [sources]

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 snafu = "0.6"
 structopt = "0.3.17"
+strum_macros = "0.24.0"
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-retry = "0.3"
 uuid = { version = "0.8", default-features = false, features = ["serde", "v4"] }

--- a/integ/src/pods-template.yaml
+++ b/integ/src/pods-template.yaml
@@ -1,0 +1,80 @@
+# statefulset pods - the example from kubernetes document
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+  - port: 80
+    name: web-test
+  clusterIP: None
+  selector:
+    app: nginx
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web-test
+spec:
+  serviceName: nginx
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: k8s.gcr.io/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web-test
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      accessModes: [ ReadWriteOnce ]
+      resources:
+        requests:
+          storage: 1Gi
+# Stateless nginx pod
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-test
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+# pod disruption budget
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: pod-disruption-budget-test
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: nginx


### PR DESCRIPTION
support integration-test to be able to test with stateful set pods,
stateless nginx pods, and pods with PodDisruptionBudget.

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#182 


**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Thu Apr 7 00:15:02 2022 +0000

    Improve Integration-test to support testing to test with pods

    support integration-test to be able to test with stateful set pods,
    stateless nginx pods, and pods with PodDisruptionBudget.
```


**Testing done:**
Brupop test

```
NAME                          READY   STATUS    RESTARTS   AGE
nginx-test-5d59d67564-25rl2   1/1     Running   0          12m
nginx-test-5d59d67564-7jtx8   1/1     Running   0          12m
nginx-test-5d59d67564-9djrn   1/1     Running   0          17m
nginx-test-5d59d67564-czl7r   1/1     Running   0          17m
nginx-test-5d59d67564-ftf2h   1/1     Running   0          12m
web-test-0                    1/1     Running   0          17m
web-test-1                    1/1     Running   0          12m
web-test-2                    1/1     Running   0          11m
```
```
NAME                         MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
pod-disruption-budget-test   2               N/A               6                     24m
```

```
NAME                                                STATE   VERSION   TARGET STATE   TARGET VERSION   CRASH COUNT
brs-ip-192-168-128-120.us-west-2.compute.internal   Idle    1.7.0     Idle                            0
brs-ip-192-168-152-67.us-west-2.compute.internal    Idle    1.7.0     Idle                            0
brs-ip-192-168-153-59.us-west-2.compute.internal    Idle    1.7.0     Idle                            0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
