### PR TITLE
add Dist in Makefile to save brupop image to tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ UNAME_ARCH = $(shell uname -m)
 # ARCH is the target architecture which is being built for.
 ARCH = $(lastword $(subst :, ,$(filter $(UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
 
+# DESTDIR is where the release artifacts will be written.
+DESTDIR = .
+# DISTFILE is the path to the dist target's output file - the container image
+# tarball.
+DISTFILE = $(DESTDIR:/=)/$(subst /,_,$(IMAGE_NAME)).tar.gz
+
 BOTTLEROCKET_SDK_VERSION = v0.25.1
 BOTTLEROCKET_SDK_ARCH = $(UNAME_ARCH)
 
@@ -61,5 +67,10 @@ brupop-image: fetch check-licenses
 		--network none \
 		-f Dockerfile .
 
+dist: brupop-image
+	@mkdir -p $(dir $(DISTFILE))
+	docker save $(IMAGE_NAME) | gzip > '$(DISTFILE)'
+
 clean:
 	-rm -rf target
+	rm -f -- '$(DISTFILE)'


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
`dist` can help on saving brupop docker image to tarball file automatically. 


**Testing done:**
run `make dist`

```
[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ ls
agent                                                          Cargo.toml          controller  integ           README.md
apiserver                                                      CHANGELOG.md        COPYRIGHT   LICENSE-APACHE  SECURITY.md
bottlerocket-update-operator-amd64:v0.2.0-4022737e-dev.tar.gz.  ....
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
