### PR TITLE
fix integ test missing subnet and sg bug

### DIFF
--- a/integ/src/eks_provider.rs
+++ b/integ/src/eks_provider.rs
@@ -229,7 +229,7 @@ impl SubnetType {
             SubnetType::Public => "Public",
             SubnetType::Private => "Private",
         };
-        format!("eksctl-{}-cluster/Subnet{}*", cluster_name, subnet_type)
+        format!("eksctl-{}-cluster*{}*", cluster_name, subnet_type)
     }
 }
 
@@ -270,7 +270,7 @@ impl SecurityGroupType {
             SecurityGroupType::ClusterShared => "ClusterSharedNodeSecurityGroup",
             SecurityGroupType::ControlPlane => "ControlPlaneSecurityGroup",
         };
-        format!("*{}-{}*", cluster_name, sg)
+        format!("*{}*{}*", cluster_name, sg)
     }
 }
 


### PR DESCRIPTION
subnet and sg have different format, so currently integration test
doesn't handle all of them. So it will cause missing subnet or sg issue.
Updates integration test to handle all format and fix this issue.

**Description of changes:**
Subnet has different formats like `eksctl-{}-cluster/SubnetPublic` and  `eksctl-{}-cluster/PublicSubnet`.
SG has different formats like `eksctl-{}-nodegroup` and `eksctl-{}-cluster/nodegroup`.

Updating integration test to handle different formats subnet and SG, which can prevent missing subnet and sg issue.

**Testing done:**
Test with brupop release account Ipv6 and ipv4 cluster

Ipv6
```
NAME                                                STATE                VERSION   TARGET STATE       TARGET VERSION
brs-ip-192-168-129-171.us-west-2.compute.internal   Idle                 1.7.0     Idle               1.7.0
brs-ip-192-168-132-209.us-west-2.compute.internal   RebootedIntoUpdate   1.7.0     MonitoringUpdate   1.7.0
brs-ip-192-168-136-46.us-west-2.compute.internal    Idle                 1.7.0     Idle
```

ipv4
```
NAME                                               STATE   VERSION   TARGET STATE   TARGET VERSION
brs-ip-192-168-147-2.us-west-2.compute.internal    Idle    1.7.0     Idle
brs-ip-192-168-147-47.us-west-2.compute.internal   Idle    1.7.0     Idle
brs-ip-192-168-159-48.us-west-2.compute.internal   Idle    1.7.0     Idle
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
