### PR TITLE
add integration test readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Then run the following to regenerate the `.yaml` resource definitions:
 cargo build -p yamlgen
 ```
 
-These can of course be deployed using `kubectl apply` or the `cargo run --bin integ` for the integration testing tool.
+These can of course be deployed using `kubectl apply` or the automatic integration testing tool [integ](https://github.com/bottlerocket-os/bottlerocket-update-operator/tree/develop/integ).
 
 ## Security
 

--- a/integ/src/README.md
+++ b/integ/src/README.md
@@ -1,0 +1,26 @@
+# Brupop Integration Test
+
+## Introduction
+Integration test is a tool that helps build automated brupop integration testing, which consists of three main subcommands *Integration-test*, *Monitor*, *and Clean*.
+
+### Integration-test subcommand
+
+This allows you to set up Brupop test environment, complete Brupop installation, and label nodes.
+
+```
+cargo run --bin integ integration-test --cluster-name <YOUR_CLUSTER_NAME> --region <YOUR_CLUSTER_REGION> --bottlerocket-version <OLD_BOTTLEROCKET_VERSION>  --arch <ARCH> --nodegroup-name <NODEGROUP_NAME>
+```
+
+### Monitor subcommand
+This allows you to verify if that nodes are being updated to target Bottlerocket version
+
+```
+cargo run --bin integ monitor --cluster-name <YOUR_CLUSTER> --region <YOUR_CLUSTER_REGION>
+```
+
+### Clean subcommand
+This allows you to destroy all resources which were created when integration test installed brupop.
+
+```
+cargo run --bin integ clean --cluster-name <YOUR_CLUSTER_NAME> --region <YOUR_CLUSTER_REGION> --nodegroup-name <NODEGROUP_NAME>
+```


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#166

**Description of changes:**
add integration test readme file


**Testing done:**
# Brupop Integration Test

## Introduction
Integration test is a tool that helps build automated brupop integration testing, which consists of three main subcommands *Integration-test*, *Monitor*, *and Clean*.

### Integration-test subcommand

This allows you to set up Brupop test environment, complete Brupop installation, and label nodes.

```
cargo run --bin integ integration-test --cluster-name <YOUR_CLUSTER_NAME> --region <YOUR_CLUSTER_REGION> --bottlerocket-version <OLD_BOTTLEROCKET_VERSION>  --arch <ARCH> --nodegroup-name <NODEGROUP_NAME>
```

### Monitor subcommand
This allows you to verify if that nodes are being updated to target Bottlerocket version

```
cargo run --bin integ monitor --cluster-name <YOUR_CLUSTER> --region <YOUR_CLUSTER_REGION>
```

### Clean subcommand
This allows you to destroy all resources which were created when integration test installed brupop.

```
cargo run --bin integ clean --cluster-name <YOUR_CLUSTER_NAME> --region <YOUR_CLUSTER_REGION> --nodegroup-name <NODEGROUP_NAME>
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
