### PR TITLE
Protect controller from becoming unschedulable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,6 +844,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
  "prometheus",
+ "semver 1.0.4",
  "serde_plain",
  "snafu",
  "tokio",

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -10,6 +10,7 @@ actix-web = { version = "4.0.0-beta.9", default-features = false }
 chrono = "0.4"
 futures = "0.3"
 http = "0.2.5"
+semver = "1.0"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_20"] }
 kube = { version = "0.71.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -4,7 +4,8 @@ use super::{
     statemachine::determine_next_node_spec,
 };
 use models::node::{
-    BottlerocketShadow, BottlerocketShadowClient, BottlerocketShadowState, Selector,
+    brs_name_from_node_name, BottlerocketShadow, BottlerocketShadowClient, BottlerocketShadowState,
+    Selector,
 };
 
 use kube::runtime::reflector::Store;
@@ -12,6 +13,7 @@ use kube::ResourceExt;
 use opentelemetry::global;
 use snafu::ResultExt;
 use std::collections::{BTreeMap, HashMap};
+use std::env;
 use tokio::time::{sleep, Duration};
 use tracing::{event, instrument, Level};
 
@@ -104,16 +106,16 @@ impl<T: BottlerocketShadowClient> BrupopController<T> {
     /// The state transition is then attempted. If successful, this node should be detected as part of the active
     /// set during the next iteration of the controller's event loop.
     #[instrument(skip(self))]
-    async fn find_and_update_ready_node(&self) -> Option<BottlerocketShadow> {
+    async fn find_and_update_ready_node(&self) -> Result<Option<BottlerocketShadow>> {
         let mut shadows: Vec<BottlerocketShadow> = self.all_nodes();
 
-        shadows.sort_by(|a, b| a.compare_crash_count(b));
-        for brs in shadows {
+        sort_shadows(&mut shadows, &get_associated_bottlerocketshadow_name()?);
+        for brs in shadows.drain(..) {
             // If we determine that the spec should change, this node is a candidate to begin updating.
             let next_spec = determine_next_node_spec(&brs);
             if next_spec != brs.spec {
                 match self.progress_node(brs.clone()).await {
-                    Ok(_) => return Some(brs),
+                    Ok(_) => return Ok(Some(brs)),
                     Err(_) => {
                         // Errors connecting to the k8s API are ignored (and also logged by `progress_node()`).
                         // We'll just move on and try a different node.
@@ -122,7 +124,7 @@ impl<T: BottlerocketShadowClient> BrupopController<T> {
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     #[instrument(skip(self))]
@@ -189,7 +191,7 @@ impl<T: BottlerocketShadowClient> BrupopController<T> {
                 }
             } else {
                 // If there's nothing to operate on, check to see if any other nodes are ready for action.
-                let new_active_node = self.find_and_update_ready_node().await;
+                let new_active_node = self.find_and_update_ready_node().await?;
                 if let Some(brs) = new_active_node {
                     event!(Level::INFO, name = %brs.name(), "Began updating new node.")
                 }
@@ -201,5 +203,188 @@ impl<T: BottlerocketShadowClient> BrupopController<T> {
             // Sleep until it's time to check for more action.
             sleep(ACTION_INTERVAL).await;
         }
+    }
+}
+
+// Get node and BottlerocketShadow names
+#[instrument]
+fn get_associated_bottlerocketshadow_name() -> Result<String> {
+    let associated_node_name = env::var("MY_NODE_NAME").context(error::GetNodeName)?;
+    let associated_bottlerocketshadow_name = brs_name_from_node_name(&associated_node_name);
+
+    event!(
+        Level::INFO,
+        ?associated_bottlerocketshadow_name,
+        "Found associated bottlerocketshadow name."
+    );
+
+    Ok(associated_bottlerocketshadow_name)
+}
+
+/// sort shadows list which uses to determine the order of node update
+/// logic1: sort shadows by crash count
+/// logic2: move the shadow which associated bottlerocketshadow node hosts controller pod to the last
+#[instrument(skip())]
+fn sort_shadows(shadows: &mut Vec<BottlerocketShadow>, associated_brs_name: &str) {
+    // sort shadows by crash count
+    shadows.sort_by(|a, b| a.compare_crash_count(b));
+
+    // move the shadow which associated bottlerocketshadow node hosts controller pod to the last
+    // Step1: find associated brs node position
+    let associated_brs_node_position = shadows
+        .iter()
+        .position(|brs| brs.metadata.name.as_ref() == Some(&associated_brs_name.to_string()));
+
+    // Step2: move associated brs node to the last
+    // if it doesn't find the brs, it means some brss aren't ready and the program should skip sort.
+    match associated_brs_node_position {
+        Some(position) => {
+            let last_brs = shadows[position].clone();
+            shadows.remove(position.clone());
+            shadows.push(last_brs);
+        }
+        None => {
+            event!(
+                Level::INFO,
+                "Unable to find associated bottlerocketshadow, skip sort."
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use semver::Version;
+    use std::str::FromStr;
+
+    use kube::api::ObjectMeta;
+
+    use models::node::{BottlerocketShadow, BottlerocketShadowState, BottlerocketShadowStatus};
+
+    pub(crate) fn fake_shadow(
+        name: String,
+        current_version: String,
+        target_version: String,
+        current_state: BottlerocketShadowState,
+    ) -> BottlerocketShadow {
+        BottlerocketShadow {
+            status: Some(BottlerocketShadowStatus::new(
+                Version::from_str(&current_version).unwrap(),
+                Version::from_str(&target_version).unwrap(),
+                current_state,
+                0,
+                Some(Utc.ymd(2022, 1, 1).and_hms_milli(0, 0, 1, 444)),
+            )),
+            metadata: ObjectMeta {
+                name: Some(name),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sort_shadows_find_brs() {
+        let mut test_shadows = vec![
+            fake_shadow(
+                "brs-ip-1.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+            fake_shadow(
+                "brs-ip-2.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+            fake_shadow(
+                "brs-ip-3.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+        ];
+
+        let associated_brs_name = "brs-ip-1.us-west-2.compute.internal";
+
+        let expected_result = vec![
+            fake_shadow(
+                "brs-ip-2.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+            fake_shadow(
+                "brs-ip-3.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+            fake_shadow(
+                "brs-ip-1.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+        ];
+
+        sort_shadows(&mut test_shadows, associated_brs_name);
+
+        assert_eq!(test_shadows, expected_result);
+    }
+
+    /// test when it doesn't find the brs (some brss aren't ready), the program should skip sort.
+    #[tokio::test]
+    async fn test_sort_shadows_not_find_brs() {
+        let mut test_shadows = vec![
+            fake_shadow(
+                "brs-ip-17.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+            fake_shadow(
+                "brs-ip-123.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+            fake_shadow(
+                "brs-ip-321.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+        ];
+
+        let associated_brs_name = "brs-ip-5.us-west-2.compute.internal";
+
+        let expected_result = vec![
+            fake_shadow(
+                "brs-ip-17.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+            fake_shadow(
+                "brs-ip-123.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+            fake_shadow(
+                "brs-ip-321.us-west-2.compute.internal".to_string(),
+                "1.8.0".to_string(),
+                "1.5.0".to_string(),
+                BottlerocketShadowState::Idle,
+            ),
+        ];
+
+        sort_shadows(&mut test_shadows, associated_brs_name);
+
+        assert_eq!(test_shadows, expected_result);
     }
 }

--- a/controller/src/error.rs
+++ b/controller/src/error.rs
@@ -37,4 +37,7 @@ pub enum Error {
 
     #[snafu(display("Controller failed due to internal assertion issue: '{}'", source))]
     Assertion { source: serde_plain::Error },
+
+    #[snafu(display("Unable to get host controller pod node name: {}", source))]
+    GetNodeName { source: std::env::VarError },
 }

--- a/controller/src/statemachine.rs
+++ b/controller/src/statemachine.rs
@@ -38,7 +38,7 @@ pub fn determine_next_node_spec(brs: &BottlerocketShadow) -> BottlerocketShadowS
                         // Or node just start or completed without crashing
                         if node_allowed_to_update(node_status) {
                             BottlerocketShadowSpec::new_starting_now(
-                                BottlerocketShadowState::StagedUpdate,
+                                BottlerocketShadowState::StagedAndPerformedUpdate,
                                 Some(target_version.clone()),
                             )
                         } else {

--- a/integ/src/monitor.rs
+++ b/integ/src/monitor.rs
@@ -469,7 +469,7 @@ pub(crate) mod test {
                             "brs-ip-2.us-west-2.compute.internal".to_string(),
                             "1.6.0".to_string(),
                             "1.5.0".to_string(),
-                            BottlerocketShadowState::StagedUpdate,
+                            BottlerocketShadowState::StagedAndPerformedUpdate,
                         ),
                         fake_shadow(
                             "brs-ip-3.us-west-2.compute.internal".to_string(),
@@ -531,7 +531,7 @@ pub(crate) mod test {
                             "brs-ip-2.us-west-2.compute.internal".to_string(),
                             "1.6.0".to_string(),
                             "1.5.0".to_string(),
-                            BottlerocketShadowState::PerformedUpdate,
+                            BottlerocketShadowState::StagedAndPerformedUpdate,
                         ),
                         fake_shadow(
                             "brs-ip-3.us-west-2.compute.internal".to_string(),

--- a/models/src/constants.rs
+++ b/models/src/constants.rs
@@ -70,3 +70,9 @@ pub const CONTROLLER_DEPLOYMENT_NAME: &str = "brupop-controller-deployment";
 pub const CONTROLLER_SERVICE_NAME: &str = "brupop-controller-server"; // The name for the `svc` fronting the controller.
 pub const CONTROLLER_INTERNAL_PORT: i32 = 8080; // The internal port on which the the controller service is hosted.
 pub const CONTROLLER_SERVICE_PORT: i32 = 80; // The k8s service port hosting the controller service.
+pub const BRUPOP_CONTROLLER_PRIORITY_CLASS: &str = "brupop-controller-high-priority";
+pub const BRUPOP_CONTROLLER_PREEMPTION_POLICY: &str = "Never";
+// We strategically determine the controller priority class value to be one million,
+// since one million presents a high priority value which can enable controller to be scheduled preferentially,
+// but not a critical value which takes precedence over customers' critical k8s resources.
+pub const BRUPOP_CONTROLLER_PRIORITY_VALUE: i32 = 1000000;

--- a/models/src/controller.rs
+++ b/models/src/controller.rs
@@ -1,7 +1,8 @@
 use crate::brupop_labels;
 use crate::constants::{
-    APP_COMPONENT, APP_MANAGED_BY, APP_PART_OF, BRUPOP, BRUPOP_DOMAIN_LIKE_NAME, CONTROLLER,
-    CONTROLLER_DEPLOYMENT_NAME, CONTROLLER_INTERNAL_PORT, CONTROLLER_SERVICE_NAME,
+    APP_COMPONENT, APP_MANAGED_BY, APP_PART_OF, BRUPOP, BRUPOP_CONTROLLER_PREEMPTION_POLICY,
+    BRUPOP_CONTROLLER_PRIORITY_CLASS, BRUPOP_CONTROLLER_PRIORITY_VALUE, BRUPOP_DOMAIN_LIKE_NAME,
+    CONTROLLER, CONTROLLER_DEPLOYMENT_NAME, CONTROLLER_INTERNAL_PORT, CONTROLLER_SERVICE_NAME,
     CONTROLLER_SERVICE_PORT, LABEL_COMPONENT, NAMESPACE,
 };
 use crate::node::{K8S_NODE_PLURAL, K8S_NODE_STATUS};
@@ -12,6 +13,7 @@ use k8s_openapi::api::core::v1::{
     Service, ServiceAccount, ServicePort, ServiceSpec,
 };
 use k8s_openapi::api::rbac::v1::{ClusterRole, ClusterRoleBinding, PolicyRule, RoleRef, Subject};
+use k8s_openapi::api::scheduling::v1::PriorityClass;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::api::ObjectMeta;
@@ -199,6 +201,7 @@ pub fn controller_deployment(
                     }],
                     image_pull_secrets,
                     service_account_name: Some(BRUPOP_CONTROLLER_SERVICE_ACCOUNT.to_string()),
+                    priority_class_name: Some(BRUPOP_CONTROLLER_PRIORITY_CLASS.to_string()),
                     ..Default::default()
                 }),
             },
@@ -226,6 +229,20 @@ pub fn controller_service() -> Service {
             }]),
             ..Default::default()
         }),
+        ..Default::default()
+    }
+}
+
+/// Defines the brupop-controller priority class
+pub fn controller_priority_class() -> PriorityClass {
+    PriorityClass {
+        metadata: ObjectMeta {
+            name: Some(BRUPOP_CONTROLLER_PRIORITY_CLASS.to_string()),
+            namespace: Some(NAMESPACE.to_string()),
+            ..Default::default()
+        },
+        preemption_policy: Some(BRUPOP_CONTROLLER_PREEMPTION_POLICY.to_string()),
+        value: BRUPOP_CONTROLLER_PRIORITY_VALUE,
         ..Default::default()
     }
 }

--- a/models/src/controller.rs
+++ b/models/src/controller.rs
@@ -7,8 +7,9 @@ use crate::constants::{
 use crate::node::{K8S_NODE_PLURAL, K8S_NODE_STATUS};
 use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStrategy};
 use k8s_openapi::api::core::v1::{
-    Affinity, Container, LocalObjectReference, NodeAffinity, NodeSelector, NodeSelectorRequirement,
-    NodeSelectorTerm, PodSpec, PodTemplateSpec, Service, ServiceAccount, ServicePort, ServiceSpec,
+    Affinity, Container, EnvVar, EnvVarSource, LocalObjectReference, NodeAffinity, NodeSelector,
+    NodeSelectorRequirement, NodeSelectorTerm, ObjectFieldSelector, PodSpec, PodTemplateSpec,
+    Service, ServiceAccount, ServicePort, ServiceSpec,
 };
 use k8s_openapi::api::rbac::v1::{ClusterRole, ClusterRoleBinding, PolicyRule, RoleRef, Subject};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
@@ -183,6 +184,17 @@ pub fn controller_deployment(
                         image_pull_policy: None,
                         name: BRUPOP.to_string(),
                         command: Some(vec!["./controller".to_string()]),
+                        env: Some(vec![EnvVar {
+                            name: "MY_NODE_NAME".to_string(),
+                            value_from: Some(EnvVarSource {
+                                field_ref: Some(ObjectFieldSelector {
+                                    field_path: "spec.nodeName".to_string(),
+                                    ..Default::default()
+                                }),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        }]),
                         ..Default::default()
                     }],
                     image_pull_secrets,

--- a/yamlgen/build.rs
+++ b/yamlgen/build.rs
@@ -16,7 +16,7 @@ use models::{
     },
     controller::{
         controller_cluster_role, controller_cluster_role_binding, controller_deployment,
-        controller_service, controller_service_account,
+        controller_priority_class, controller_service, controller_service_account,
     },
     namespace::brupop_namespace,
     node::combined_crds,
@@ -88,6 +88,7 @@ fn main() {
     serde_yaml::to_writer(&brupop_resources, &controller_service_account()).unwrap();
     serde_yaml::to_writer(&brupop_resources, &controller_cluster_role()).unwrap();
     serde_yaml::to_writer(&brupop_resources, &controller_cluster_role_binding()).unwrap();
+    serde_yaml::to_writer(&brupop_resources, &controller_priority_class()).unwrap();
     serde_yaml::to_writer(
         &brupop_resources,
         &controller_deployment(brupop_image.clone(), brupop_image_pull_secrets.clone()),

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -674,6 +674,11 @@ spec:
       containers:
         - command:
             - "./controller"
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v0.2.1"
           name: brupop
       serviceAccountName: brupop-controller-service-account

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -634,6 +634,14 @@ subjects:
     name: brupop-controller-service-account
     namespace: brupop-bottlerocket-aws
 ---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: brupop-controller-high-priority
+  namespace: brupop-bottlerocket-aws
+preemptionPolicy: Never
+value: 1000000
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -681,6 +689,7 @@ spec:
                   fieldPath: spec.nodeName
           image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v0.2.1"
           name: brupop
+      priorityClassName: brupop-controller-high-priority
       serviceAccountName: brupop-controller-service-account
 ---
 apiVersion: v1

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -43,8 +43,7 @@ spec:
                   description: "Records the desired state of the `BottlerocketShadow`"
                   enum:
                     - Idle
-                    - StagedUpdate
-                    - PerformedUpdate
+                    - StagedAndPerformedUpdate
                     - RebootedIntoUpdate
                     - MonitoringUpdate
                     - ErrorReset
@@ -73,8 +72,7 @@ spec:
                   description: "BottlerocketShadowState represents a node's state in the update state machine."
                   enum:
                     - Idle
-                    - StagedUpdate
-                    - PerformedUpdate
+                    - StagedAndPerformedUpdate
                     - RebootedIntoUpdate
                     - MonitoringUpdate
                     - ErrorReset


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#14 


**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Tue Jun 21 03:03:50 2022 +0000

    Make the controller a high-priority

    As part of Protect controller from becoming unschedulable, this approach
    means to give controller a high priority so that controller may be scheduled
    sooner than Pods with lower priority if its scheduling requirements are met.

commit c7716c2109894f41c2b2ab960c5cfcd8c1f5b489
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Tue Jun 21 03:00:36 2022 +0000

    Update the node which hosts controller last

    As part of Protect controller from becoming unschedulable, this part can
    make brupop Update the node which hosts controller last. Therefore, this
    approach can reduce the effect when controller pods is dead as much as possible.

commit 7eff6e627247d58c574bf1c105a065d43a2bebe3
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Mon Jun 20 21:48:47 2022 +0000

    redesign the responsibilities of controller and agent

    As part of prevent controller from becoming unschedualable, we redesign
    the responsibilities of controler and agent. Basically new design makes
    agent be able to complete a node update even lack controller's signal.
```

**Testing done:**

- [x] Test controller state machine
- [x] Test if the node which hosts controller pod update last
- [x] Make sure controller pod has desired priority value. 

The node which hosts controller pod is ` ip-192-168-131-7.us-west-2.compute.internal
The priority class value is `1000000`

```
Name:                 brupop-controller-deployment-8484df4fb4-vcjxb
Namespace:            brupop-bottlerocket-aws
Priority:             100000
Priority Class Name:  brupop-controller-high-priority
Node:                  ip-192-168-131-7.us-west-2.compute.internal/192.168.129.76
```

```
[kubectl -n brupop-bottlerocket-aws get brs
NAME                                                STATE   VERSION   TARGET STATE               TARGET VERSION   CRASH COUNT
brs-ip-192-168-131-7.us-west-2.compute.internal     Idle    1.6.1     Idle                       <no value>       0
brs-ip-192-168-134-90.us-west-2.compute.internal    Idle    1.6.1     Idle                       <no value>       0
brs-ip-192-168-137-157.us-west-2.compute.internal   Idle    1.6.1     StagedAndPerformedUpdate   1.8.0            0
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
