### PR TITLE
Integ test - creation/deletion of brupop and test pods improvement

### DIFF
--- a/integ/src/main.rs
+++ b/integ/src/main.rs
@@ -15,9 +15,7 @@ use integ::eks_provider::{get_cluster_info, write_kubeconfig};
 use integ::error::ProviderError;
 use integ::monitor::{BrupopMonitor, IntegBrupopClient, Monitor};
 use integ::nodegroup_provider::{create_nodegroup, terminate_nodegroup};
-use integ::updater::{
-    delete_brupop_cluster_resources, nodes_exist, process_pods_test, run_brupop, Action,
-};
+use integ::updater::{nodes_exist, process_brupop_resources, process_pods_test, Action};
 
 type Result<T> = std::result::Result<T, error::Error>;
 
@@ -192,7 +190,7 @@ async fn run() -> Result<()> {
 
             // install brupop on EKS cluster
             info!("Running brupop on existing EKS cluster ...");
-            run_brupop(&kube_config_path)
+            process_brupop_resources(Action::Apply, &kube_config_path)
                 .await
                 .context(error::RunBrupop)?;
         }
@@ -251,7 +249,7 @@ async fn run() -> Result<()> {
             if !nodes_exist(k8s_client).await.context(error::RunBrupop)? {
                 // Clean up all brupop resources like namespace, deployment on brupop test
                 info!("Deleting all brupop cluster resources created by integration test ...");
-                delete_brupop_cluster_resources(&kube_config_path)
+                process_brupop_resources(Action::Apply, &kube_config_path)
                     .await
                     .context(error::DeleteClusterResources)?;
 

--- a/integ/src/main.rs
+++ b/integ/src/main.rs
@@ -186,7 +186,7 @@ async fn run() -> Result<()> {
                 "creating pods(statefulset pods, stateless pods, and pods with PodDisruptionBudgets) ...
             "
             );
-            process_pods_test(Action::Create, &kube_config_path)
+            process_pods_test(Action::Apply, &kube_config_path)
                 .await
                 .context(error::CreatePod)?;
 

--- a/integ/src/updater.rs
+++ b/integ/src/updater.rs
@@ -4,7 +4,6 @@
 !*/
 
 use lazy_static::lazy_static;
-
 use snafu::{ensure, ResultExt};
 use std::process::Command;
 
@@ -39,7 +38,7 @@ lazy_static! {
 
 #[derive(strum_macros::Display, Debug)]
 pub enum Action {
-    Create,
+    Apply,
     Delete,
 }
 
@@ -121,7 +120,9 @@ pub async fn delete_brupop_cluster_resources(kube_config_path: &str) -> UpdaterR
     Ok(())
 }
 
-// create/delete statefulset pods, stateless nginx pods, and pods with PDBs on EKS cluster
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^= Deletion and Creation of test pods  =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+// create or delete statefulset pods, stateless nginx pods, and pods with PDBs on EKS cluster
 pub async fn process_pods_test(action: Action, kube_config_path: &str) -> UpdaterResult<()> {
     let action_string: String = action.to_string();
 
@@ -144,7 +145,6 @@ pub async fn process_pods_test(action: Action, kube_config_path: &str) -> Update
             action: action_string
         }
     );
-
     Ok(())
 }
 

--- a/integ/src/updater.rs
+++ b/integ/src/updater.rs
@@ -2,39 +2,15 @@
   updater helps running brupop on existing EKS cluster and clean up all
   resources once completing integration test
 !*/
-
-use lazy_static::lazy_static;
 use snafu::{ensure, ResultExt};
 use std::process::Command;
 
 use k8s_openapi::api::core::v1::Node;
 use kube::api::{Api, ListParams};
 
-use models::constants::NAMESPACE;
-
 const CURRENT_LOCATION_PATH: &str = "integ/src";
 const PODS_TEMPLATE: &str = "pods-template.yaml";
 const KUBECTL_BINARY: &str = "kubectl";
-
-lazy_static! {
-    static ref BRUPOP_CLUSTER_ROLES: Vec<&'static str> = {
-        let mut m = Vec::new();
-        m.push("brupop-apiserver-role");
-        m.push("brupop-agent-role");
-        m.push("brupop-controller-role");
-        m
-    };
-}
-
-lazy_static! {
-    static ref BRUPOP_CLUSTER_ROLE_BINDINGS: Vec<&'static str> = {
-        let mut m = Vec::new();
-        m.push("brupop-apiserver-role-binding");
-        m.push("brupop-agent-role-binding");
-        m.push("brupop-controller-role-binding");
-        m
-    };
-}
 
 #[derive(strum_macros::Display, Debug)]
 pub enum Action {
@@ -42,11 +18,15 @@ pub enum Action {
     Delete,
 }
 
-// installing brupop on EKS cluster
-pub async fn run_brupop(kube_config_path: &str) -> UpdaterResult<()> {
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^= Deletion and Creation of brupop resources  =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+// install or destroy all brupop resources
+pub async fn process_brupop_resources(action: Action, kube_config_path: &str) -> UpdaterResult<()> {
+    let action_string: String = action.to_string();
+
     let brupop_resource_status = Command::new(KUBECTL_BINARY)
         .args([
-            "apply",
+            &action_string.to_lowercase(),
             "-f",
             "yamlgen/deploy/bottlerocket-update-operator.yaml",
             "--kubeconfig",
@@ -55,68 +35,12 @@ pub async fn run_brupop(kube_config_path: &str) -> UpdaterResult<()> {
         .status()
         .context(update_error::BrupopProcess)?;
 
-    ensure!(brupop_resource_status.success(), update_error::BrupopRun);
-
-    Ok(())
-}
-
-// destroy all brupop resources which were created when integration test installed brupop
-pub async fn delete_brupop_cluster_resources(kube_config_path: &str) -> UpdaterResult<()> {
-    // delete namespaces brupop-bottlerocket-aws. This can clean all resources under this namespace like daemonsets.apps
-    let namespace_deletion_status = Command::new("kubectl")
-        .args([
-            "delete",
-            "namespaces",
-            NAMESPACE,
-            "--kubeconfig",
-            kube_config_path,
-        ])
-        .status()
-        .context(update_error::BrupopCleanUp {
-            cluster_resource: "namespaces",
-        })?;
-    ensure!(namespace_deletion_status.success(), update_error::BrupopRun);
-
-    // delete clusterrolebinding.rbac.authorization.k8s.io
-    for cluster_role_binding in BRUPOP_CLUSTER_ROLE_BINDINGS.iter() {
-        let clusterrolebinding_deletion_status = Command::new("kubectl")
-            .args([
-                "delete",
-                "clusterrolebinding.rbac.authorization.k8s.io",
-                cluster_role_binding,
-                "--kubeconfig",
-                kube_config_path,
-            ])
-            .status()
-            .context(update_error::BrupopCleanUp {
-                cluster_resource: "clusterrolebinding.rbac.authorization.k8s.io",
-            })?;
-        ensure!(
-            clusterrolebinding_deletion_status.success(),
-            update_error::BrupopRun
-        );
-    }
-
-    // delete clusterrole.rbac.authorization.k8s.io
-    for cluster_role in BRUPOP_CLUSTER_ROLES.iter() {
-        let clusterrole_deletion_status = Command::new("kubectl")
-            .args([
-                "delete",
-                "clusterrole.rbac.authorization.k8s.io",
-                cluster_role,
-                "--kubeconfig",
-                kube_config_path,
-            ])
-            .status()
-            .context(update_error::BrupopCleanUp {
-                cluster_resource: "clusterrole.rbac.authorization.k8s.io",
-            })?;
-        ensure!(
-            clusterrole_deletion_status.success(),
-            update_error::BrupopRun
-        );
-    }
-
+    ensure!(
+        brupop_resource_status.success(),
+        update_error::BrupopRun {
+            action: action_string
+        }
+    );
     Ok(())
 }
 
@@ -172,14 +96,8 @@ pub mod update_error {
         #[snafu(display("Failed to install brupop: {}", source))]
         BrupopProcess { source: std::io::Error },
 
-        #[snafu(display("Failed to run brupop test"))]
-        BrupopRun,
-
-        #[snafu(display("Failed to deleted resource {}: {}", cluster_resource, source))]
-        BrupopCleanUp {
-            cluster_resource: String,
-            source: std::io::Error,
-        },
+        #[snafu(display("Failed to process brupop resources: {:?} brupop", action))]
+        BrupopRun { action: String },
 
         #[snafu(display("Failed to {:?} pods", action))]
         ProcessPodsTest {


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#216
#208


**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Tue Jun 28 01:00:14 2022 +0000

    skip creating brupop resources if they already exist

    Integration test allows to launch multiple nodegroups on eks cluster,
    and it would be redundant to create brupop resources multiple times.
    Therefore this change make system to skip creating brupop resources
    if they already exist.

    Meanwhile, simplify the functionality of create and delete brupop
    resources.

commit 55587205f41633d823b3bef0ccaa91216f1b98cf
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Tue Jun 28 00:33:44 2022 +0000

    skip creating test pods if they already exist

    Integration test allows to launch multiple nodegroups on eks cluster,
    and it would be redundant to create test pods multiple times. Therefore
    this change make system to skip creating test pods if they already
    exist.
```


**Testing done:**
Method: Launch multiple nodegroup and check if brupop resources and test pods are created only once (first nodegroup)
```
cargo run --bin integ integration-test --cluster-name brupop-ipv4 --region us-west-2 --bottlerocket-version 1.6.1  --arch x86_64 --nodegroup-name x86

cargo run --bin integ integration-test --cluster-name brupop-ipv4 --region us-west-2 --bottlerocket-version 1.6.1  --arch arm64 --nodegroup-name arm64
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
