### PR TITLE
Brupop - Apply common k8s labels to all created resources

### DIFF
--- a/models/src/agent.rs
+++ b/models/src/agent.rs
@@ -1,3 +1,4 @@
+use crate::brupop_labels;
 use crate::constants::{
     AGENT, AGENT_NAME, APISERVER_SERVICE_NAME, APP_COMPONENT, APP_MANAGED_BY, APP_PART_OF, BRUPOP,
     BRUPOP_INTERFACE_VERSION, LABEL_BRUPOP_INTERFACE_NAME, LABEL_COMPONENT, NAMESPACE, SECRET_NAME,
@@ -27,6 +28,7 @@ pub const AGENT_TOKEN_PATH: &str = "bottlerocket-agent-service-account-token";
 pub fn agent_service_account() -> ServiceAccount {
     ServiceAccount {
         metadata: ObjectMeta {
+            labels: Some(brupop_labels!(AGENT)),
             name: Some(BRUPOP_AGENT_SERVICE_ACCOUNT.to_string()),
             namespace: Some(NAMESPACE.to_string()),
             annotations: Some(btreemap! {
@@ -42,6 +44,7 @@ pub fn agent_service_account() -> ServiceAccount {
 pub fn agent_cluster_role() -> ClusterRole {
     ClusterRole {
         metadata: ObjectMeta {
+            labels: Some(brupop_labels!(AGENT)),
             name: Some(BRUPOP_AGENT_CLUSTER_ROLE.to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()
@@ -77,6 +80,7 @@ pub fn agent_cluster_role() -> ClusterRole {
 pub fn agent_cluster_role_binding() -> ClusterRoleBinding {
     ClusterRoleBinding {
         metadata: ObjectMeta {
+            labels: Some(brupop_labels!(AGENT)),
             name: Some("brupop-agent-role-binding".to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()
@@ -102,17 +106,7 @@ pub fn agent_daemonset(agent_image: String, image_pull_secret: Option<String>) -
 
     DaemonSet {
         metadata: ObjectMeta {
-            labels: Some(
-                btreemap! {
-                    APP_COMPONENT => AGENT,
-                    APP_MANAGED_BY => BRUPOP,
-                    APP_PART_OF => BRUPOP,
-                    LABEL_COMPONENT => AGENT,
-                }
-                .iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect(),
-            ),
+            labels: Some(brupop_labels!(AGENT)),
             name: Some(AGENT_NAME.to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()

--- a/models/src/apiserver.rs
+++ b/models/src/apiserver.rs
@@ -1,3 +1,4 @@
+use crate::brupop_labels;
 use crate::constants::{
     APISERVER, APISERVER_HEALTH_CHECK_ROUTE, APISERVER_INTERNAL_PORT, APISERVER_MAX_UNAVAILABLE,
     APISERVER_SERVICE_NAME, APISERVER_SERVICE_PORT, APP_COMPONENT, APP_MANAGED_BY, APP_PART_OF,
@@ -28,6 +29,7 @@ const AUTH_DELEGATOR_ROLE_NAME: &str = "system:auth-delegator";
 pub fn apiserver_service_account() -> ServiceAccount {
     ServiceAccount {
         metadata: ObjectMeta {
+            labels: Some(brupop_labels!(APISERVER)),
             name: Some(BRUPOP_APISERVER_SERVICE_ACCOUNT.to_string()),
             namespace: Some(NAMESPACE.to_string()),
             annotations: Some(btreemap! {
@@ -43,6 +45,7 @@ pub fn apiserver_service_account() -> ServiceAccount {
 pub fn apiserver_cluster_role() -> ClusterRole {
     ClusterRole {
         metadata: ObjectMeta {
+            labels: Some(brupop_labels!(APISERVER)),
             name: Some(BRUPOP_APISERVER_CLUSTER_ROLE.to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()
@@ -110,6 +113,7 @@ pub fn apiserver_cluster_role() -> ClusterRole {
 pub fn apiserver_cluster_role_binding() -> ClusterRoleBinding {
     ClusterRoleBinding {
         metadata: ObjectMeta {
+            labels: Some(brupop_labels!(APISERVER)),
             name: Some("brupop-apiserver-role-binding".to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()
@@ -132,6 +136,7 @@ pub fn apiserver_cluster_role_binding() -> ClusterRoleBinding {
 pub fn apiserver_auth_delegator_cluster_role_binding() -> ClusterRoleBinding {
     ClusterRoleBinding {
         metadata: ObjectMeta {
+            labels: Some(brupop_labels!(APISERVER)),
             name: Some("brupop-apiserver-auth-delegator-role-binding".to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()
@@ -160,17 +165,7 @@ pub fn apiserver_deployment(
 
     Deployment {
         metadata: ObjectMeta {
-            labels: Some(
-                btreemap! {
-                    APP_COMPONENT => APISERVER.to_string(),
-                    APP_MANAGED_BY => BRUPOP.to_string(),
-                    APP_PART_OF => BRUPOP.to_string(),
-                    LABEL_COMPONENT => APISERVER.to_string(),
-                }
-                .iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect(),
-            ),
+            labels: Some(brupop_labels!(APISERVER)),
             name: Some(APISERVER_SERVICE_NAME.to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()
@@ -292,17 +287,7 @@ pub fn apiserver_deployment(
 pub fn apiserver_service() -> Service {
     Service {
         metadata: ObjectMeta {
-            labels: Some(
-                btreemap! {
-                    APP_COMPONENT => APISERVER.to_string(),
-                    APP_MANAGED_BY => BRUPOP.to_string(),
-                    APP_PART_OF => BRUPOP.to_string(),
-                    LABEL_COMPONENT => APISERVER.to_string(),
-                }
-                .iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect(),
-            ),
+            labels: Some(brupop_labels!(APISERVER)),
             name: Some(APISERVER_SERVICE_NAME.to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()

--- a/models/src/constants.rs
+++ b/models/src/constants.rs
@@ -10,6 +10,22 @@ macro_rules! brupop_domain {
         concat!(brupop_domain!(), "/", $s)
     };
 }
+/// Helper macro to generate all brupop resources' common k8s labels.
+/// When given a string parameter it assign the value to `APP_COMPONENT` and `LABEL_COMPONENT`
+#[macro_export]
+macro_rules! brupop_labels {
+    ($s:expr) => {
+        btreemap! {
+            APP_COMPONENT => $s,
+            APP_MANAGED_BY => BRUPOP,
+            APP_PART_OF => BRUPOP,
+            LABEL_COMPONENT => $s,
+        }
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+    };
+}
 
 pub const API_VERSION: &str = brupop_domain!("v2");
 pub const NAMESPACE: &str = "brupop-bottlerocket-aws";

--- a/models/src/controller.rs
+++ b/models/src/controller.rs
@@ -1,3 +1,4 @@
+use crate::brupop_labels;
 use crate::constants::{
     APP_COMPONENT, APP_MANAGED_BY, APP_PART_OF, BRUPOP, BRUPOP_DOMAIN_LIKE_NAME, CONTROLLER,
     CONTROLLER_DEPLOYMENT_NAME, CONTROLLER_INTERNAL_PORT, CONTROLLER_SERVICE_NAME,
@@ -22,6 +23,7 @@ const BRUPOP_CONTROLLER_CLUSTER_ROLE: &str = "brupop-controller-role";
 pub fn controller_service_account() -> ServiceAccount {
     ServiceAccount {
         metadata: ObjectMeta {
+            labels: Some(brupop_labels!(CONTROLLER)),
             name: Some(BRUPOP_CONTROLLER_SERVICE_ACCOUNT.to_string()),
             namespace: Some(NAMESPACE.to_string()),
             annotations: Some(btreemap! {
@@ -37,6 +39,7 @@ pub fn controller_service_account() -> ServiceAccount {
 pub fn controller_cluster_role() -> ClusterRole {
     ClusterRole {
         metadata: ObjectMeta {
+            labels: Some(brupop_labels!(CONTROLLER)),
             name: Some(BRUPOP_CONTROLLER_CLUSTER_ROLE.to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()
@@ -89,6 +92,7 @@ pub fn controller_cluster_role() -> ClusterRole {
 pub fn controller_cluster_role_binding() -> ClusterRoleBinding {
     ClusterRoleBinding {
         metadata: ObjectMeta {
+            labels: Some(brupop_labels!(CONTROLLER)),
             name: Some("brupop-controller-role-binding".to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()
@@ -117,17 +121,7 @@ pub fn controller_deployment(
 
     Deployment {
         metadata: ObjectMeta {
-            labels: Some(
-                btreemap! {
-                    APP_COMPONENT => CONTROLLER.to_string(),
-                    APP_MANAGED_BY => BRUPOP.to_string(),
-                    APP_PART_OF => BRUPOP.to_string(),
-                    LABEL_COMPONENT => CONTROLLER.to_string(),
-                }
-                .iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect(),
-            ),
+            labels: Some(brupop_labels!(CONTROLLER)),
             name: Some(CONTROLLER_DEPLOYMENT_NAME.to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()
@@ -205,17 +199,7 @@ pub fn controller_deployment(
 pub fn controller_service() -> Service {
     Service {
         metadata: ObjectMeta {
-            labels: Some(
-                btreemap! {
-                    APP_COMPONENT => CONTROLLER.to_string(),
-                    APP_MANAGED_BY => BRUPOP.to_string(),
-                    APP_PART_OF => BRUPOP.to_string(),
-                    LABEL_COMPONENT => CONTROLLER.to_string(),
-                }
-                .iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect(),
-            ),
+            labels: Some(brupop_labels!(CONTROLLER)),
             name: Some(CONTROLLER_SERVICE_NAME.to_string()),
             namespace: Some(NAMESPACE.to_string()),
             ..Default::default()

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -224,12 +224,22 @@ kind: ServiceAccount
 metadata:
   annotations:
     kubernetes.io/service-account.name: brupop-apiserver-service-account
+  labels:
+    app.kubernetes.io/component: apiserver
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: apiserver
   name: brupop-apiserver-service-account
   namespace: brupop-bottlerocket-aws
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: apiserver
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: apiserver
   name: brupop-apiserver-role
   namespace: brupop-bottlerocket-aws
 rules:
@@ -283,6 +293,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: apiserver
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: apiserver
   name: brupop-apiserver-role-binding
   namespace: brupop-bottlerocket-aws
 roleRef:
@@ -297,6 +312,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: apiserver
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: apiserver
   name: brupop-apiserver-auth-delegator-role-binding
   namespace: brupop-bottlerocket-aws
 roleRef:
@@ -397,12 +417,22 @@ kind: ServiceAccount
 metadata:
   annotations:
     kubernetes.io/service-account.name: brupop-agent-service-account
+  labels:
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: agent
   name: brupop-agent-service-account
   namespace: brupop-bottlerocket-aws
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: agent
   name: brupop-agent-role
   namespace: brupop-bottlerocket-aws
 rules:
@@ -427,6 +457,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: agent
   name: brupop-agent-role-binding
   namespace: brupop-bottlerocket-aws
 roleRef:
@@ -533,12 +568,22 @@ kind: ServiceAccount
 metadata:
   annotations:
     kubernetes.io/service-account.name: brupop-controller-service-account
+  labels:
+    app.kubernetes.io/component: brupop-controller
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: brupop-controller
   name: brupop-controller-service-account
   namespace: brupop-bottlerocket-aws
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: brupop-controller
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: brupop-controller
   name: brupop-controller-role
   namespace: brupop-bottlerocket-aws
 rules:
@@ -575,6 +620,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: brupop-controller
+    app.kubernetes.io/managed-by: brupop
+    app.kubernetes.io/part-of: brupop
+    brupop.bottlerocket.aws/component: brupop-controller
   name: brupop-controller-role-binding
   namespace: brupop-bottlerocket-aws
 roleRef:


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#113 


**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Thu Jul 7 20:52:34 2022 +0000

    Apply common k8s labels to all created resources

    We have some of these label defined in our model package; however,
    we weren’t consistently applying those labels to all brupop created
    resources. Hence, we need improve to apply those labels to all brupop
    resources.
```

**Testing done:**
Check if all brupop resources have correct labels

Checklist

Agent
- [x] agent_service_account
- [x] agent_cluster_role
- [x] agent_cluster_role_binding
- [x] agent_daemonset

Controller

- [x] controller_service_account
- [x] controller_cluster_role
- [x] controller_cluster_role_binding
- [x] controller_deployment
- [x] controller_service

Apiserver

- [x] apiserver_service_account
- [x] apiserver_cluster_role
- [x] apiserver_cluster_role_binding
- [x] apiserver_auth_delegator_cluster_role_binding
- [x] apiserver_deployment
- [x] apiserver_service



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
