### PR TITLE
Add Webhooks logic for CRD migration

### DIFF
--- a/apiserver/src/api/node.rs
+++ b/apiserver/src/api/node.rs
@@ -1,15 +1,18 @@
 use super::{APIServerSettings, ApiserverCommonHeaders};
 use crate::error::{self, Result};
+use crate::webhook::ConversionRequest;
+
 use models::node::{BottlerocketShadowClient, BottlerocketShadowStatus};
 
 use actix_web::{
     web::{self},
     HttpRequest, HttpResponse, Responder,
 };
+
 use serde_json::json;
 use snafu::ResultExt;
-
 use std::convert::TryFrom;
+use tracing::{event, Level};
 
 /// HTTP endpoint which creates BottlerocketShadow custom resources on behalf of the caller.
 pub(crate) async fn create_bottlerocket_shadow_resource<T: BottlerocketShadowClient>(
@@ -42,14 +45,31 @@ pub(crate) async fn update_bottlerocket_shadow_resource<T: BottlerocketShadowCli
     Ok(HttpResponse::Ok().body(format!("{}", json!(&node_status))))
 }
 
+pub(crate) async fn convert_bottlerocket_shadow_resource(
+    conversion_req: web::Json<ConversionRequest>,
+) -> Result<impl Responder> {
+    event!(Level::INFO, ?conversion_req, "Original conversion request");
+    let response = conversion_req.convert_resource();
+    let response_string = serde_json::to_string(&response).context(error::WebhookError)?;
+    event!(Level::INFO, ?response_string, "Converted response:");
+
+    // Webhook will always respond with 200.
+    // The actual status of the conversion will be returned in
+    // ConversionResponse.response.result.status
+    Ok(HttpResponse::Ok()
+        .content_type("application/json")
+        .body(response_string))
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::tests::test_settings;
     use super::*;
     use crate::constants::{
-        HEADER_BRUPOP_K8S_AUTH_TOKEN, HEADER_BRUPOP_NODE_NAME, HEADER_BRUPOP_NODE_UID,
-        NODE_RESOURCE_ENDPOINT,
+        CRD_CONVERT_ENDPOINT, HEADER_BRUPOP_K8S_AUTH_TOKEN, HEADER_BRUPOP_NODE_NAME,
+        HEADER_BRUPOP_NODE_UID, NODE_RESOURCE_ENDPOINT,
     };
+    use crate::webhook::{ConversionRequest, ConversionResponse, Request};
     use models::node::{
         BottlerocketShadow, BottlerocketShadowSelector, BottlerocketShadowSpec,
         BottlerocketShadowState, MockBottlerocketShadowClient, Version,
@@ -178,6 +198,66 @@ mod tests {
             let return_status: BottlerocketShadowStatus =
                 serde_json::from_slice(&b).expect("Could not parse JSON response.");
             assert_eq!(return_status, node_status);
+        } else {
+            panic!("Response did not return a body.");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_convert_crd() {
+        let conversion_req = ConversionRequest {
+            kind: "ConversionReview".to_string(),
+            api_version: "apiextensions.k8s.io/v1".to_string(),
+            request: Request {
+                uid: "5a6adc7e-c74b-43c0-9718-293de1b104cb".to_string(),
+                desired_api_version: "brupop.bottlerocket.aws/v2".to_string(),
+                objects: vec![json!({
+                    "apiVersion": "brupop.bottlerocket.aws/v1",
+                    "kind": "BottlerocketShadow",
+                    "metadata": {
+                        "name": "brs-ip-192-168-22-145.us-west-2.compute.internal",
+                        "namespace": "brupop-bottlerocket-aws",
+                        "uid": "3153df27-6619-4b6b-bc75-adbf92ef7266",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "v1",
+                                "kind": "Node",
+                                "name": "ip-192-168-22-145.us-west-2.compute.internal",
+                                "uid": "6b714046-3b20-4a79-aaa9-27cf626a2c12"
+                            }
+                        ]
+                    },
+                    "spec": {
+                        "state": "Idle",
+                    },
+                    "status": {
+                        "current_state": "Idle",
+                        "target_version": "1.8.0",
+                        "current_version": "1.8.0"
+                    }
+
+                })],
+            },
+        };
+        let req = test::TestRequest::put()
+            .uri(CRD_CONVERT_ENDPOINT)
+            .set_json(&conversion_req)
+            .to_request();
+
+        let app = test::init_service(App::new().route(
+            CRD_CONVERT_ENDPOINT,
+            web::put().to(convert_bottlerocket_shadow_resource),
+        ))
+        .await;
+
+        let resp = test::call_service(&app, req).await;
+
+        assert!(resp.status().is_success());
+        if let AnyBody::Bytes(b) = resp.into_body() {
+            // Only check the response body can be converted to ConversionResponse.
+            // Contents of the ConversionResponse should be tested in convert_resource method.
+            serde_json::from_slice::<ConversionResponse>(&b)
+                .expect("Could not parse JSON response.");
         } else {
             panic!("Response did not return a body.");
         }

--- a/apiserver/src/constants.rs
+++ b/apiserver/src/constants.rs
@@ -1,6 +1,9 @@
+use models::constants::APISERVER_CRD_CONVERT_ENDPOINT;
+
 pub const NODE_RESOURCE_ENDPOINT: &str = "/bottlerocket-node-resource";
 pub const NODE_CORDON_AND_DRAIN_ENDPOINT: &str = "/bottlerocket-node-resource/cordon-and-drain";
 pub const NODE_UNCORDON_ENDPOINT: &str = "/bottlerocket-node-resource/uncordon";
+pub const CRD_CONVERT_ENDPOINT: &str = APISERVER_CRD_CONVERT_ENDPOINT;
 
 // Key names for HTTP headers for apiserver.
 pub(crate) const HEADER_BRUPOP_NODE_NAME: &str = "BrupopNodeName";

--- a/apiserver/src/error.rs
+++ b/apiserver/src/error.rs
@@ -44,6 +44,9 @@ pub enum Error {
 
     #[snafu(display("Failed to set up SslAcceptorBuilder : {:?}", source))]
     SSLError { source: openssl::error::ErrorStack },
+
+    #[snafu(display("Failed to serialize Webhook response: {:?}", source))]
+    WebhookError { source: serde_json::error::Error },
 }
 
 impl ResponseError for Error {}

--- a/apiserver/src/lib.rs
+++ b/apiserver/src/lib.rs
@@ -9,6 +9,8 @@ pub mod telemetry;
 
 #[cfg(feature = "client")]
 pub mod client;
+#[cfg(feature = "server")]
+pub mod webhook;
 
 pub(crate) mod constants;
 

--- a/apiserver/src/webhook/mod.rs
+++ b/apiserver/src/webhook/mod.rs
@@ -1,0 +1,416 @@
+mod request;
+mod response;
+
+pub use self::request::{ConversionRequest, Request};
+pub use self::response::{ConversionResponse, ConvertResult, Response};
+
+use models::node::v1::BottlerocketShadow as BottleRocketShadowV1;
+use models::node::v2::BottlerocketShadow as BottlerocketShadowV2;
+
+use snafu::{ResultExt, Snafu};
+use std::convert::TryFrom;
+use tracing::instrument;
+
+pub type Result<T> = std::result::Result<T, WebhookConvertError>;
+
+/// Convert k8s ConversionReview object from request to response
+/// by applying chained convert methods on its objects.
+///
+/// Sample request in yaml format:
+#[cfg_attr(doctest, doc = " ````no_test")]
+/// ```
+/// {
+///     "apiVersion": "apiextensions.k8s.io/v1",
+///     "kind": "ConversionReview",
+///     "request": {
+///         # Random uid uniquely identifying this conversion call
+///         "uid": "5a6adc7e-c74b-43c0-9718-293de1b104cb",
+///
+///         # The API group and version the objects should be converted to
+///         "desiredAPIVersion": "brupop.bottlerocket.aws/v2",
+///
+///         # The list of objects to convert.
+///         # May contain one or more objects, in one or more versions.
+///         "objects": [
+///             {
+///                 "kind": "BottlerocketShadow",
+///                 "apiVersion": "brupop.bottlerocket.aws/v1",
+///                 "metadata": {
+///                     "name": "brs-ip-192-168-22-145.us-west-2.compute.internal",
+///                     "namespace": "brupop-bottlerocket-aws",
+///                     "uid": "3153df27-6619-4b6b-bc75-adbf92ef7266"
+///                 },
+///                 "spec": {
+///                     "state": "Idle",
+///                 },
+///                 "status": {
+///                     "current_state": "Idle",
+///                     "target_version": "1.8.0",
+///                     "current_version": "1.8.0"
+///                 }
+///             }
+///         ]
+///
+///     }
+/// }
+/// ```
+/// Sample response in yaml format:
+#[cfg_attr(doctest, doc = " ````no_test")]
+/// ```
+/// {
+///     "apiVersion": "apiextensions.k8s.io/v1",
+///     "kind": "ConversionReview",
+///     "response": {
+///         # must match <request.uid>
+///         "uid": "5a6adc7e-c74b-43c0-9718-293de1b104cb",
+///
+///         "result": {
+///             "status": "Success"
+///         },
+///
+///         # Objects must match the order of request.objects, and have apiVersion set to <request.desiredAPIVersion>.
+///         # kind, metadata.uid, metadata.name, and metadata.namespace fields must not be changed by the webhook.
+///         # metadata.labels and metadata.annotations fields may be changed by the webhook.
+///         # All other changes to metadata fields by the webhook are ignored.
+///         "objects": [
+///             {
+///                 "kind": "BottlerocketShadow",
+///                 "apiVersion": "brupop.bottlerocket.aws/v2",
+///                 "metadata": {
+///                     "name": "brs-ip-192-168-22-145.us-west-2.compute.internal",
+///                     "namespace": "brupop-bottlerocket-aws",
+///                     "uid": "3153df27-6619-4b6b-bc75-adbf92ef7266"
+///                 },
+///                 "spec": {
+///                     "state": "Idle",
+///                 },
+///                 "status": {
+///                     "current_state": "Idle",
+///                     "target_version": "1.8.0",
+///                     "current_version": "1.8.0"
+///                 }
+///             }
+///         ]
+///
+///     }
+/// }
+/// ```
+pub fn convert_request_to_response(req: &ConversionRequest) -> ConversionResponse {
+    let request = &req.request;
+    let desired_version = request.desired_api_version.clone();
+
+    match convert_objects(desired_version, request.objects.clone()) {
+        Ok(new_objects) => {
+            let response = Response {
+                uid: request.uid.clone(),
+                result: ConvertResult::default(),
+                converted_objects: Some(new_objects),
+            };
+            ConversionResponse {
+                kind: req.kind.clone(),
+                api_version: req.api_version.clone(),
+                response: response,
+            }
+        }
+        Err(e) => {
+            let fail_result = ConvertResult::create_fail_result(e.to_string());
+            let response = Response {
+                uid: request.uid.clone(),
+                result: fail_result,
+                converted_objects: None,
+            };
+            ConversionResponse {
+                kind: req.kind.clone(),
+                api_version: req.api_version.clone(),
+                response: response,
+            }
+        }
+    }
+}
+
+#[instrument(err)]
+fn convert_objects(
+    desired_version: String,
+    objects: Vec<serde_json::Value>,
+) -> Result<Vec<serde_json::Value>> {
+    let mut new_objects = Vec::new();
+    for old_object in objects.into_iter() {
+        let old_brs_object = BRSObject { object: old_object };
+        let new_brs_object = old_brs_object.chained_convert_object(desired_version.clone())?;
+        new_objects.push(new_brs_object.object);
+    }
+    Ok(new_objects)
+}
+
+/// An abstraction over BottlerocketShadow's json value.
+/// Its implementation contains the logic to chain convert BottlerocketShadow
+/// to a different version.
+///
+/// To add a new version convert, first add a method build the logic
+/// to convert from previous version like:
+#[cfg_attr(doctest, doc = " ````no_test")]
+/// ```
+/// fn to_v2(source_obj: BRSObject) -> Result<BRSObject> {
+///     Self::try_from(BottlerocketShadowV2::from(BottleRocketShadowV1::try_from(
+///         source_obj,
+///     )?))
+/// }
+/// ```
+///
+/// Then update `convert_to_next_version` to map the
+/// BottlerocketShadow version to the above method.
+///
+struct BRSObject {
+    pub object: serde_json::Value,
+}
+
+impl BRSObject {
+    fn get_version(&self) -> Result<String> {
+        Ok(serde_json::from_value(self.object["apiVersion"].clone())
+            .context(SourceVersionNotExistInRequest)?)
+    }
+
+    fn to_v2(source_obj: BRSObject) -> Result<BRSObject> {
+        Self::try_from(BottlerocketShadowV2::from(BottleRocketShadowV1::try_from(
+            source_obj,
+        )?))
+    }
+
+    fn convert_to_next_version(self) -> Result<Self> {
+        let version = self.get_version()?;
+        match version.as_str() {
+            "brupop.bottlerocket.aws/v1" => BRSObject::to_v2(self),
+            _ => InvalidVersionError { version }.fail(),
+        }
+    }
+
+    #[instrument(skip(self), err)]
+    fn chained_convert_object(self, desired_version: String) -> Result<Self> {
+        let mut version = self.get_version()?;
+        let mut source_object = self;
+
+        while version != desired_version {
+            match source_object.convert_to_next_version() {
+                Ok(val) => source_object = val,
+                Err(_) => {
+                    return ChainedConvertError {
+                        src_version: version,
+                        dst_version: desired_version,
+                    }
+                    .fail()
+                }
+            }
+            version = source_object.get_version()?;
+        }
+
+        Ok(source_object)
+    }
+}
+
+impl TryFrom<BRSObject> for BottleRocketShadowV1 {
+    type Error = WebhookConvertError;
+
+    fn try_from(obj: BRSObject) -> Result<Self> {
+        serde_json::from_value(obj.object).context(JsonToBottlerocketShadowConvertError {
+            version: "v1".to_string(),
+        })
+    }
+}
+
+impl TryFrom<BRSObject> for BottlerocketShadowV2 {
+    type Error = WebhookConvertError;
+
+    fn try_from(obj: BRSObject) -> Result<Self> {
+        serde_json::from_value(obj.object).context(JsonToBottlerocketShadowConvertError {
+            version: "v2".to_string(),
+        })
+    }
+}
+
+impl TryFrom<BottlerocketShadowV2> for BRSObject {
+    type Error = WebhookConvertError;
+
+    fn try_from(shadow: BottlerocketShadowV2) -> Result<Self> {
+        Ok(BRSObject {
+            object: serde_json::to_value(shadow).context(BottlerocketShadowToJsonConvertError {
+                version: "v2".to_string(),
+            })?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        convert_request_to_response, ConversionRequest, ConversionResponse, ConvertResult, Request,
+        Response,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn test_convert_request_to_response_succeed() {
+        let conversion_req = ConversionRequest {
+            kind: "ConversionReview".to_string(),
+            api_version: "apiextensions.k8s.io/v1".to_string(),
+            request: Request {
+                uid: "5a6adc7e-c74b-43c0-9718-293de1b104cb".to_string(),
+                desired_api_version: "brupop.bottlerocket.aws/v2".to_string(),
+                objects: vec![json!({
+                    "apiVersion": "brupop.bottlerocket.aws/v1",
+                    "kind": "BottlerocketShadow",
+                    "metadata": {
+                        "name": "brs-ip-192-168-22-145.us-west-2.compute.internal",
+                        "namespace": "brupop-bottlerocket-aws",
+                        "uid": "3153df27-6619-4b6b-bc75-adbf92ef7266",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "v1",
+                                "kind": "Node",
+                                "name": "ip-192-168-22-145.us-west-2.compute.internal",
+                                "uid": "6b714046-3b20-4a79-aaa9-27cf626a2c12"
+                            }
+                        ]
+                    },
+                    "spec": {
+                        "state": "Idle",
+                    },
+                    "status": {
+                        "current_state": "Idle",
+                        "target_version": "1.8.0",
+                        "current_version": "1.8.0"
+                    }
+
+                })],
+            },
+        };
+
+        let expected_response = ConversionResponse {
+            kind: conversion_req.kind.clone(),
+            api_version: conversion_req.api_version.clone(),
+            response: Response {
+                uid: conversion_req.request.uid.clone(),
+                result: ConvertResult::default(),
+                converted_objects: Some(vec![json!({
+                    "apiVersion": "brupop.bottlerocket.aws/v2",
+                    "kind": "BottlerocketShadow",
+                    "metadata": {
+                        "name": "brs-ip-192-168-22-145.us-west-2.compute.internal",
+                        "namespace": "brupop-bottlerocket-aws",
+                        "uid": "3153df27-6619-4b6b-bc75-adbf92ef7266",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "v1",
+                                "kind": "Node",
+                                "name": "ip-192-168-22-145.us-west-2.compute.internal",
+                                "uid": "6b714046-3b20-4a79-aaa9-27cf626a2c12"
+                            }
+                        ]
+                    },
+                    "spec": {
+                        "state": "Idle",
+                        "state_transition_timestamp": null,
+                        "version": null
+                    },
+                    "status": {
+                        "current_state": "Idle",
+                        "target_version": "1.8.0",
+                        "current_version": "1.8.0",
+                        "crash_count": 0,
+                        "state_transition_failure_timestamp": null,
+                    }
+
+                })]),
+            },
+        };
+
+        let converted_response = convert_request_to_response(&conversion_req);
+        assert_eq!(converted_response, expected_response);
+    }
+
+    #[test]
+    fn test_convert_request_to_response_failed() {
+        let conversion_req = ConversionRequest {
+            kind: "ConversionReview".to_string(),
+            api_version: "apiextensions.k8s.io/v1".to_string(),
+            request: Request {
+                uid: "5a6adc7e-c74b-43c0-9718-293de1b104cb".to_string(),
+                // desired_version not exist
+                desired_api_version: "brupop.bottlerocket.aws/-v2".to_string(),
+                objects: vec![json!({
+                    "apiVersion": "brupop.bottlerocket.aws/v1",
+                    "kind": "BottlerocketShadow",
+                    "metadata": {
+                        "name": "brs-ip-192-168-22-145.us-west-2.compute.internal",
+                        "namespace": "brupop-bottlerocket-aws",
+                        "uid": "3153df27-6619-4b6b-bc75-adbf92ef7266",
+                        "ownerReferences": [
+                            {
+                                "apiVersion": "v1",
+                                "kind": "Node",
+                                "name": "ip-192-168-22-145.us-west-2.compute.internal",
+                                "uid": "6b714046-3b20-4a79-aaa9-27cf626a2c12"
+                            }
+                        ]
+                    },
+                    "spec": {
+                        "state": "Idle",
+                    },
+                    "status": {
+                        "current_state": "Idle",
+                        "target_version": "1.8.0",
+                        "current_version": "1.8.0"
+                    }
+
+                })],
+            },
+        };
+
+        let expected_response = ConversionResponse {
+            kind: conversion_req.kind.clone(),
+            api_version: conversion_req.api_version.clone(),
+            response: Response {
+                uid: conversion_req.request.uid.clone(),
+                result: ConvertResult::create_fail_result("Failed to convert from brupop.bottlerocket.aws/v2 to brupop.bottlerocket.aws/-v2 version".to_string()),
+                converted_objects: None,
+            },
+        };
+
+        let converted_response = convert_request_to_response(&conversion_req);
+        assert_eq!(converted_response, expected_response);
+    }
+}
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub")]
+pub enum WebhookConvertError {
+    #[snafu(display("Source version does not exist in ConversionRequest: {}", source))]
+    SourceVersionNotExistInRequest { source: serde_json::Error },
+
+    #[snafu(display(
+        "Failed to convert BottlerocketShadow {} to json object due to:{}",
+        version,
+        source
+    ))]
+    BottlerocketShadowToJsonConvertError {
+        version: String,
+        source: serde_json::error::Error,
+    },
+
+    #[snafu(display(
+        "Failed to convert json object to BottlerocketShadow {} due to: {}",
+        version,
+        source
+    ))]
+    JsonToBottlerocketShadowConvertError {
+        version: String,
+        source: serde_json::error::Error,
+    },
+
+    #[snafu(display("Version {} does not exist in converting logic", version))]
+    InvalidVersionError { version: String },
+
+    #[snafu(display("Failed to convert from {} to {} version", src_version, dst_version))]
+    ChainedConvertError {
+        src_version: String,
+        dst_version: String,
+    },
+}

--- a/apiserver/src/webhook/request.rs
+++ b/apiserver/src/webhook/request.rs
@@ -1,0 +1,28 @@
+use super::convert_request_to_response;
+use super::response::ConversionResponse;
+
+use serde::{Deserialize, Serialize};
+#[derive(Deserialize, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversionRequest {
+    pub kind: String,
+    pub api_version: String,
+    pub request: Request,
+}
+
+#[derive(Deserialize, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Request {
+    pub uid: String,
+    #[serde(rename = "desiredAPIVersion")]
+    pub desired_api_version: String,
+    pub objects: Vec<serde_json::Value>,
+}
+
+impl ConversionRequest {
+    /// Wrap over convert_request_to_response so
+    /// actix_web::web::Json<ConversionRequest> could call the method
+    pub fn convert_resource(&self) -> ConversionResponse {
+        convert_request_to_response(self)
+    }
+}

--- a/apiserver/src/webhook/response.rs
+++ b/apiserver/src/webhook/response.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversionResponse {
+    pub kind: String,
+    pub api_version: String,
+    pub response: Response,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct ConvertResult {
+    pub status: Status,
+    pub message: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum Status {
+    Success,
+    Failed,
+}
+
+impl Default for ConvertResult {
+    fn default() -> Self {
+        ConvertResult {
+            status: Status::Success,
+            message: None,
+        }
+    }
+}
+
+impl ConvertResult {
+    pub fn create_fail_result(msg: String) -> Self {
+        ConvertResult {
+            status: Status::Failed,
+            message: Some(msg),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Response {
+    pub uid: String,
+    pub result: ConvertResult,
+    pub converted_objects: Option<Vec<serde_json::Value>>,
+}

--- a/models/src/constants.rs
+++ b/models/src/constants.rs
@@ -40,6 +40,8 @@ pub const CA_NAME: &str = "ca.crt";
 pub const PUBLIC_KEY_NAME: &str = "tls.crt";
 pub const PRIVATE_KEY_NAME: &str = "tls.key";
 pub const TLS_KEY_MOUNT_PATH: &str = "/etc/brupop-tls-keys";
+// Certificate object name
+pub const CERTIFICATE_NAME: &str = "brupop-apiserver-certificate";
 
 // Label keys
 pub const LABEL_COMPONENT: &str = brupop_domain!("component");
@@ -58,6 +60,7 @@ pub const APISERVER_INTERNAL_PORT: i32 = 8443; // The internal port on which the
 pub const APISERVER_SERVICE_PORT: i32 = 443; // The k8s service port hosting the apiserver.
 pub const APISERVER_MAX_UNAVAILABLE: &str = "33%"; // The maximum number of unavailable nodes for the apiserver deployment.
 pub const APISERVER_HEALTH_CHECK_ROUTE: &str = "/ping"; // Route used for apiserver k8s liveness and readiness checks.
+pub const APISERVER_CRD_CONVERT_ENDPOINT: &str = "/crdconvert"; // Custom Resource convert endpoint
 pub const APISERVER_SERVICE_NAME: &str = "brupop-apiserver"; // The name for the `svc` fronting the apiserver.
 
 // agent constants

--- a/models/src/node/crd/mod.rs
+++ b/models/src/node/crd/mod.rs
@@ -12,18 +12,26 @@
 /// ```
 ///
 /// Push the BottlerocketShadow version to the end of BOTTLEROCKETSHADOW_CRD_METHODS
-/// So the build tool could find all BottlerocketShadow versions and generate correct
+/// so the build tool could find all BottlerocketShadow versions and generate correct
 /// yaml file for CustomResrouceDefinition
 #[cfg_attr(doctest, doc = " ````no_test")]
 /// ```
 /// static ref BOTTLEROCKETSHADOW_CRD_METHODS: Vec<fn() -> CustomResourceDefinition> = {
 ///    // A list of CRD methods for different BottlerocketShadow version
 ///    // The latest version should be added at the end of the vector.
-///    let mut crd_methods = Vec::new();
-///    crd_methods.push(v1::BottlerocketShadow::crd as fn()->CustomResourceDefinition);
-///    crd_methods.push(v2::BottlerocketShadow::crd as fn()->CustomResourceDefinition);
-///    crd_methods
+///    vec![
+///            v1::BottlerocketShadow::crd as fn() -> CustomResourceDefinition,
+///            v2::BottlerocketShadow::crd as fn() -> CustomResourceDefinition,
+///        ]
 /// };
+/// ```
+///
+/// Add the BottlerocketShadow version to the end of BOTTLEROCKETSHADOW_CRD_VERSIONS
+/// so the webhook conversion could set up proper conversion_review_versions
+#[cfg_attr(doctest, doc = " ````no_test")]
+/// ```
+/// static ref BOTTLEROCKETSHADOW_CRD_VERSIONS: Vec<String> =
+///     vec!["v1".to_string(), "v2".to_string()];
 /// ```
 ///
 pub mod v1;
@@ -44,13 +52,13 @@ use std::fmt::Debug;
 
 lazy_static! {
     static ref BOTTLEROCKETSHADOW_CRD_METHODS: Vec<fn() -> CustomResourceDefinition> = {
-        // A list of CRD methods for different BottlerocketShadow version
-        // The latest version should be added at the end of the vector.
-        let mut crd_methods = Vec::new();
-        crd_methods.push(v1::BottlerocketShadow::crd as fn()->CustomResourceDefinition);
-        crd_methods.push(v2::BottlerocketShadow::crd as fn()->CustomResourceDefinition);
-        crd_methods
+        vec![
+            v1::BottlerocketShadow::crd as fn() -> CustomResourceDefinition,
+            v2::BottlerocketShadow::crd as fn() -> CustomResourceDefinition,
+        ]
     };
+    static ref BOTTLEROCKETSHADOW_CRD_VERSIONS: Vec<String> =
+        vec!["v1".to_string(), "v2".to_string()];
 }
 
 pub trait BottlerocketShadowResource: kube::ResourceExt {}

--- a/models/src/node/crd/v2.rs
+++ b/models/src/node/crd/v2.rs
@@ -1,13 +1,19 @@
+use super::v1::BottlerocketShadow as BottleRocketShadowV1;
+use super::v1::BottlerocketShadowSpec as BottlerocketShadowSpecV1;
+use super::v1::BottlerocketShadowState as BottlerocketShadowStateV1;
+use super::v1::BottlerocketShadowStatus as BottlerocketShadowStatusV1;
 use super::BottlerocketShadowResource;
 use crate::node::{error, SEMVER_RE};
 
 use chrono::{DateTime, Utc};
+use kube::api::ObjectMeta;
 use kube::CustomResource;
 use schemars::JsonSchema;
 pub use semver::Version;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::cmp::Ordering;
+use std::convert::From;
 use std::str::FromStr;
 use tokio::time::Duration;
 use validator::Validate;
@@ -65,6 +71,20 @@ impl BottlerocketShadowState {
             Self::MonitoringUpdate => MONITORING_UPDATE_TIMEOUT,
             Self::ErrorReset => ERROR_RESET_TIMEOUT,
         }
+    }
+}
+
+impl From<BottlerocketShadowStateV1> for BottlerocketShadowState {
+    fn from(previous_state: BottlerocketShadowStateV1) -> Self {
+        // TODO: Remap the state when merge PR with preventing controller from being unscheduled
+        let new_state = match previous_state {
+            BottlerocketShadowStateV1::Idle => Self::Idle,
+            BottlerocketShadowStateV1::StagedUpdate => Self::StagedAndPerformedUpdate,
+            BottlerocketShadowStateV1::PerformedUpdate => Self::StagedAndPerformedUpdate,
+            BottlerocketShadowStateV1::RebootedIntoUpdate => Self::RebootedIntoUpdate,
+            BottlerocketShadowStateV1::MonitoringUpdate => Self::MonitoringUpdate,
+        };
+        new_state
     }
 }
 
@@ -181,6 +201,15 @@ impl BottlerocketShadowSpec {
     }
 }
 
+impl From<BottlerocketShadowSpecV1> for BottlerocketShadowSpec {
+    fn from(previous_spec: BottlerocketShadowSpecV1) -> Self {
+        Self::new(
+            BottlerocketShadowState::from(previous_spec.state),
+            previous_spec.state_timestamp().unwrap(),
+            previous_spec.version(),
+        )
+    }
+}
 /// `BottlerocketShadowStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent,
 /// while the spec is updated by the brupop controller.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
@@ -240,5 +269,204 @@ impl BottlerocketShadowStatus {
                     .context(error::TimestampFormat)
             })
             .transpose()
+    }
+}
+
+impl From<BottlerocketShadowStatusV1> for BottlerocketShadowStatus {
+    fn from(previous_status: BottlerocketShadowStatusV1) -> Self {
+        Self::new(
+            previous_status.current_version(),
+            previous_status.target_version(),
+            BottlerocketShadowState::from(previous_status.current_state),
+            0,
+            None,
+        )
+    }
+}
+
+impl From<BottleRocketShadowV1> for BottlerocketShadow {
+    fn from(previous_shadow: BottleRocketShadowV1) -> Self {
+        let previous_metadata = previous_shadow.metadata;
+        let previous_spec = previous_shadow.spec;
+        let previous_status = previous_shadow.status;
+
+        let status = match previous_status {
+            None => None,
+            Some(previous_status) => Some(BottlerocketShadowStatus::from(previous_status)),
+        };
+
+        let spec = BottlerocketShadowSpec::from(previous_spec);
+        let new_shadow = BottlerocketShadow {
+            metadata: ObjectMeta {
+                /// The converted object has to maintain the same name, namespace and uid
+                name: previous_metadata.name,
+                namespace: previous_metadata.namespace,
+                uid: previous_metadata.uid,
+                owner_references: previous_metadata.owner_references,
+                ..Default::default()
+            },
+            spec,
+            status,
+        };
+        new_shadow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BottleRocketShadowV1;
+    use super::BottlerocketShadow;
+    use super::BottlerocketShadowSpec;
+    use super::BottlerocketShadowSpecV1;
+    use super::BottlerocketShadowState;
+    use super::BottlerocketShadowStateV1;
+    use super::BottlerocketShadowStatus;
+    use super::BottlerocketShadowStatusV1;
+    use serde_json::json;
+
+    #[test]
+    fn test_state_convert() {
+        let original_target_state = vec![
+            (json!("Idle"), json!("Idle")),
+            (json!("StagedUpdate"), json!("StagedAndPerformedUpdate")),
+            (json!("PerformedUpdate"), json!("StagedAndPerformedUpdate")),
+            (json!("RebootedIntoUpdate"), json!("RebootedIntoUpdate")),
+            (json!("MonitoringUpdate"), json!("MonitoringUpdate")),
+        ];
+
+        for (original, target) in original_target_state.into_iter() {
+            let old_state: BottlerocketShadowStateV1 = serde_json::from_value(original).unwrap();
+            let new_state = BottlerocketShadowState::from(old_state);
+            assert_eq!(serde_json::to_value(new_state).unwrap(), target);
+        }
+    }
+
+    #[test]
+    fn test_spec_convert() {
+        let original_target_spec = vec![
+            (
+                json!({
+                    "state": "Idle",
+                    "state_transition_timestamp": null,
+                    "version": null
+                }),
+                json!({
+                    "state": "Idle",
+                    "state_transition_timestamp": null,
+                    "version": null
+                }),
+            ),
+            (
+                json!({
+                    "state": "RebootedIntoUpdate",
+                    "state_transition_timestamp": "2022-07-09T19:32:38.609610964+00:00",
+                    "version": "1.8.0"
+                }),
+                json!({
+                    "state": "RebootedIntoUpdate",
+                    "state_transition_timestamp": "2022-07-09T19:32:38.609610964+00:00",
+                    "version": "1.8.0"
+                }),
+            ),
+        ];
+
+        for (original, target) in original_target_spec.into_iter() {
+            let old_spec: BottlerocketShadowSpecV1 = serde_json::from_value(original).unwrap();
+            let new_spec = BottlerocketShadowSpec::from(old_spec);
+            assert_eq!(serde_json::to_value(new_spec).unwrap(), target);
+        }
+    }
+
+    #[test]
+    fn test_status_convert() {
+        let original_target_status = vec![(
+            json!({
+                "current_state": "RebootedIntoUpdate",
+                "current_version": "1.6.0",
+                "target_version": "1.8.0"
+            }),
+            json!({
+                "current_state": "RebootedIntoUpdate",
+                "current_version": "1.6.0",
+                "target_version": "1.8.0",
+                "crash_count":0,
+                "state_transition_failure_timestamp": null,
+            }),
+        )];
+
+        for (original, target) in original_target_status.into_iter() {
+            let old_status: BottlerocketShadowStatusV1 = serde_json::from_value(original).unwrap();
+            let new_status = BottlerocketShadowStatus::from(old_status);
+            assert_eq!(serde_json::to_value(new_status).unwrap(), target);
+        }
+    }
+
+    #[test]
+    fn test_convert_from_old_version() {
+        let original_target_version = vec![(
+            json!({
+                "apiVersion": "brupop.bottlerocket.aws/v1",
+                "kind": "BottlerocketShadow",
+                "metadata": {
+                    "name": "brs-ip-192-168-22-145.us-west-2.compute.internal",
+                    "namespace": "brupop-bottlerocket-aws",
+                    "uid": "3153df27-6619-4b6b-bc75-adbf92ef7266",
+                    "ownerReferences": [
+                        {
+                            "apiVersion": "v1",
+                            "kind": "Node",
+                            "name": "ip-192-168-22-145.us-west-2.compute.internal",
+                            "uid": "6b714046-3b20-4a79-aaa9-27cf626a2c12"
+                        }
+                    ]
+                },
+                "spec": {
+                    "state": "Idle",
+                },
+                "status": {
+                    "current_state": "Idle",
+                    "target_version": "1.8.0",
+                    "current_version": "1.8.0"
+                }
+
+            }),
+            json!({
+                "apiVersion": "brupop.bottlerocket.aws/v2",
+                "kind": "BottlerocketShadow",
+                "metadata": {
+                    "name": "brs-ip-192-168-22-145.us-west-2.compute.internal",
+                    "namespace": "brupop-bottlerocket-aws",
+                    "uid": "3153df27-6619-4b6b-bc75-adbf92ef7266",
+                    "ownerReferences": [
+                        {
+                            "apiVersion": "v1",
+                            "kind": "Node",
+                            "name": "ip-192-168-22-145.us-west-2.compute.internal",
+                            "uid": "6b714046-3b20-4a79-aaa9-27cf626a2c12"
+                        }
+                    ]
+                },
+                "spec": {
+                    "state": "Idle",
+                    "state_transition_timestamp": null,
+                    "version": null
+                },
+                "status": {
+                    "current_state": "Idle",
+                    "target_version": "1.8.0",
+                    "current_version": "1.8.0",
+                    "crash_count": 0,
+                    "state_transition_failure_timestamp": null,
+                }
+
+            }),
+        )];
+
+        for (original, target) in original_target_version.into_iter() {
+            let old_brs: BottleRocketShadowV1 = serde_json::from_value(original).unwrap();
+            let new_brs = BottlerocketShadow::from(old_brs);
+            let new_version = serde_json::to_value(new_brs).unwrap();
+            assert_eq!(new_version, target);
+        }
     }
 }

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -3,8 +3,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: brupop-bottlerocket-aws/brupop-apiserver-certificate
   name: bottlerocketshadows.brupop.bottlerocket.aws
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: brupop-apiserver
+          namespace: brupop-bottlerocket-aws
+          path: /crdconvert
+          port: 443
+      conversionReviewVersions:
+        - v1
+        - v2
   group: brupop.bottlerocket.aws
   names:
     categories: []
@@ -201,7 +215,7 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: brupop-apiserver
+  name: brupop-apiserver-certificate
   namespace: brupop-bottlerocket-aws
 spec:
   isCA: true
@@ -212,6 +226,7 @@ spec:
     encoding: PKCS8
   dnsNames:
     - brupop-apiserver.brupop-bottlerocket-aws.svc.cluster.local
+    - brupop-apiserver.brupop-bottlerocket-aws.svc
   issuerRef:
     name: selfsigned-issuer
     kind: ClusterIssuer

--- a/yamlgen/deploy/cert.yaml
+++ b/yamlgen/deploy/cert.yaml
@@ -29,6 +29,7 @@ spec:
     encoding: PKCS8
   dnsNames:
     - brupop-apiserver.brupop-bottlerocket-aws.svc.cluster.local
+    - brupop-apiserver.brupop-bottlerocket-aws.svc
   issuerRef:
     name: selfsigned-issuer
     kind: ClusterIssuer

--- a/yamlgen/deploy/cert.yaml
+++ b/yamlgen/deploy/cert.yaml
@@ -18,7 +18,7 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: brupop-apiserver
+  name: brupop-apiserver-certificate
   namespace: brupop-bottlerocket-aws
 spec:
   isCA: true


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#161 


**Description of changes:**
Add Webhooks in API Server and implemented the corresponding logic to convert different custom resources version.

Changes include:
* Update logic in CRD generation so the webhook config will be generated in yaml file.
* Implemented the BottlerocketShadow v1 to v2 convert in models.
* Defined `ConversionRequest` and `ConversionResponse` as the object webhook talk with Kubernetes API server
* Added chained convert logic and registered webhook on Brupop API Server.

**Testing done:**
* Unit test
* Provisioned a cluster with old Bottlerocket OS, deployed 0.2.1 on it, wait Brupop create CRDs with v1 and deploy the webhook to the cluster, monitor and wait the cluster complete upgrade to confirm webhook work as expected.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
