### PR TITLE
integration-test bug fix

### DIFF
--- a/integ/src/main.rs
+++ b/integ/src/main.rs
@@ -249,7 +249,7 @@ async fn run() -> Result<()> {
             if !nodes_exist(k8s_client).await.context(error::RunBrupop)? {
                 // Clean up all brupop resources like namespace, deployment on brupop test
                 info!("Deleting all brupop cluster resources created by integration test ...");
-                process_brupop_resources(Action::Apply, &kube_config_path)
+                process_brupop_resources(Action::Delete, &kube_config_path)
                     .await
                     .context(error::DeleteClusterResources)?;
 


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Mon Jul 18 23:03:19 2022 +0000

    integration-test bug fix

    When destroying brupop resources, the action should be 'delete'
    instead of 'apply'"

````


**Testing done:**
brupop integration test.

- Confirm all resources has been deleted.
```
[tianhg@ip-172-31-39-243 bottlerocket-update-operator]$ cargo run --bin integ clean --cluster-name brupop-ipv4 --region us-west-2
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/integ clean --cluster-name brupop-ipv4 --region us-west-2`
customresourcedefinition.apiextensions.k8s.io "bottlerocketshadows.brupop.bottlerocket.aws" deleted
namespace "brupop-bottlerocket-aws" deleted
clusterissuer.cert-manager.io "selfsigned-issuer" deleted
issuer.cert-manager.io "my-ca-issuer" deleted
certificate.cert-manager.io "brupop-apiserver" deleted
serviceaccount "brupop-apiserver-service-account" deleted
clusterrole.rbac.authorization.k8s.io "brupop-apiserver-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "brupop-apiserver-role-binding" deleted
clusterrolebinding.rbac.authorization.k8s.io "brupop-apiserver-auth-delegator-role-binding" deleted
deployment.apps "brupop-apiserver" deleted
service "brupop-apiserver" deleted
serviceaccount "brupop-agent-service-account" deleted
clusterrole.rbac.authorization.k8s.io "brupop-agent-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "brupop-agent-role-binding" deleted
daemonset.apps "brupop-agent" deleted
serviceaccount "brupop-controller-service-account" deleted
clusterrole.rbac.authorization.k8s.io "brupop-controller-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "brupop-controller-role-binding" deleted
deployment.apps "brupop-controller-deployment" deleted
service "brupop-controller-server" deleted
service "nginx" deleted
statefulset.apps "web-test" deleted
deployment.apps "nginx-test" deleted
poddisruptionbudget.policy "pod-disruption-budget-test" deleted
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
