### PR TITLE
Remove empty categories in Custom Resouce spec

### DIFF
--- a/models/src/node/crd/mod.rs
+++ b/models/src/node/crd/mod.rs
@@ -194,6 +194,14 @@ fn add_webhook_setting(
     combined_version_crds
 }
 
+/// `#[derive(CustomResource)]` set default categories to empty list
+/// causes mismatch in Kubernetes's object and YAML manifest file,
+/// futher causes ArgoCD/FluxCD constantly reapply defined manifest.
+fn remove_empty_categories(mut crds: CustomResourceDefinition) -> CustomResourceDefinition {
+    crds.spec.names.categories = None;
+    crds
+}
+
 pub fn combined_crds() -> CustomResourceDefinition {
     let mut crds: Vec<CustomResourceDefinition> = BOTTLEROCKETSHADOW_CRD_METHODS
         .iter()
@@ -201,5 +209,6 @@ pub fn combined_crds() -> CustomResourceDefinition {
         .collect();
     let latest_crd = crds.pop().unwrap();
     let combined_version_crds = combine_version_in_crds(latest_crd, crds);
-    add_webhook_setting(combined_version_crds)
+    let crds_with_webhook = add_webhook_setting(combined_version_crds);
+    remove_empty_categories(crds_with_webhook)
 }

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -21,7 +21,6 @@ spec:
         - v2
   group: brupop.bottlerocket.aws
   names:
-    categories: []
     kind: BottlerocketShadow
     plural: bottlerocketshadows
     shortNames:


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#205 


**Description of changes:**
Remove empty categories list in CRD.


Reason:
`#[derive(CustomResource)]` by default set categories to [empty list](https://github.com/kube-rs/kube-rs/blob/master/kube-derive/src/custom_resource.rs#L25), which doesn't match the object in Kubernetes.
```
  Group:  brupop.bottlerocket.aws
  Names:
    Kind:       BottlerocketShadow
    List Kind:  BottlerocketShadowList
    Plural:     bottlerocketshadows
    Short Names:
      brs
    Singular:  bottlerocketshadow
  Scope:       Namespaced
```
Causing  ArgoCD / FluxCD  detect differences and reapply the manifest


**Testing done:**
cargo build


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
