### PR TITLE
Add option to deregister node before draining.

### DIFF
--- a/.env
+++ b/.env
@@ -10,3 +10,9 @@ BRUPOP_CONTAINER_IMAGE=public.ecr.aws/bottlerocket/bottlerocket-update-operator:
 #  --docker-password=$(aws --region us-west-2 ecr get-login-password) \
 #  --namespace=brupop-bottlerocket-aws
 # BRUPOP_CONTAINER_IMAGE_PULL_SECRET=brupop
+
+# External load balancer setting.
+# When EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC is set to positive value
+# brupop will exclude the node from load balancer and 
+# wait for EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC seconds before draining node.
+EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC=0

--- a/README.md
+++ b/README.md
@@ -27,6 +27,32 @@ This will create the required namespace, custom resource definition, roles, depl
 Note: The above link is set to use the configuration for the latest version of the Update Operator, `v0.2.1`.
 Be sure to use the git tag for the Update Operator release that you plan to deploy.
 
+#### Configuration
+
+##### Exclude Nodes from Load Balancers Before Draining
+This configuration uses Kuberenetes [ServiceNodeExclusion](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) feature.
+`EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC` can be used to enable the feature to exclude the node from load balancer before draining.
+When `EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC` is 0 (default), the feature is disabled.
+When `EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC` is set to a positive integer, bottlerocket update operater will exclude the node from 
+load balancer and then wait `EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC` seconds before draining the pods on the node.
+
+To enable this feature, go to `bottlerocket-update-operator.yaml`, change `EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC` to a positive integer value.
+For example:
+```yaml
+      ...
+      containers:
+        - command:
+            - "./agent"
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC
+              value: "180"
+      ...
+```
+
 ### Label nodes
 
 By default, each Workload resource constrains scheduling of the update operator by limiting pods to Bottlerocket nodes based on their labels.

--- a/apiserver/src/api/drain.rs
+++ b/apiserver/src/api/drain.rs
@@ -45,3 +45,33 @@ pub(crate) async fn uncordon<T: BottlerocketShadowClient>(
 
     Ok(HttpResponse::Ok())
 }
+
+/// HTTP endpoint which exludes a node from load balancer.
+pub(crate) async fn exclude<T: BottlerocketShadowClient>(
+    settings: web::Data<APIServerSettings<T>>,
+    http_req: HttpRequest,
+) -> Result<impl Responder> {
+    let headers = ApiserverCommonHeaders::try_from(http_req.headers())?;
+    settings
+        .node_client
+        .exclude_node_from_lb(&headers.node_selector)
+        .await
+        .context(error::BottlerocketShadowDrain)?;
+
+    Ok(HttpResponse::Ok())
+}
+
+/// HTTP endpoint which remove node's exlusion from load balancer.
+pub(crate) async fn remove_exclusion<T: BottlerocketShadowClient>(
+    settings: web::Data<APIServerSettings<T>>,
+    http_req: HttpRequest,
+) -> Result<impl Responder> {
+    let headers = ApiserverCommonHeaders::try_from(http_req.headers())?;
+    settings
+        .node_client
+        .remove_node_exclusion_from_lb(&headers.node_selector)
+        .await
+        .context(error::BottlerocketShadowDrain)?;
+
+    Ok(HttpResponse::Ok())
+}

--- a/apiserver/src/api/mod.rs
+++ b/apiserver/src/api/mod.rs
@@ -7,9 +7,9 @@ mod ping;
 use crate::{
     auth::{K8STokenAuthorizor, K8STokenReviewer, TokenAuthMiddleware},
     constants::{
-        CRD_CONVERT_ENDPOINT, HEADER_BRUPOP_K8S_AUTH_TOKEN, HEADER_BRUPOP_NODE_NAME,
-        HEADER_BRUPOP_NODE_UID, NODE_CORDON_AND_DRAIN_ENDPOINT, NODE_RESOURCE_ENDPOINT,
-        NODE_UNCORDON_ENDPOINT,
+        CRD_CONVERT_ENDPOINT, EXCLUDE_NODE_FROM_LB_ENDPOINT, HEADER_BRUPOP_K8S_AUTH_TOKEN,
+        HEADER_BRUPOP_NODE_NAME, HEADER_BRUPOP_NODE_UID, NODE_CORDON_AND_DRAIN_ENDPOINT,
+        NODE_RESOURCE_ENDPOINT, NODE_UNCORDON_ENDPOINT, REMOVE_NODE_EXCLUSION_TO_LB_ENDPOINT,
     },
     error::{self, Result},
     telemetry,
@@ -187,6 +187,14 @@ pub async fn run_server<T: 'static + BottlerocketShadowClient>(
             )
             .service(
                 web::resource(NODE_UNCORDON_ENDPOINT).route(web::post().to(drain::uncordon::<T>)),
+            )
+            .service(
+                web::resource(EXCLUDE_NODE_FROM_LB_ENDPOINT)
+                    .route(web::post().to(drain::exclude::<T>)),
+            )
+            .service(
+                web::resource(REMOVE_NODE_EXCLUSION_TO_LB_ENDPOINT)
+                    .route(web::post().to(drain::remove_exclusion::<T>)),
             )
             .service(
                 web::resource(CRD_CONVERT_ENDPOINT)

--- a/apiserver/src/client/error.rs
+++ b/apiserver/src/client/error.rs
@@ -70,4 +70,26 @@ pub enum ClientError {
 
     #[snafu(display("Failed to create https client due to {}", source))]
     CreateClientError { source: reqwest::Error },
+
+    #[snafu(display(
+        "Unable to exclude node from load balancer ({}, {}): '{}'",
+        selector.node_name,
+        selector.node_uid,
+        source
+    ))]
+    ExcludeNodeFromLB {
+        source: Box<dyn std::error::Error>,
+        selector: BottlerocketShadowSelector,
+    },
+
+    #[snafu(display(
+        "Unable to remove node exlucsion from load balancer ({}, {}): '{}'",
+        selector.node_name,
+        selector.node_uid,
+        source
+    ))]
+    RemoveNodeExclusionFromLB {
+        source: Box<dyn std::error::Error>,
+        selector: BottlerocketShadowSelector,
+    },
 }

--- a/apiserver/src/client/mock.rs
+++ b/apiserver/src/client/mock.rs
@@ -2,6 +2,7 @@
 use super::{error::Result, APIServerClient};
 use crate::{
     CordonAndDrainBottlerocketShadowRequest, CreateBottlerocketShadowRequest,
+    ExcludeNodeFromLoadBalancerRequest, RemoveNodeExclusionFromLoadBalancerRequest,
     UncordonBottlerocketShadowRequest, UpdateBottlerocketShadowRequest,
 };
 use models::node::{BottlerocketShadow, BottlerocketShadowStatus};
@@ -26,5 +27,7 @@ mock! {
         async fn cordon_and_drain_node(&self, req: CordonAndDrainBottlerocketShadowRequest)
             -> Result<()>;
         async fn uncordon_node(&self, req: UncordonBottlerocketShadowRequest) -> Result<()>;
+        async fn exclude_node_from_lb(&self, req: ExcludeNodeFromLoadBalancerRequest) -> Result<()>;
+        async fn remove_node_exclusion_from_lb(&self, req: RemoveNodeExclusionFromLoadBalancerRequest) -> Result<()>;
     }
 }

--- a/apiserver/src/constants.rs
+++ b/apiserver/src/constants.rs
@@ -4,6 +4,9 @@ pub const NODE_RESOURCE_ENDPOINT: &str = "/bottlerocket-node-resource";
 pub const NODE_CORDON_AND_DRAIN_ENDPOINT: &str = "/bottlerocket-node-resource/cordon-and-drain";
 pub const NODE_UNCORDON_ENDPOINT: &str = "/bottlerocket-node-resource/uncordon";
 pub const CRD_CONVERT_ENDPOINT: &str = APISERVER_CRD_CONVERT_ENDPOINT;
+pub const EXCLUDE_NODE_FROM_LB_ENDPOINT: &str = "/bottlerocket-node-resource/exclude-from-lb";
+pub const REMOVE_NODE_EXCLUSION_TO_LB_ENDPOINT: &str =
+    "/bottlerocket-node-resource/remove-exclusion-from-lb";
 
 // Key names for HTTP headers for apiserver.
 pub(crate) const HEADER_BRUPOP_NODE_NAME: &str = "BrupopNodeName";

--- a/apiserver/src/lib.rs
+++ b/apiserver/src/lib.rs
@@ -41,3 +41,13 @@ pub struct CordonAndDrainBottlerocketShadowRequest {
 pub struct UncordonBottlerocketShadowRequest {
     pub node_selector: BottlerocketShadowSelector,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExcludeNodeFromLoadBalancerRequest {
+    pub node_selector: BottlerocketShadowSelector,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoveNodeExclusionFromLoadBalancerRequest {
+    pub node_selector: BottlerocketShadowSelector,
+}

--- a/models/src/node/error.rs
+++ b/models/src/node/error.rs
@@ -63,6 +63,28 @@ pub enum Error {
     },
 
     #[snafu(display(
+        "Unable to exclude node from load balancer ({}, {}): '{}'",
+        selector.node_name,
+        selector.node_uid,
+        source
+    ))]
+    ExcludeNodeFromLB {
+        source: Box<dyn std::error::Error>,
+        selector: BottlerocketShadowSelector,
+    },
+
+    #[snafu(display(
+        "Unable to remove node exclusion from load balancer ({}, {}): '{}'",
+        selector.node_name,
+        selector.node_uid,
+        source
+    ))]
+    RemoveNodeExclusionFromLB {
+        source: Box<dyn std::error::Error>,
+        selector: BottlerocketShadowSelector,
+    },
+
+    #[snafu(display(
         "Unable to uncordon BottlerocketShadow ({}, {}): '{}'",
         selector.node_name,
         selector.node_uid,

--- a/yamlgen/build.rs
+++ b/yamlgen/build.rs
@@ -48,6 +48,11 @@ fn main() {
 
     let brupop_image = env::var("BRUPOP_CONTAINER_IMAGE").ok().unwrap();
     let brupop_image_pull_secrets = env::var("BRUPOP_CONTAINER_IMAGE_PULL_SECRET").ok();
+    let exclude_from_lb_wait_time: u64 = env::var("EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC")
+        .ok()
+        .unwrap()
+        .parse()
+        .unwrap();
 
     serde_yaml::to_writer(&brupop_resources, &brupop_namespace()).unwrap();
 
@@ -80,7 +85,11 @@ fn main() {
     serde_yaml::to_writer(&brupop_resources, &agent_cluster_role_binding()).unwrap();
     serde_yaml::to_writer(
         &brupop_resources,
-        &agent_daemonset(brupop_image.clone(), brupop_image_pull_secrets.clone()),
+        &agent_daemonset(
+            brupop_image.clone(),
+            brupop_image_pull_secrets.clone(),
+            exclude_from_lb_wait_time,
+        ),
     )
     .unwrap();
 

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -531,6 +531,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC
+              value: "0"
           image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v0.2.2"
           name: brupop
           resources:


### PR DESCRIPTION


<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#156 


**Description of changes:**
* Add `DEREGISTER_FROM_LB_WAIT_TIME_IN_SEC` in `.env` as environment variable.
* Deregister node from load balancer before draining
  when DEREGISTER_FROM_LB_WAIT_TIME_IN_SEC is larger than 0.
* Register node to load balancer after draining
  when DEREGISTER_FROM_LB_WAIT_TIME_IN_SEC is larger than 0.


**Testing done:**
Tested on cluster, monitored node get labeled and unlabeled.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
