### PR TITLE
cleanup brs when brupop is removed from the node.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,7 @@ dependencies = [
  "http",
  "k8s-openapi",
  "kube",
+ "maplit",
  "models",
  "opentelemetry",
  "opentelemetry-prometheus",

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -10,6 +10,7 @@ actix-web = { version = "4.0.0-beta.9", default-features = false }
 chrono = "0.4"
 futures = "0.3"
 http = "0.2.5"
+maplit = "1.0"
 semver = "1.0"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_20"] }

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -4,4 +4,5 @@ mod metrics;
 pub mod statemachine;
 pub mod telemetry;
 
+pub use crate::controller::controllerclient_error;
 pub use crate::controller::BrupopController;

--- a/models/src/controller.rs
+++ b/models/src/controller.rs
@@ -63,7 +63,7 @@ pub fn controller_cluster_role() -> ClusterRole {
             PolicyRule {
                 api_groups: Some(vec![BRUPOP_DOMAIN_LIKE_NAME.to_string()]),
                 resources: Some(vec![K8S_NODE_PLURAL.to_string()]),
-                verbs: vec!["create", "patch", "update"]
+                verbs: vec!["create", "patch", "update", "delete"]
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
@@ -84,6 +84,15 @@ pub fn controller_cluster_role() -> ClusterRole {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
+                ..Default::default()
+            },
+            PolicyRule {
+                api_groups: Some(vec!["".to_string()]),
+                resources: Some(vec!["nodes".to_string()]),
+                verbs: vec!["get", "list", "watch"]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
                 ..Default::default()
             },
         ]),

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -618,6 +618,7 @@ rules:
       - create
       - patch
       - update
+      - delete
   - apiGroups:
       - apps
     resources:
@@ -630,6 +631,14 @@ rules:
       - list
       - patch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#107 


**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Thu Aug 11 19:32:12 2022 +0000

    cleanup brs when the brupop is removed from the node

    Currently we require customers to manually clean up the Custom Resources
    if they choose to delete only the updater-interface-version label. This
    change would help on automatically cleaning up BRS if customer removes
    brupop(label) from corresponding node.

commit b81eefc195f4669510146793acf64b3c5bc959e9
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Thu Aug 11 18:36:49 2022 +0000

    Add deletion support to brs client

    According to brs cleanup strategy, we support brs client to be able to
    delete brs object.
```


**Testing done:**
Method: Run brupop integration test. Remove brupop label from nodes, and then confirm if associated brs has been removed. 

Test with three scenarios 

- [x] [Waiting-for-update] The node is waiting for update and customers remove the labels 
- [x] [In-progress] Customers remove the labels when brupop is preforming update on the node.
- [x] [Complete] The node has been updated, and customers remove the labels.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
