### PR TITLE
Add support for concurrent update

### DIFF
--- a/.env
+++ b/.env
@@ -16,3 +16,12 @@ BRUPOP_CONTAINER_IMAGE=public.ecr.aws/bottlerocket/bottlerocket-update-operator:
 # brupop will exclude the node from load balancer and 
 # wait for EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC seconds before draining node.
 EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC=0
+
+# Concurrent update nodes setting.
+# When MAX_CONCURRENT_UPDATE is set to a positive integer value,
+# brupop will concurrently update max MAX_CONCURRENT_UPDATE nodes.
+# When MAX_CONCURRENT_UPDATE is set to "unlimited",
+# brupop will concurrently update all nodes with respecting `PodDisruptionBudgets`
+# Note: the "unlimited" option does not work well with `EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC`
+# option, which could potential exclude all nodes from load balancer at the same time.
+MAX_CONCURRENT_UPDATE=1

--- a/README.md
+++ b/README.md
@@ -53,6 +53,32 @@ For example:
       ...
 ```
 
+##### Set Up Max Concurrent Update
+`MAX_CONCURRENT_UPDATE` can be used to specify the max concurrent updates during updating.
+When `MAX_CONCURRENT_UPDATE` is a positive integer number, bottlerocket update operator
+will concurrently update up to `MAX_CONCURRENT_UPDATE` nodes respecting [PodDisruptionBudgets](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).
+When `MAX_CONCURRENT_UPDATE` is set to `unlimited`, bottlerocket update operator
+will concurrently update all nodes respecting [PodDisruptionBudgets](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).
+
+Note: The `MAX_CONCURRENT_UPDATE` configuration does not work well with `EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC` 
+configuration, especially when `MAX_CONCURRENT_UPDATE` is set to `unlimited`, it could potentially exclude all 
+nodes from load balancer at the same time..
+
+To enable this feature, go to `bottlerocket-update-operator.yaml`, change `MAX_CONCURRENT_UPDATE` to a positive integer value or `unlimited`.
+For example:
+```yaml
+      containers:
+        - command:
+            - "./controller"
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MAX_CONCURRENT_UPDATE
+              value: "1"
+```
+
 ### Label nodes
 
 By default, each Workload resource constrains scheduling of the update operator by limiting pods to Bottlerocket nodes based on their labels.

--- a/models/src/controller.rs
+++ b/models/src/controller.rs
@@ -118,6 +118,7 @@ pub fn controller_cluster_role_binding() -> ClusterRoleBinding {
 pub fn controller_deployment(
     brupop_image: String,
     image_pull_secret: Option<String>,
+    max_concurrent_update: String,
 ) -> Deployment {
     let image_pull_secrets =
         image_pull_secret.map(|secret| vec![LocalObjectReference { name: Some(secret) }]);
@@ -186,17 +187,24 @@ pub fn controller_deployment(
                         image_pull_policy: None,
                         name: BRUPOP.to_string(),
                         command: Some(vec!["./controller".to_string()]),
-                        env: Some(vec![EnvVar {
-                            name: "MY_NODE_NAME".to_string(),
-                            value_from: Some(EnvVarSource {
-                                field_ref: Some(ObjectFieldSelector {
-                                    field_path: "spec.nodeName".to_string(),
+                        env: Some(vec![
+                            EnvVar {
+                                name: "MY_NODE_NAME".to_string(),
+                                value_from: Some(EnvVarSource {
+                                    field_ref: Some(ObjectFieldSelector {
+                                        field_path: "spec.nodeName".to_string(),
+                                        ..Default::default()
+                                    }),
                                     ..Default::default()
                                 }),
                                 ..Default::default()
-                            }),
-                            ..Default::default()
-                        }]),
+                            },
+                            EnvVar {
+                                name: "MAX_CONCURRENT_UPDATE".to_string(),
+                                value: Some(max_concurrent_update),
+                                ..Default::default()
+                            },
+                        ]),
                         ..Default::default()
                     }],
                     image_pull_secrets,

--- a/yamlgen/build.rs
+++ b/yamlgen/build.rs
@@ -54,6 +54,14 @@ fn main() {
         .parse()
         .unwrap();
 
+    let max_concurrent_update: String = env::var("MAX_CONCURRENT_UPDATE")
+        .ok()
+        .unwrap()
+        .to_lowercase();
+    // Make sure it is integer if it is not "unlimited"
+    if !max_concurrent_update.eq("unlimited") {
+        max_concurrent_update.clone().parse::<usize>().unwrap();
+    }
     serde_yaml::to_writer(&brupop_resources, &brupop_namespace()).unwrap();
 
     // cert-manager and secret
@@ -100,7 +108,11 @@ fn main() {
     serde_yaml::to_writer(&brupop_resources, &controller_priority_class()).unwrap();
     serde_yaml::to_writer(
         &brupop_resources,
-        &controller_deployment(brupop_image.clone(), brupop_image_pull_secrets.clone()),
+        &controller_deployment(
+            brupop_image.clone(),
+            brupop_image_pull_secrets.clone(),
+            max_concurrent_update,
+        ),
     )
     .unwrap();
     serde_yaml::to_writer(&brupop_resources, &controller_service()).unwrap();

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -703,6 +703,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: MAX_CONCURRENT_UPDATE
+              value: "1"
           image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v0.2.2"
           name: brupop
       priorityClassName: brupop-controller-high-priority


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#163 


**Description of changes:**
Add support for concurrent update


**Testing done:**
Tested on my cluster on number value and unlimited value.
Making sure Brupop run update parallel based on the setting value.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
