### PR TITLE
Fix README.md to point to 0.2.2 branch rather than v0.2.2 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We use [cert-manager](https://cert-manager.io) to manage self-signed certificate
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.8.2/cert-manager.yaml
 ```
 
-We can install the Bottlerocket update operator using the recommended configuration defined in [bottlerocket-update-operator.yaml](https://github.com/bottlerocket-os/bottlerocket-update-operator/blob/v0.2.2/yamlgen/deploy/bottlerocket-update-operator.yaml):
+We can install the Bottlerocket update operator using the recommended configuration defined in [bottlerocket-update-operator.yaml](https://github.com/bottlerocket-os/bottlerocket-update-operator/blob/0.2.2/yamlgen/deploy/bottlerocket-update-operator.yaml):
 
 ```sh
 kubectl apply -f ./bottlerocket-update-operator.yaml


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#237 


**Description of changes:**
README.md point to  [v0.2.2](https://github.com/bottlerocket-os/bottlerocket-update-operator/blob/v0.2.2/yamlgen/deploy/bottlerocket-update-operator.yaml#L534) file which still uses 0.2.1 image.

Update README.md point to [0.2.2](https://github.com/bottlerocket-os/bottlerocket-update-operator/blob/0.2.2/yamlgen/deploy/bottlerocket-update-operator.yaml#L534) branch.


**Testing done:**
None


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
