### PR TITLE
Provide a mechanism to allow updates in certain time window

### DIFF
--- a/.env
+++ b/.env
@@ -25,3 +25,9 @@ EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC=0
 # Note: the "unlimited" option does not work well with `EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC`
 # option, which could potential exclude all nodes from load balancer at the same time.
 MAX_CONCURRENT_UPDATE=1
+
+# Update time window setting
+# Brupop will operate node updates within update time window.
+# when you set up time window start and stop time, you should use UTC (24-hour time notation).
+UPDATE_WINDOW_START=0:0:0
+UPDATE_WINDOW_STOP=0:0:0

--- a/README.md
+++ b/README.md
@@ -79,6 +79,31 @@ For example:
               value: "1"
 ```
 
+##### Set Up Update Time Window
+`UPDATE_WINDOW_START` and `UPDATE_WINDOW_STOP` can be used to specify the time window in which updates are permitted.
+When `UPDATE_WINDOW_START` and `UPDATE_WINDOW_STOP` is 0:0:0 (default), the feature is disabled.
+
+To enable this feature, go to `bottlerocket-update-operator.yaml`, change `UPDATE_WINDOW_START` and `UPDATE_WINDOW__STOP` to a `hour:minute:second` formate value (UTC (24-hour time notation)). Note that `UPDATE_WINDOW_START` is inclusive and `UPDATE_WINDOW_STOP` is exclusive.
+
+To avoid stopping an in-process node update when the update window stops, Bottlerocket update operator reserves 6 mins before `UPDATE_WINDOW_STOP` to finish remaining updates.
+
+Note: brupop uses UTC (24-hour time notation), please convert your local time to UTC.
+For example:
+```yaml
+      containers:
+        - command:
+            - "./controller"
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: UPDATE_WINDOW_START
+              value: "9:0:0"
+            - name: UPDATE_WINDOW_STOP
+              value: "21:0:0"
+```
+
 ### Label nodes
 
 By default, each Workload resource constrains scheduling of the update operator by limiting pods to Bottlerocket nodes based on their labels.

--- a/models/src/controller.rs
+++ b/models/src/controller.rs
@@ -128,6 +128,8 @@ pub fn controller_deployment(
     brupop_image: String,
     image_pull_secret: Option<String>,
     max_concurrent_update: String,
+    update_window_start: String,
+    update_window_stop: String,
 ) -> Deployment {
     let image_pull_secrets =
         image_pull_secret.map(|secret| vec![LocalObjectReference { name: Some(secret) }]);
@@ -211,6 +213,16 @@ pub fn controller_deployment(
                             EnvVar {
                                 name: "MAX_CONCURRENT_UPDATE".to_string(),
                                 value: Some(max_concurrent_update),
+                                ..Default::default()
+                            },
+                            EnvVar {
+                                name: "UPDATE_WINDOW_START".to_string(),
+                                value: Some(update_window_start),
+                                ..Default::default()
+                            },
+                            EnvVar {
+                                name: "UPDATE_WINDOW_STOP".to_string(),
+                                value: Some(update_window_stop),
                                 ..Default::default()
                             },
                         ]),

--- a/yamlgen/build.rs
+++ b/yamlgen/build.rs
@@ -53,6 +53,8 @@ fn main() {
         .unwrap()
         .parse()
         .unwrap();
+    let update_window_start: String = env::var("UPDATE_WINDOW_START").ok().unwrap();
+    let update_window_stop: String = env::var("UPDATE_WINDOW_STOP").ok().unwrap();
 
     let max_concurrent_update: String = env::var("MAX_CONCURRENT_UPDATE")
         .ok()
@@ -112,6 +114,8 @@ fn main() {
             brupop_image,
             brupop_image_pull_secrets,
             max_concurrent_update,
+            update_window_start,
+            update_window_stop,
         ),
     )
     .unwrap();

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -714,6 +714,10 @@ spec:
                   fieldPath: spec.nodeName
             - name: MAX_CONCURRENT_UPDATE
               value: "1"
+            - name: UPDATE_WINDOW_START
+              value: "0:0:0"
+            - name: UPDATE_WINDOW_STOP
+              value: "0:0:0"
           image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v0.2.2"
           name: brupop
       priorityClassName: brupop-controller-high-priority


### PR DESCRIPTION
users could have workload that cannot be interrupted during some periods of the day, so we provide a mechanism to prevent Bottlerocket nodes update on user customized time window.

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes: #67

**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>

Provide a mechanism to allow updates in certain update time window

Users could have workload that cannot be interrupted during some periods
of the day, so we provide a mechanism to allow Bottlerocket nodes updates
on user customized update time window. Beyond update time window,
bottlerocker update operator will prevent any updates.
```


**Testing done:**
Set up update time window and then confirm if brupop stops updating nodes except in-process node.

```
UPDATE_WINDOW_START=23:55:0
UPDATE_WINDOW_STOP=0:10:0
```

```
UPDATE_WINDOW_START=0:15:0
UPDATE_WINDOW_STOP=0:24:0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
