### PR TITLE
Use ca.crt in ssl

### DIFF
--- a/apiserver/src/api/mod.rs
+++ b/apiserver/src/api/mod.rs
@@ -15,8 +15,8 @@ use crate::{
     telemetry,
 };
 use models::constants::{
-    AGENT, APISERVER_HEALTH_CHECK_ROUTE, APISERVER_SERVICE_NAME, LABEL_COMPONENT, NAMESPACE,
-    PRIVATE_KEY_NAME, PUBLIC_KEY_NAME, TLS_KEY_MOUNT_PATH,
+    AGENT, APISERVER_HEALTH_CHECK_ROUTE, APISERVER_SERVICE_NAME, CA_NAME, LABEL_COMPONENT,
+    NAMESPACE, PRIVATE_KEY_NAME, PUBLIC_KEY_NAME, TLS_KEY_MOUNT_PATH,
 };
 use models::node::{BottlerocketShadowClient, BottlerocketShadowSelector};
 
@@ -152,7 +152,13 @@ pub async fn run_server<T: 'static + BottlerocketShadowClient>(
     let mut builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls()).context(error::SSLError)?;
 
     builder
-        .set_certificate_chain_file(format!("{}/{}", TLS_KEY_MOUNT_PATH, PUBLIC_KEY_NAME))
+        .set_certificate_chain_file(format!("{}/{}", TLS_KEY_MOUNT_PATH, CA_NAME))
+        .context(error::SSLError)?;
+    builder
+        .set_certificate_file(
+            format!("{}/{}", TLS_KEY_MOUNT_PATH, PUBLIC_KEY_NAME),
+            SslFiletype::PEM,
+        )
         .context(error::SSLError)?;
     builder
         .set_private_key_file(

--- a/apiserver/src/client/webclient.rs
+++ b/apiserver/src/client/webclient.rs
@@ -11,8 +11,7 @@ use crate::{
 };
 use models::{
     constants::{
-        APISERVER_SERVICE_NAME, APISERVER_SERVICE_PORT, NAMESPACE, PUBLIC_KEY_NAME,
-        TLS_KEY_MOUNT_PATH,
+        APISERVER_SERVICE_NAME, APISERVER_SERVICE_PORT, CA_NAME, NAMESPACE, TLS_KEY_MOUNT_PATH,
     },
     node::{BottlerocketShadow, BottlerocketShadowSelector, BottlerocketShadowStatus},
 };
@@ -110,8 +109,8 @@ impl K8SAPIServerClient {
     fn https_client() -> Result<reqwest::Client> {
         let mut buf = Vec::new();
 
-        let public_key_path = format!("{}/{}", TLS_KEY_MOUNT_PATH, PUBLIC_KEY_NAME);
-        std::fs::File::open(public_key_path)
+        let ca_path = format!("{}/{}", TLS_KEY_MOUNT_PATH, CA_NAME);
+        std::fs::File::open(ca_path)
             .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
             .context(error::IOError)?
             .read_to_end(&mut buf)


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#232 

**Description of changes:**
Use CA.crt in the SSL configurations.


**Testing done:**
Integration test done.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
