### PR TITLE
clarify crossbeam license

### DIFF
--- a/clarify.toml
+++ b/clarify.toml
@@ -7,7 +7,7 @@ license-files = [
 ]
 
 [clarify.crossbeam-channel]
-expression = "(MIT OR Apache-2.0) AND BSD-2-Clause AND CC-BY-3.0"
+expression = "MIT OR Apache-2.0"
 license-files = [
     { path = "LICENSE-APACHE", hash = 0x24b54f4b },
     { path = "LICENSE-MIT", hash = 0xbc436f08 },


### PR DESCRIPTION
**Issue number:**
N/A


**Description of changes:**
The BSD-2-Clause license is not listed upstream since this change:
  https://github.com/crossbeam-rs/crossbeam/pull/537


**Testing done:**
None!

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
