### PR TITLE
Use ca.crt in ssl - rebased

### DIFF
--- a/apiserver/src/api/mod.rs
+++ b/apiserver/src/api/mod.rs
@@ -15,8 +15,8 @@ use crate::{
     telemetry,
 };
 use models::constants::{
-    AGENT, APISERVER_HEALTH_CHECK_ROUTE, APISERVER_SERVICE_NAME, LABEL_COMPONENT, NAMESPACE,
-    PRIVATE_KEY_NAME, PUBLIC_KEY_NAME, TLS_KEY_MOUNT_PATH,
+    AGENT, APISERVER_HEALTH_CHECK_ROUTE, APISERVER_SERVICE_NAME, CA_NAME, LABEL_COMPONENT,
+    NAMESPACE, PRIVATE_KEY_NAME, PUBLIC_KEY_NAME, TLS_KEY_MOUNT_PATH,
 };
 use models::node::{BottlerocketShadowClient, BottlerocketShadowSelector};
 
@@ -152,7 +152,13 @@ pub async fn run_server<T: 'static + BottlerocketShadowClient>(
     let mut builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls()).context(error::SSLSnafu)?;
 
     builder
-        .set_certificate_chain_file(format!("{}/{}", TLS_KEY_MOUNT_PATH, PUBLIC_KEY_NAME))
+        .set_certificate_chain_file(format!("{}/{}", TLS_KEY_MOUNT_PATH, CA_NAME))
+        .context(error::SSLSnafu)?;
+    builder
+        .set_certificate_file(
+            format!("{}/{}", TLS_KEY_MOUNT_PATH, PUBLIC_KEY_NAME),
+            SslFiletype::PEM,
+        )
         .context(error::SSLSnafu)?;
     builder
         .set_private_key_file(

--- a/apiserver/src/client/webclient.rs
+++ b/apiserver/src/client/webclient.rs
@@ -11,8 +11,7 @@ use crate::{
 };
 use models::{
     constants::{
-        APISERVER_SERVICE_NAME, APISERVER_SERVICE_PORT, NAMESPACE, PUBLIC_KEY_NAME,
-        TLS_KEY_MOUNT_PATH,
+        APISERVER_SERVICE_NAME, APISERVER_SERVICE_PORT, CA_NAME, NAMESPACE, TLS_KEY_MOUNT_PATH,
     },
     node::{BottlerocketShadow, BottlerocketShadowSelector, BottlerocketShadowStatus},
 };
@@ -110,8 +109,8 @@ impl K8SAPIServerClient {
     fn https_client() -> Result<reqwest::Client> {
         let mut buf = Vec::new();
 
-        let public_key_path = format!("{}/{}", TLS_KEY_MOUNT_PATH, PUBLIC_KEY_NAME);
-        std::fs::File::open(public_key_path)
+        let ca_path = format!("{}/{}", TLS_KEY_MOUNT_PATH, CA_NAME);
+        std::fs::File::open(ca_path)
             .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
             .context(error::IOSnafu)?
             .read_to_end(&mut buf)


### PR DESCRIPTION
```
Co-authored-by: Lu Ma <lummam@amazon.com>
Co-authored-by: John McBride <jpmmcb@amazon.com>
Signed-off-by: John McBride <jpmmcb@amazon.com>
```

This PR succeeds and closes #249  (note: it was required to re-create this PR since Lu no longer works on this project)

**Issue number:**

Closes: https://github.com/bottlerocket-os/bottlerocket-update-operator/issues/232

**Description of changes:**

Uses a CA cert in the SSL configuration

**Testing done:**

Running integration tests now, but should be fine since #249 worked with it's integration tests

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
