### PR TITLE
Enables automatic prometheus scrapping for controller's service

### DIFF
--- a/models/src/controller.rs
+++ b/models/src/controller.rs
@@ -234,6 +234,10 @@ pub fn controller_service() -> Service {
             labels: Some(brupop_labels!(CONTROLLER)),
             name: Some(CONTROLLER_SERVICE_NAME.to_string()),
             namespace: Some(NAMESPACE.to_string()),
+            annotations: Some(btreemap! {
+                "prometheus.io/scrape".to_string() => true.to_string(),
+                "prometheus.io/port".to_string() => "8080".to_string(),
+            }),
             ..Default::default()
         },
 

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -722,6 +722,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
   labels:
     app.kubernetes.io/component: brupop-controller
     app.kubernetes.io/managed-by: brupop

--- a/yamlgen/telemetry/prometheus-resources.yaml
+++ b/yamlgen/telemetry/prometheus-resources.yaml
@@ -48,6 +48,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-config
+  namespace: brupop-bottlerocket-aws
 data:
   prometheus.yml: |
     global:


### PR DESCRIPTION
```
- Adds prometheues config map to the brupop namespace

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

### ssue number:

Closes https://github.com/bottlerocket-os/bottlerocket-update-operator/issues/159

### Description of changes:

This commit adds the 
```
  annotations:
    prometheus.io/port: "8080"
    prometheus.io/scrape: "true"
```
to the controller service (so that prometheus may automatically start scraping metrics when deployed).

This also adds a missing namespace delimiter for the `prometheus-config` ConfigMap. Otherwise, I would get an error that the configmap could not be found

From the kubernetes docs:

> You can write a Pod spec that refers to a ConfigMap and configures the container(s) in that Pod based on the data in the ConfigMap. The Pod and the ConfigMap must be in the same [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces).

Ref: https://kubernetes.io/docs/concepts/configuration/configmap/#configmaps-and-pods

### Testing done:

Deployed cert-manager, the modified `bottlerocket-update-operator.yaml`, and the modified `yamlgen/telemetry/prometheus-resources.yaml` to a bottlerocket based cluster.

I see that automatically Prometheus starts scraping the metrics:

```
$ curl http://localhost:9090/api/v1/label/__name__/values
{"status":"success","data":["brupop_hosts_state","brupop_hosts_version" ... }
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
