### PR TITLE
Fix broken enum serialization in openapi schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.11"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
+checksum = "1847b767a3d62d95cbf3d8a9f0e421cf57a0d8aa4f411d4b16525afb0284d4ed"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -2556,9 +2556,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.11"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
+checksum = "af4d7e1b012cb3d9129567661a63755ea4b8a7386d339dc945ae187e403c6743"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -37,7 +37,7 @@ lazy_static = "1.4"
 log = "0.4"
 mockall = { version = "0.10", optional = true }
 reqwest = { version = "0.11", features =  [ "json", "native-tls" ] }
-schemars = "0.8"
+schemars = "0.8.10"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 snafu = "0.7"

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -18,7 +18,7 @@ maplit = "1.0"
 mockall = { version = "0.10", optional = true }
 regex = "1.6"
 reqwest = "0.11"
-schemars = "0.8"
+schemars = "0.8.10"
 semver = "1.0"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"


### PR DESCRIPTION
### Issue number:

Quickfix related to  #277 

**Description of changes:**

This locks us into the `v0.8.10` release of `schemars` since `develop` is broken and the generated yaml is invalid

### Testing done:

Able to `make build` and `git status` shows no diff in `yamlgen/`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
