### PR TITLE
Refactors `apiserver` errors to be module specific

### DIFF
--- a/apiserver/src/api/drain.rs
+++ b/apiserver/src/api/drain.rs
@@ -1,5 +1,6 @@
+use super::error;
+use super::Result;
 use super::{APIServerSettings, ApiserverCommonHeaders};
-use crate::error::{self, Result};
 use models::node::BottlerocketShadowClient;
 
 use actix_web::{

--- a/apiserver/src/api/error.rs
+++ b/apiserver/src/api/error.rs
@@ -3,16 +3,9 @@ use models::node::BottlerocketShadowError;
 use actix_web::error::ResponseError;
 use snafu::Snafu;
 
-/// The crate-wide result type.
-pub type Result<T> = std::result::Result<T, Error>;
-
-/// The crate-wide error type.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
-    #[snafu(display("Unable to create client: '{}'", source))]
-    ClientCreate { source: kube::Error },
-
     #[snafu(display("Unable to parse HTTP header. Missing '{}'", missing_header))]
     HTTPHeaderParse { missing_header: &'static str },
 
@@ -27,11 +20,6 @@ pub enum Error {
 
     #[snafu(display("Error running HTTP server: '{}'", source))]
     HttpServerError { source: std::io::Error },
-
-    #[snafu(display("Error configuring tracing: '{}'", source))]
-    TracingConfiguration {
-        source: tracing::subscriber::SetGlobalDefaultError,
-    },
 
     #[snafu(display("The Kubernetes WATCH on Pod objects has failed."))]
     KubernetesWatcherFailed {},

--- a/apiserver/src/api/mod.rs
+++ b/apiserver/src/api/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains the brupop API server. Endpoints are stored in submodules, separated
 //! by the resource on which they act.
 mod drain;
+pub mod error;
 mod node;
 mod ping;
 
@@ -11,7 +12,6 @@ use crate::{
         HEADER_BRUPOP_NODE_NAME, HEADER_BRUPOP_NODE_UID, NODE_CORDON_AND_DRAIN_ENDPOINT,
         NODE_RESOURCE_ENDPOINT, NODE_UNCORDON_ENDPOINT, REMOVE_NODE_EXCLUSION_TO_LB_ENDPOINT,
     },
-    error::{self, Result},
     telemetry,
 };
 use models::constants::{
@@ -45,6 +45,9 @@ use std::convert::TryFrom;
 
 // The set of API endpoints for which `tracing::Span`s will not be recorded.
 pub const NO_TELEMETRY_ENDPOINTS: &[&str] = &[APISERVER_HEALTH_CHECK_ROUTE];
+
+/// The API module-wide result type.
+type Result<T> = std::result::Result<T, error::Error>;
 
 /// A struct containing information intended to be passed to the apiserver via HTTP headers.
 pub(crate) struct ApiserverCommonHeaders {

--- a/apiserver/src/api/node.rs
+++ b/apiserver/src/api/node.rs
@@ -1,5 +1,4 @@
 use super::{APIServerSettings, ApiserverCommonHeaders};
-use crate::error::{self, Result};
 use crate::webhook::ConversionRequest;
 
 use models::node::{BottlerocketShadowClient, BottlerocketShadowStatus};
@@ -13,6 +12,9 @@ use serde_json::json;
 use snafu::ResultExt;
 use std::convert::TryFrom;
 use tracing::{event, Level};
+
+use super::error;
+use super::Result;
 
 /// HTTP endpoint which creates BottlerocketShadow custom resources on behalf of the caller.
 pub(crate) async fn create_bottlerocket_shadow_resource<T: BottlerocketShadowClient>(

--- a/apiserver/src/lib.rs
+++ b/apiserver/src/lib.rs
@@ -3,8 +3,6 @@ pub mod api;
 #[cfg(feature = "server")]
 mod auth;
 #[cfg(feature = "server")]
-pub mod error;
-#[cfg(feature = "server")]
 pub mod telemetry;
 
 #[cfg(feature = "client")]

--- a/apiserver/src/main.rs
+++ b/apiserver/src/main.rs
@@ -1,6 +1,6 @@
 use apiserver::api::{self, APIServerSettings};
-use apiserver::error::{self, Result};
 use apiserver::telemetry::init_telemetry;
+use apiserver_error::{StartServerSnafu, StartTelemetrySnafu};
 use models::constants::APISERVER_INTERNAL_PORT;
 use models::node::K8SBottlerocketShadowClient;
 use tracing::{event, Level};
@@ -28,18 +28,42 @@ async fn main() {
     opentelemetry::global::shutdown_tracer_provider();
 }
 
-async fn run_server() -> Result<()> {
-    init_telemetry()?;
+async fn run_server() -> Result<(), apiserver_error::Error> {
+    init_telemetry().context(StartTelemetrySnafu)?;
+
     let prometheus_exporter = opentelemetry_prometheus::exporter().init();
 
     let k8s_client = kube::client::Client::try_default()
         .await
-        .context(error::ClientCreateSnafu)?;
+        .context(apiserver_error::K8sClientCreateSnafu)?;
 
     let settings = APIServerSettings {
         node_client: K8SBottlerocketShadowClient::new(k8s_client.clone()),
         server_port: APISERVER_INTERNAL_PORT as u16,
     };
 
-    api::run_server(settings, k8s_client, Some(prometheus_exporter)).await
+    api::run_server(settings, k8s_client, Some(prometheus_exporter))
+        .await
+        .context(StartServerSnafu)
+}
+
+pub mod apiserver_error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub))]
+    pub enum Error {
+        #[snafu(display("Unable to create client: '{}'", source))]
+        K8sClientCreate { source: kube::Error },
+
+        #[snafu(display("Unable to start API server telemetry: '{}'", source))]
+        StartTelemetry {
+            source: apiserver::telemetry::telemetry_error::Error,
+        },
+
+        #[snafu(display("Unable to start API server: '{}'", source))]
+        StartServer {
+            source: apiserver::api::error::Error,
+        },
+    }
 }


### PR DESCRIPTION
**Issue number:**

Related: https://github.com/bottlerocket-os/bottlerocket-update-operator/issues/121

**Description of changes:**

Refactors the `apiserver` error handling to be less generic and more module spcific.

**Testing done:**

_Coming soon_

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
