### PR TITLE
Reload certificate periodically

### DIFF
--- a/apiserver/src/api/error.rs
+++ b/apiserver/src/api/error.rs
@@ -1,4 +1,4 @@
-use models::node::BottlerocketShadowError;
+use models::node::{error, BottlerocketShadowError};
 
 use actix_web::error::ResponseError;
 use snafu::Snafu;
@@ -29,6 +29,12 @@ pub enum Error {
 
     #[snafu(display("Failed to drain Node: '{}'", source))]
     BottlerocketShadowDrain { source: BottlerocketShadowError },
+
+    #[snafu(display("Failed to read certificate."))]
+    ReadCertificateFailed { source: error::Error },
+
+    #[snafu(display("Failed to reload certificate."))]
+    ReloadCertificateFailed {},
 
     #[snafu(display("Failed to set up SslAcceptorBuilder : {:?}", source))]
     SSLError { source: openssl::error::ErrorStack },

--- a/models/src/node/error.rs
+++ b/models/src/node/error.rs
@@ -74,6 +74,12 @@ pub enum Error {
     },
 
     #[snafu(display(
+        "IO error occurred while attempting to use APIServerClient: '{}'",
+        source
+    ))]
+    IOError { source: Box<dyn std::error::Error> },
+
+    #[snafu(display(
         "Unable to remove node exclusion from load balancer ({}, {}): '{}'",
         selector.node_name,
         selector.node_uid,

--- a/models/src/node/mod.rs
+++ b/models/src/node/mod.rs
@@ -1,14 +1,17 @@
 mod client;
 mod crd;
 mod drain;
-mod error;
+pub mod error;
 
 pub use self::client::*;
 pub use self::crd::*;
 pub use self::error::Error as BottlerocketShadowError;
+use error::Result;
 
 use lazy_static::lazy_static;
 pub use semver::Version;
+use snafu::ResultExt;
+use std::io::Read;
 
 lazy_static! {
     // Regex gathered from semver.org as the recommended semver validation regex.
@@ -29,3 +32,16 @@ pub const K8S_NODE_KIND: &str = "BottlerocketShadow";
 pub const K8S_NODE_PLURAL: &str = "bottlerocketshadows";
 pub const K8S_NODE_STATUS: &str = "bottlerocketshadows/status";
 pub const K8S_NODE_SHORTNAME: &str = "brs";
+
+pub fn read_certificate(public_key_path: &str) -> Result<Vec<u8>> {
+    let mut buf = Vec::new();
+
+    std::fs::File::open(public_key_path)
+        .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
+        .context(error::IOSnafu)?
+        .read_to_end(&mut buf)
+        .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
+        .context(error::IOSnafu)?;
+
+    Ok(buf)
+}


### PR DESCRIPTION
when cert-manager rotates the certificate brupop-apiserver-certificate (which by default will be after 60 days), brupop apiserver needs to reload certificate to bounce all the agent and APIServer pods.

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes: #233 


**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Mon Oct 10 17:46:26 2022 +0000

    Reload certificate periodically

    when cert-manager rotates the certificate brupop-apiserver-certificate
    (which by default will be after 60 days), brupop apiserver needs to reload
    certificate to bounce all the agent and APIServer pods.
```

Add a mechanism to monitor if certificate has been renewed. If yes, stop servers and apiserver will be restarted to reload new certificate.  Agent doesn't need do anything since the logic in brupop that agent will always use current certificate on volume to talk with apiserver.  



**Testing done:**
1. Set Certificate to be expired on 7 mins 
```
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: brupop-apiserver-certificate
  namespace: brupop-bottlerocket-aws
spec:
  isCA: true
  commonName: my-selfsigned-ca
  secretName: brupop-tls
  renewBefore: 2159h53m
```

2. Run integration test to monitor if all nodes still are updated to latest version.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
