### PR TITLE
Fix `MissingClusterIPFamily` error spelling

### DIFF
--- a/apiserver/src/api/error.rs
+++ b/apiserver/src/api/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
     HTTPHeaderParse { missing_header: &'static str },
 
     #[snafu(display("Unable to detect cluster IP family. For '{}'", source))]
-    MissingClusterIPFamiliy { source: std::env::VarError },
+    MissingClusterIPFamily { source: std::env::VarError },
 
     #[snafu(display("Error creating BottlerocketShadow: '{}'", source))]
     BottlerocketShadowCreate { source: BottlerocketShadowError },

--- a/apiserver/src/api/mod.rs
+++ b/apiserver/src/api/mod.rs
@@ -148,7 +148,7 @@ pub async fn run_server<T: 'static + BottlerocketShadowClient>(
     // Use IP for KUBERNETES_SERVICE_HOST to decide the IP family for the cluster,
     // Match API server IP family same as cluster
     let k8s_service_addr =
-        env::var("KUBERNETES_SERVICE_HOST").context(error::MissingClusterIPFamiliySnafu)?;
+        env::var("KUBERNETES_SERVICE_HOST").context(error::MissingClusterIPFamilySnafu)?;
     let server_addr = if k8s_service_addr.contains(':') {
         // IPv6 format
         format!("[::]:{}", server_port)


### PR DESCRIPTION
**Issue number:**

Closes #294

**Description of changes:**

`MissingClusterIPFamiliy` ➡️  `MissingClusterIPFamily`

**Testing done:**

Ran `make` and builds 👍🏼 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
