### PR TITLE
Removes `bunyan` JSON style logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,6 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tracing",
- "tracing-bunyan-formatter",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -311,7 +310,6 @@ dependencies = [
  "tokio-retry",
  "tracing",
  "tracing-actix-web",
- "tracing-bunyan-formatter",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -865,7 +863,6 @@ dependencies = [
  "snafu",
  "tokio",
  "tracing",
- "tracing-bunyan-formatter",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -1245,16 +1242,6 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "gethostname"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -3241,23 +3228,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tracing-bunyan-formatter"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0814e45b1ba02f79418d90107acc44ae55dceb0623d40f4ee7d981b5e1984869"
-dependencies = [
- "chrono",
- "gethostname",
- "log",
- "serde",
- "serde_json",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -14,7 +14,6 @@ futures = "0.3"
 opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
-tracing-bunyan-formatter = "0.3"
 tracing-opentelemetry = "0.16"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -15,8 +15,7 @@ use models::node::{brs_name_from_node_name, BottlerocketShadow};
 use opentelemetry::sdk::propagation::TraceContextPropagator;
 use snafu::{OptionExt, ResultExt};
 use tracing::{event, Level};
-use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Registry};
 
 use std::env;
 use std::fs;
@@ -117,10 +116,9 @@ pub fn init_telemetry() -> Result<()> {
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
 
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let stdio_formatting_layer = BunyanFormattingLayer::new(AGENT.into(), std::io::stdout);
+    let stdio_formatting_layer = fmt::layer().pretty();
     let subscriber = Registry::default()
         .with(env_filter)
-        .with(JsonStorageLayer)
         .with(stdio_formatting_layer);
     tracing::subscriber::set_global_default(subscriber)
         .context(agent_error::TracingConfigurationSnafu)?;

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -22,7 +22,6 @@ opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"]}
 opentelemetry-prometheus = "0.9"
 tracing = "0.1"
 tracing-actix-web = "0.4.0-beta.14"
-tracing-bunyan-formatter = "0.3"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-opentelemetry = "0.16"
 

--- a/apiserver/src/telemetry.rs
+++ b/apiserver/src/telemetry.rs
@@ -8,8 +8,7 @@ use opentelemetry::sdk::propagation::TraceContextPropagator;
 use snafu::ResultExt;
 use tracing::Span;
 use tracing_actix_web::{DefaultRootSpanBuilder, RootSpanBuilder};
-use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Registry};
 
 use std::collections::HashSet;
 
@@ -58,10 +57,9 @@ pub fn init_telemetry() -> Result<(), telemetry_error::Error> {
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
 
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let stdio_formatting_layer = BunyanFormattingLayer::new(APISERVER.into(), std::io::stdout);
+    let stdio_formatting_layer = fmt::layer().pretty();
     let subscriber = Registry::default()
         .with(env_filter)
-        .with(JsonStorageLayer)
         .with(stdio_formatting_layer);
     tracing::subscriber::set_global_default(subscriber)
         .context(telemetry_error::TracingConfigurationSnafu)?;

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -24,6 +24,5 @@ serde_plain = "1.0.0"
 snafu = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1"
-tracing-bunyan-formatter = "0.3"
 tracing-opentelemetry = "0.16"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -16,8 +16,7 @@ use kube::{
 use opentelemetry::sdk::propagation::TraceContextPropagator;
 use snafu::ResultExt;
 use tracing::{event, Level};
-use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Registry};
 
 const DEFAULT_TRACE_LEVEL: &str = "info";
 
@@ -105,10 +104,9 @@ fn init_telemetry() -> Result<()> {
 
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_TRACE_LEVEL));
-    let stdio_formatting_layer = BunyanFormattingLayer::new(CONTROLLER.into(), std::io::stdout);
+    let stdio_formatting_layer = fmt::layer().pretty();
     let subscriber = Registry::default()
         .with(env_filter)
-        .with(JsonStorageLayer)
         .with(stdio_formatting_layer);
     tracing::subscriber::set_global_default(subscriber)
         .context(controller_error::TracingConfigurationSnafu)?;


### PR DESCRIPTION
```
Replaced with "pretty", human readable logs.
This will enable kubernetes users to more easily debug and view their logs.

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

**Issue number:**

Closes #148

**Description of changes:**

Removes the `bunyan` JSON style logging in favor of human readable, "pretty" logs.

**Testing done:**

Here's a before:

![Screen Shot 2022-10-13 at 12 00 36 PM](https://user-images.githubusercontent.com/23109390/195671658-a545a4ee-ae35-4585-a035-3c2007ff5c4f.png)

And after:

![Screen Shot 2022-10-13 at 11 59 52 AM](https://user-images.githubusercontent.com/23109390/195671507-bb1fa5f0-2c3f-4612-bd94-cbc4856f20e1.png)


---

Did some further validation with kubernetes logging. Built a kind cluster locally:
```
kind create cluster --name test
```

Built the image:
```
make
```

Loaded the local image into my kind cluster
```
kind load docker-image bottlerocket-update-operator-amd64:v0.2.0-bad7512c-dev --name test
```

And made modifications to the `image` tags in the manifest:
```yaml
image: "bottlerocket-update-operator-amd64:v0.2.0-bad7512c-dev"
```

Logs are lookin nice!

![Screen Shot 2022-10-13 at 12 02 56 PM](https://user-images.githubusercontent.com/23109390/195672117-da79cf3f-ca3f-4bbc-8106-c8d3381f6ad4.png)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
