### PR TITLE
Upgrades `kube-rs` to 0.75 and `k8s-openapi` to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash",
+ "ahash 0.7.6",
  "base64",
  "bitflags",
  "bytes",
@@ -166,7 +166,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "actix-web-codegen",
- "ahash",
+ "ahash 0.7.6",
  "bytes",
  "cfg-if",
  "derive_more",
@@ -250,6 +250,18 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
+dependencies = [
+ "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
@@ -929,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -939,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -953,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
  "darling_core",
  "quote",
@@ -1612,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0489fc937cc7616a9abfa61bf39c250d7e32e1325ef028c8d9278dd24ea395b3"
+checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
 dependencies = [
  "base64",
  "bytes",
@@ -1626,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.71.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342744dfeb81fe186b84f485b33f12c6a15d3396987d933b06a566a3db52ca38"
+checksum = "9bb19108692aeafebb108fd0a1c381c06ac4c03859652599420975165e939b8a"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1639,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.71.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f69a504997799340408635d6e351afb8aab2c34ca3165e162f41b3b34a69a79"
+checksum = "97e1a80ecd1b1438a2fc004549e155d47250b9e01fbfcf4cfbe9c8b56a085593"
 dependencies = [
  "base64",
  "bytes",
@@ -1662,7 +1674,7 @@ dependencies = [
  "pem",
  "pin-project",
  "rustls 0.20.4",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile 1.0.1",
  "secrecy",
  "serde",
  "serde_json",
@@ -1677,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.71.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a247487699941baaf93438d65b12d4e32450bea849d619d19ed394e8a4a645"
+checksum = "f4d780f2bb048eeef64a4c6b2582d26a0fe19e30b4d3cc9e081616e1779c5d47"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1695,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.71.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203f7c5acf9d0dfb0b08d44ec1d66ace3d1dfe0cdd82e65e274f3f96615d666c"
+checksum = "98459d53b2841237392cd6959956185b2df15c19d32c3b275ed6ca7b7ee1adae"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1708,11 +1720,11 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.71.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ea50e6ed56578e1d1d02548901b12fe6d3edbf110269a396955e285d487973"
+checksum = "7769af142ee2e46bfa44bd393cf7f40b9d8b80d2e11f6317399551ed17760beb"
 dependencies = [
- "ahash",
+ "ahash 0.8.0",
  "backoff",
  "derivative",
  "futures",
@@ -2309,9 +2321,9 @@ checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -2539,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "0.3.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64",
 ]
@@ -3163,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.2.5"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
+checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
 dependencies = [
  "base64",
  "bitflags",
@@ -3448,9 +3460,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -17,9 +17,8 @@ tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-opentelemetry = "0.16"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_20"] }
-# "rustls-tls" feature must be used kube 0.71.0 to build correct k8s client for IPv6 cluster
-kube = { version = "0.71.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
+k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_20"] }
+kube = { version = "0.75.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
 
 semver = { version = "1.0", features = [ "serde" ] }
 serde = { version = "1", features = [ "derive" ] }

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -26,9 +26,8 @@ tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-opentelemetry = "0.16"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_20"] }
-# "rustls-tls" feature must be used kube 0.71.0 to build correct k8s client for IPv6 cluster
-kube = { version = "0.71.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
+k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_20"] }
+kube = { version = "0.75.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
 
 async-trait = "0.1"
 futures = "0.3"

--- a/apiserver/src/telemetry.rs
+++ b/apiserver/src/telemetry.rs
@@ -1,6 +1,5 @@
 use crate::api::NO_TELEMETRY_ENDPOINTS;
 use crate::constants::HEADER_BRUPOP_NODE_NAME;
-use models::constants::APISERVER;
 
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use lazy_static::lazy_static;

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -13,8 +13,8 @@ http = "0.2.8"
 maplit = "1.0"
 semver = "1.0"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.71.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
+k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_20"] }
+kube = { version = "0.75.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
 models = { path = "../models", version = "0.1.0" }
 opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"] }
 opentelemetry-prometheus = "0.9"

--- a/deny.toml
+++ b/deny.toml
@@ -43,7 +43,10 @@ skip-tree = [
     { name = "structopt-derive", version = "0.4.18"},
     # use "rustls-tls" feature in kube to build correct k8s client for IPv6 cluster
     # with "rustls-tls" enabled, kube uses mixed versions of hyper-rustls
-    { name = "kube", version = "0.71.0"}
+    { name = "kube", version = "0.75.0"},
+    # aws-smithy-client brings in several lagging dependencies that can be ignored
+    # since it is only used in the integration tests
+    { name = "aws-smithy-client", version = "0.49.0" }
 ]
 
 [sources]

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -34,8 +34,8 @@ tokio-retry = "0.3"
 uuid = { version = "0.8", default-features = false, features = ["serde", "v4"] }
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.71", default-features = true, features = [ "derive", "runtime" ] }
+k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_20"] }
+kube = { version = "0.75", default-features = true, features = [ "derive", "runtime" ] }
 
 
 [dev-dependencies]

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -10,8 +10,8 @@ async-trait = "0.1"
 chrono = "0.4"
 futures = "0.3"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.71.0", default-features = true, features = [ "derive", "runtime" ] }
+k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_20"] }
+kube = { version = "0.75.0", default-features = true, features = [ "derive", "runtime" ] }
 
 lazy_static = "1.4"
 maplit = "1.0"

--- a/models/src/node/crd/mod.rs
+++ b/models/src/node/crd/mod.rs
@@ -84,9 +84,13 @@ impl<T: BottlerocketShadowResource> Selector for T {
             .meta()
             .owner_references
             .as_ref()
-            .ok_or(Error::MissingOwnerReference { name: self.name() })?
+            .ok_or(Error::MissingOwnerReference {
+                name: self.name_any(),
+            })?
             .first()
-            .ok_or(Error::MissingOwnerReference { name: self.name() })?;
+            .ok_or(Error::MissingOwnerReference {
+                name: self.name_any(),
+            })?;
 
         Ok(BottlerocketShadowSelector {
             node_name: node_owner.name.clone(),

--- a/yamlgen/Cargo.toml
+++ b/yamlgen/Cargo.toml
@@ -8,5 +8,5 @@ license = "Apache-2.0 OR MIT"
 [build-dependencies]
 models = { path = "../models", version = "0.1.0" }
 dotenv = "0.15"
-kube = { version = "0.71.0", default-features = true, features = [ "derive", "runtime" ] }
+kube = { version = "0.75.0", default-features = true, features = [ "derive", "runtime" ] }
 serde_yaml = "0.8"


### PR DESCRIPTION
```
Ignores duplicate dependencies in the integration tests which are brought in via the aws config / sdk

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

**Issue number:**

This will close a few stale dependabot PRs automatically

**Description of changes:**

- Upgrades `kube-rs` to 0.75 and `k8s-openapi` to 0.16. Upgrades a few methods to non-deprecated APIs in `kube`:

```
Deprecated since 0.74.0: 

ResourceExt::name can panic and has been replaced by ResourceExt::name_any and ResourceExt::name_unchecked.
This fn will be removed in 0.77.0.
```

[Reference](https://docs.rs/kube/latest/kube/trait.ResourceExt.html#tymethod.name)

```
Deprecated since 0.72.0: 

fn replaced with the WatchStreamExt::touched_objects which can be chained onto watcher.
Add use kube::runtime::WatchStreamExt; and call stream.touched_objects() instead.
This function will be removed in 0.75.0.
```

[Reference](https://docs.rs/kube/latest/kube/runtime/utils/fn.try_flatten_touched.html)

- Also, since the integration tests is the only crate that's pulling in AWS dependencies, we can safely ignore the duplicate dependencies causing problems through the `aws-smithy-client` tree.


- Finally, this patch also removes a few const variables that weren't being used and were throwing warnings during compile time
 
**Testing done:**

_Coming soon!_

Also, still need to verify that this works with creating IPv6 clusters (since there were comments about `rustls-tls` being tied in with kube 0.71 - @gthao313, do you have any insight on this? Or with how to test IPv6 clusters?)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
