### PR TITLE
Webhook conversion: Support v2 to v1

### DIFF
--- a/models/src/node/crd/mod.rs
+++ b/models/src/node/crd/mod.rs
@@ -27,12 +27,13 @@ pub mod error;
 /// };
 /// ```
 ///
-/// Add the BottlerocketShadow version to the end of BOTTLEROCKETSHADOW_CRD_VERSIONS
-/// so the webhook conversion could set up proper conversion_review_versions
+/// Add the BottlerocketShadow version to the start of BOTTLEROCKETSHADOW_CRD_VERSIONS
+/// so the webhook conversion could set up proper conversion_review_versions.
+/// The API server will query the webhook for the first version found in this list.
 #[cfg_attr(doctest, doc = " ````no_test")]
 /// ```
 /// static ref BOTTLEROCKETSHADOW_CRD_VERSIONS: Vec<String> =
-///     vec!["v1".to_string(), "v2".to_string()];
+///     vec!["v2".to_string(), "v1".to_string()];
 /// ```
 ///
 pub mod v1;
@@ -69,7 +70,7 @@ lazy_static! {
         ]
     };
     static ref BOTTLEROCKETSHADOW_CRD_VERSIONS: Vec<String> =
-        vec!["v1".to_string(), "v2".to_string()];
+        vec!["v2".to_string(), "v1".to_string()];
 }
 
 pub trait BottlerocketShadowResource: kube::ResourceExt {}
@@ -145,7 +146,9 @@ fn combine_version_in_crds(
 }
 
 /// Generate webhook conversion from scratch since k8s_api didn't provide
-/// a decent way to set up CustomResourceConversion
+/// a decent way to set up CustomResourceConversion.
+/// Note the ordering of `conversionReviewVersions`: the first version is what the Kube API server
+/// will query the webhook for and both versions must be supported via the webhook converter.
 ///
 /// Sample generated config:
 /// conversion:
@@ -158,8 +161,8 @@ fn combine_version_in_crds(
 ///         path: /crdconvert
 ///         port: 443
 ///     conversionReviewVersions:
-///       - v1
 ///       - v2
+///       - v1
 fn generate_webhook_conversion() -> CustomResourceConversion {
     CustomResourceConversion {
         strategy: "Webhook".to_string(),

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -17,8 +17,8 @@ spec:
           path: /crdconvert
           port: 443
       conversionReviewVersions:
-        - v1
         - v2
+        - v1
   group: brupop.bottlerocket.aws
   names:
     kind: BottlerocketShadow


### PR DESCRIPTION
**Issue number:**

Fixes #247

**Description of changes:**

This patch sets a path for `v2` to `v1` conversions via the established conversion webhook:

- Implements `From` blocks for type conversion from `BottlerocketShadow` v2 to v1
  - Tests for these conversions
- Creates path in webhook for conversion from v2 to v1
  - Establishes the idea of using a pinwheel converter for future implementations
  - Tests for this webhook conversion

The idea that we need to support a _downgrade_ seems abit counter intuitive, but since we are shipping _both_ the v1 and v2 CRD, we also need to support conversion between both: users may query either crd version and the `kube-api` server needs to know how to resolve the difference in what is in it's "Stored Version" (which by default will be v2). Further, since there the `kube-api` server has a watcher on both the v1 and v2 resources, without this patch, it can't convert v1 queries into v2 (and dumps _alot_ of logs in the `kube-api` server and the bottlerocket apiserver)

References:
- https://book.kubebuilder.io/multiversion-tutorial/conversion-concepts.html
- https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#webhook-conversion

**Testing done:**

Unit tests pass.

Tested on a new cluster with a new image and logs are _much_ more quite. Doesn't affect `brs` coming up or upgrades.

Ran through integration tests on ipv4 cluster and ipv6 cluster using custom build image 👍🏼 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
