### PR TITLE
Enable port configurability

### DIFF
--- a/.env
+++ b/.env
@@ -31,3 +31,7 @@ MAX_CONCURRENT_UPDATE=1
 # when you set up time window start and stop time, you should use UTC (24-hour time notation).
 UPDATE_WINDOW_START=0:0:0
 UPDATE_WINDOW_STOP=0:0:0
+
+# API Server ports
+APISERVER_INTERNAL_PORT=8443
+APISERVER_SERVICE_PORT=443

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,3 @@ COPY --from=build \
     /usr/share/licenses/rust \
     /usr/share/licenses/openssl \
     /licenses/bottlerocket-sdk/
-
-# Expose apiserver port
-EXPOSE 8443

--- a/README.md
+++ b/README.md
@@ -29,6 +29,43 @@ Be sure to use the git tag for the Update Operator release that you plan to depl
 
 #### Configuration
 
+##### Configure API server ports
+
+If you'd like to configure what ports the API server uses,
+adjust the value that is consumed in the container environment:
+
+```yaml
+      ...
+      containers:
+        - command:
+            - "./api-server"
+          env:
+            - name: APISERVER_INTERNAL_PORT
+              value: 999
+      ...
+```
+
+You'll then also need to adjust the various "port" entries in the manifest
+to correctly reflect what port the API server starts on and expects for its service port:
+
+```yaml
+    ...
+    webhook:
+      clientConfig:
+        service:
+          name: brupop-apiserver
+          namespace: brupop-bottlerocket-aws
+          path: /crdconvert
+          port: 123
+```
+
+The default values are generated from the `.env` file (and can be used when building the update operator from source to configure your own ports):
+- `APISERVER_INTERNAL_PORT = 8443` - This is the container port the API server starts on.
+  If this environment variable is _not_ found, the Brupop API server will fail to start.
+- `APISERVER_SERVICE_PORT = 443` - This is the port Brupop's Kubernetes Service uses to target the internal API Server port.
+  It is used by the node agents to access the API server.
+  If this environment variable is _not_ found, the Brupop agents will fail to start.
+
 ##### Exclude Nodes from Load Balancers Before Draining
 This configuration uses Kuberenetes [ServiceNodeExclusion](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) feature.
 `EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC` can be used to enable the feature to exclude the node from load balancer before draining.

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -49,7 +49,8 @@ async fn run_agent() -> Result<()> {
     let token_path = token_path.to_str().context(agent_error::AssertionSnafu {
         message: "Token path (defined in models/agent.rs) is not valid unicode.",
     })?;
-    let apiserver_client = K8SAPIServerClient::new(token_path.to_string());
+    let apiserver_client =
+        K8SAPIServerClient::new(token_path.to_string()).context(agent_error::ApiClientSnafu)?;
 
     // Get node and BottlerocketShadow names
     let associated_node_name = env::var("MY_NODE_NAME").context(agent_error::GetNodeNameSnafu)?;
@@ -135,6 +136,11 @@ pub mod agent_error {
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub))]
     pub enum Error {
+        #[snafu(display("Error creating API server client: '{}'", source))]
+        ApiClientError {
+            source: apiserver::client::ClientError,
+        },
+
         #[snafu(display("Error running agent server: '{}'", source))]
         AgentError { source: agentclient_error::Error },
 

--- a/apiserver/src/api/mod.rs
+++ b/apiserver/src/api/mod.rs
@@ -269,7 +269,6 @@ async fn reload_certificate(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use models::constants::APISERVER_INTERNAL_PORT;
     use models::node::MockBottlerocketShadowClient;
 
     use std::sync::Arc;
@@ -281,6 +280,7 @@ mod tests {
     where
         F: FnOnce(&mut MockBottlerocketShadowClient),
     {
+        let apiserver_internal_port: i32 = 8443;
         let mut node_client = MockBottlerocketShadowClient::new();
         mock_expectations(&mut node_client);
 
@@ -290,7 +290,7 @@ mod tests {
 
         APIServerSettings {
             node_client,
-            server_port: APISERVER_INTERNAL_PORT as u16,
+            server_port: apiserver_internal_port as u16,
         }
     }
 }

--- a/apiserver/src/client/error.rs
+++ b/apiserver/src/client/error.rs
@@ -10,6 +10,16 @@ pub type Result<T> = std::result::Result<T, ClientError>;
 #[snafu(visibility(pub))]
 pub enum ClientError {
     #[snafu(display(
+        "Unable to get environment variable '{}' for client due to : '{}'",
+        variable,
+        source
+    ))]
+    MissingEnvVariable {
+        source: std::env::VarError,
+        variable: String,
+    },
+
+    #[snafu(display(
         "API server responded with an error status code {}: '{}'",
         status_code,
         response
@@ -67,6 +77,9 @@ pub enum ClientError {
         source
     ))]
     IOError { source: Box<dyn std::error::Error> },
+
+    #[snafu(display("Failed to create kubernetes client due to {}", source))]
+    CreateK8sClientError { source: std::num::ParseIntError },
 
     #[snafu(display("Failed to create https client due to {}", source))]
     CreateClientError { source: reqwest::Error },

--- a/models/src/agent.rs
+++ b/models/src/agent.rs
@@ -104,6 +104,7 @@ pub fn agent_daemonset(
     agent_image: String,
     image_pull_secret: Option<String>,
     exclude_from_lb_wait_time: u64,
+    apiserver_service_port: String,
 ) -> DaemonSet {
     let image_pull_secrets =
         image_pull_secret.map(|secret| vec![LocalObjectReference { name: Some(secret) }]);
@@ -184,6 +185,11 @@ pub fn agent_daemonset(
                             EnvVar {
                                 name: "EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC".to_string(),
                                 value: Some(exclude_from_lb_wait_time.to_string()),
+                                ..Default::default()
+                            },
+                            EnvVar {
+                                name: "APISERVER_SERVICE_PORT".to_string(),
+                                value: Some(apiserver_service_port),
                                 ..Default::default()
                             },
                         ]),

--- a/models/src/constants.rs
+++ b/models/src/constants.rs
@@ -56,8 +56,6 @@ pub const APP_CREATED_BY: &str = "app.kubernetes.io/created-by";
 
 // apiserver constants
 pub const APISERVER: &str = "apiserver";
-pub const APISERVER_INTERNAL_PORT: i32 = 8443; // The internal port on which the the apiservice is hosted.
-pub const APISERVER_SERVICE_PORT: i32 = 443; // The k8s service port hosting the apiserver.
 pub const APISERVER_MAX_UNAVAILABLE: &str = "33%"; // The maximum number of unavailable nodes for the apiserver deployment.
 pub const APISERVER_HEALTH_CHECK_ROUTE: &str = "/ping"; // Route used for apiserver k8s liveness and readiness checks.
 pub const APISERVER_CRD_CONVERT_ENDPOINT: &str = "/crdconvert"; // Custom Resource convert endpoint

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -381,6 +381,9 @@ spec:
       containers:
         - command:
             - "./apiserver"
+          env:
+            - name: APISERVER_INTERNAL_PORT
+              value: "8443"
           image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v0.2.2"
           livenessProbe:
             httpGet:
@@ -533,6 +536,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC
               value: "0"
+            - name: APISERVER_SERVICE_PORT
+              value: "443"
           image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v0.2.2"
           name: brupop
           resources:


### PR DESCRIPTION
```
- Api-server: Port can be configured from default 8443
- Agent / webhook: Port can be configured from default 443

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

### Issue number:

Closes: #305

### Description of changes:

Enables ports used by the API server and the agent to be configurable. Removes constant values and instead, interpolates from the container environment.

### Testing done:

Ran through integration testing 👍🏼 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
