### PR TITLE
Add resources requests and limits for all containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,25 @@ The default values are generated from the [`.env`](https://github.com/bottlerock
   It is used by the node agents to access the API server.
   If this environment variable is _not_ found, the Brupop agents will fail to start.
 
-#### Exclude Nodes from Load Balancers Before Draining
-This configuration uses the Kuberenetes [ServiceNodeExclusion](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) feature.
+##### Resource Requests & Limits
+
+The `bottlerocket-update-operator.yaml` manifest makes several default recommendations for
+Kubernetes resource requests and limits. In general, the update operator and it's components are lite-weight
+and shouldn't consume more than 10m CPU (which is roughly equivalent to 1/100th of a CPU core)
+and 50Mi (which is roughly equivalent to 0.05 GB of memory).
+If this limit is breached, the Kubernetes API will restart the faulting container.
+
+Note that your mileage with these resource requests and limits may vary.
+Any number of factors may contribute to varying results in resource utilization (different compute instance types, workload utilization, API ingress/egress, etc).
+[The Kubernetes documentation for Resource Management of Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+is an excellent resource for understanding how various compute resources are utilized
+and how Kubernetes manages these resources.
+
+If resource utilization by the brupop components is not a concern,
+removing the `resources` fields in the manifest will not affect the functionality of any components.
+
+##### Exclude Nodes from Load Balancers Before Draining
+This configuration uses Kuberenetes [ServiceNodeExclusion](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) feature.
 `EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC` can be used to enable the feature to exclude the node from load balancer before draining.
 When `EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC` is 0 (default), the feature is disabled.
 When `EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC` is set to a positive integer, bottlerocket update operator will exclude the node from

--- a/models/src/agent.rs
+++ b/models/src/agent.rs
@@ -194,10 +194,11 @@ pub fn agent_daemonset(
                             },
                         ]),
                         resources: Some(ResourceRequirements {
-                            limits: Some(btreemap! {
-                                "memory".to_string() => Quantity("50Mi".to_string()),
-                            }),
                             requests: Some(btreemap! {
+                                "memory".to_string() => Quantity("8Mi".to_string()),
+                                "cpu".to_string() => Quantity("5m".to_string()),
+                            }),
+                            limits: Some(btreemap! {
                                 "memory".to_string() => Quantity("50Mi".to_string()),
                                 "cpu".to_string() => Quantity("10m".to_string()),
                             }),

--- a/models/src/apiserver.rs
+++ b/models/src/apiserver.rs
@@ -11,9 +11,11 @@ use k8s_openapi::api::apps::v1::{
 use k8s_openapi::api::core::v1::{
     Affinity, Container, ContainerPort, EnvVar, HTTPGetAction, LocalObjectReference, NodeAffinity,
     NodeSelector, NodeSelectorRequirement, NodeSelectorTerm, PodSpec, PodTemplateSpec, Probe,
-    SecretVolumeSource, Service, ServiceAccount, ServicePort, ServiceSpec, Volume, VolumeMount,
+    ResourceRequirements, SecretVolumeSource, Service, ServiceAccount, ServicePort, ServiceSpec,
+    Volume, VolumeMount,
 };
 use k8s_openapi::api::rbac::v1::{ClusterRole, ClusterRoleBinding, PolicyRule, RoleRef, Subject};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::api::ObjectMeta;
@@ -241,6 +243,16 @@ pub fn apiserver_deployment(
                             value: Some(apiserver_internal_port),
                             ..Default::default()
                         }]),
+                        resources: Some(ResourceRequirements {
+                            requests: Some(btreemap! {
+                                "memory".to_string() => Quantity("8Mi".to_string()),
+                                "cpu".to_string() => Quantity("3m".to_string()),
+                            }),
+                            limits: Some(btreemap! {
+                                "memory".to_string() => Quantity("50Mi".to_string()),
+                                "cpu".to_string() => Quantity("10m".to_string()),
+                            }),
+                        }),
                         ports: Some(vec![ContainerPort {
                             container_port: apiserver_internal_port_conv,
                             ..Default::default()

--- a/models/src/controller.rs
+++ b/models/src/controller.rs
@@ -10,10 +10,11 @@ use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStrategy}
 use k8s_openapi::api::core::v1::{
     Affinity, Container, EnvVar, EnvVarSource, LocalObjectReference, NodeAffinity, NodeSelector,
     NodeSelectorRequirement, NodeSelectorTerm, ObjectFieldSelector, PodSpec, PodTemplateSpec,
-    Service, ServiceAccount, ServicePort, ServiceSpec,
+    ResourceRequirements, Service, ServiceAccount, ServicePort, ServiceSpec,
 };
 use k8s_openapi::api::rbac::v1::{ClusterRole, ClusterRoleBinding, PolicyRule, RoleRef, Subject};
 use k8s_openapi::api::scheduling::v1::PriorityClass;
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::api::ObjectMeta;
@@ -226,6 +227,16 @@ pub fn controller_deployment(
                                 ..Default::default()
                             },
                         ]),
+                        resources: Some(ResourceRequirements {
+                            requests: Some(btreemap! {
+                                "memory".to_string() => Quantity("8Mi".to_string()),
+                                "cpu".to_string() => Quantity("3m".to_string()),
+                            }),
+                            limits: Some(btreemap! {
+                                "memory".to_string() => Quantity("50Mi".to_string()),
+                                "cpu".to_string() => Quantity("10m".to_string()),
+                            }),
+                        }),
                         ..Default::default()
                     }],
                     image_pull_secrets,

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -400,6 +400,13 @@ spec:
               port: 8443
               scheme: HTTPS
             initialDelaySeconds: 5
+          resources:
+            limits:
+              cpu: 10m
+              memory: 50Mi
+            requests:
+              cpu: 3m
+              memory: 8Mi
           volumeMounts:
             - mountPath: /etc/brupop-tls-keys
               name: bottlerocket-tls-keys
@@ -542,10 +549,11 @@ spec:
           name: brupop
           resources:
             limits:
-              memory: 50Mi
-            requests:
               cpu: 10m
               memory: 50Mi
+            requests:
+              cpu: 5m
+              memory: 8Mi
           securityContext:
             seLinuxOptions:
               level: s0
@@ -725,6 +733,13 @@ spec:
               value: "0:0:0"
           image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.0.0"
           name: brupop
+          resources:
+            limits:
+              cpu: 10m
+              memory: 50Mi
+            requests:
+              cpu: 3m
+              memory: 8Mi
       priorityClassName: brupop-controller-high-priority
       serviceAccountName: brupop-controller-service-account
 ---


### PR DESCRIPTION
### Issue number:

Closes #240

### Description of changes:

This patch provides the expected resource (cpu and memory) requests for each container along with some reasonable limits. These numbers were derived from several experiments (noted in #240 and in the process of creating this patch): the `10m` CPU and `50Mi` memory limit is due to components having spikes in resource requirements when nodes rotate and pods are re-scheduled (during upgrade scenarios where the agent, api-server, and/or controller exist on the upgrading node). The `request` delimiter allows for more resources to be consumed (if they are available on the node) and should be safe since we drain the nodes before doing an upgrade. Having _too tight_ of resource limits will cause the system's kernel to kill the process, so these are intentionally forgiving.

**_TODO_**:

- [x] documentation for consumers of brupop

### Testing done:

Several integration tests were run with the `metric-server` and kubernetes `dashboard` also installed to monitor resource utilization. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
