### PR TITLE
Yamlgen: Upgrade to serde-yaml 0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
       - run: rustup update stable
       - run: make build
       - name: Ensure git is clean
-        run: test -z "$(git status --untracked-files=all --porcelain)"
+        shell: bash
+        run: |
+          git --no-pager diff
+          test -z "$(git status --untracked-files=all --porcelain)"
 
   build-container:
     name: brupop-image
@@ -37,4 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: make brupop-image
       - name: Ensure git is clean
-        run: test -z "$(git status --untracked-files=all --porcelain)"
+        shell: bash
+        run: |
+          git --no-pager diff
+          test -z "$(git status --untracked-files=all --porcelain)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,7 +1738,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "thiserror",
  "tokio",
  "tokio-util 0.7.1",
@@ -2659,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847b767a3d62d95cbf3d8a9f0e421cf57a0d8aa4f411d4b16525afb0284d4ed"
+checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -2671,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4d7e1b012cb3d9129567661a63755ea4b8a7386d339dc945ae187e403c6743"
+checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2841,6 +2841,19 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
+dependencies = [
+ "indexmap",
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3416,6 +3429,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,7 +3813,7 @@ dependencies = [
  "dotenv",
  "kube",
  "models",
- "serde_yaml",
+ "serde_yaml 0.9.14",
 ]
 
 [[package]]

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -36,7 +36,7 @@ lazy_static = "1.4"
 log = "0.4"
 mockall = { version = "0.11", optional = true }
 reqwest = { version = "0.11", features =  [ "json", "native-tls" ] }
-schemars = "0.8.10"
+schemars = "0.8.11"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 snafu = "0.7"

--- a/deny.toml
+++ b/deny.toml
@@ -41,9 +41,6 @@ skip-tree = [
     { name = "clap", version = "2.34.0" },
     # structopt-derive uses an older version of heck, which clashed with the one used by strum_macros.
     { name = "structopt-derive", version = "0.4.18"},
-    # use "rustls-tls" feature in kube to build correct k8s client for IPv6 cluster
-    # with "rustls-tls" enabled, kube uses mixed versions of hyper-rustls
-    { name = "kube", version = "0.75.0"},
     # aws-smithy-client brings in several lagging dependencies that can be ignored
     # since it is only used in the integration tests
     { name = "integ" }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -18,7 +18,7 @@ maplit = "1.0"
 mockall = { version = "0.11", optional = true }
 regex = "1.7"
 reqwest = "0.11"
-schemars = "0.8.10"
+schemars = "0.8.11"
 semver = "1.0"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"

--- a/yamlgen/Cargo.toml
+++ b/yamlgen/Cargo.toml
@@ -9,4 +9,4 @@ license = "Apache-2.0 OR MIT"
 models = { path = "../models", version = "0.1.0" }
 dotenv = "0.15"
 kube = { version = "0.76.0", default-features = true, features = [ "derive", "runtime" ] }
-serde_yaml = "0.8"
+serde_yaml = "0.9"

--- a/yamlgen/build.rs
+++ b/yamlgen/build.rs
@@ -28,6 +28,7 @@ use std::path::PathBuf;
 
 const YAMLGEN_DIR: &str = env!("CARGO_MANIFEST_DIR");
 const HEADER: &str = "# This file is generated. Do not edit.\n";
+const YAML_DOC_LEADER: &str = "---\n";
 
 fn main() {
     dotenv::dotenv().ok();
@@ -46,6 +47,9 @@ fn main() {
     let apiserver_internal_port = env::var("APISERVER_INTERNAL_PORT").ok().unwrap();
     let apiserver_service_port = env::var("APISERVER_SERVICE_PORT").ok().unwrap();
     brupop_resources.write_all(HEADER.as_bytes()).unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(
         &brupop_resources,
         &combined_crds(apiserver_service_port.clone()),
@@ -70,6 +74,9 @@ fn main() {
     if !max_concurrent_update.eq("unlimited") {
         max_concurrent_update.parse::<usize>().unwrap();
     }
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &brupop_namespace()).unwrap();
 
     // cert-manager and secret
@@ -80,14 +87,29 @@ fn main() {
     brupop_resources.write_all(contents.as_bytes()).unwrap();
 
     // apiserver resources
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &apiserver_service_account()).unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &apiserver_cluster_role()).unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &apiserver_cluster_role_binding()).unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(
         &brupop_resources,
         &apiserver_auth_delegator_cluster_role_binding(),
     )
     .unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(
         &brupop_resources,
         &apiserver_deployment(
@@ -97,6 +119,10 @@ fn main() {
         ),
     )
     .unwrap();
+
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(
         &brupop_resources,
         &apiserver_service(apiserver_internal_port, apiserver_service_port.clone()),
@@ -104,9 +130,21 @@ fn main() {
     .unwrap();
 
     // agent resources
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &agent_service_account()).unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &agent_cluster_role()).unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &agent_cluster_role_binding()).unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(
         &brupop_resources,
         &agent_daemonset(
@@ -119,10 +157,25 @@ fn main() {
     .unwrap();
 
     // controller resources
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &controller_service_account()).unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &controller_cluster_role()).unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &controller_cluster_role_binding()).unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &controller_priority_class()).unwrap();
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(
         &brupop_resources,
         &controller_deployment(
@@ -134,5 +187,9 @@ fn main() {
         ),
     )
     .unwrap();
+
+    brupop_resources
+        .write_all(YAML_DOC_LEADER.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&brupop_resources, &controller_service()).unwrap();
 }

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -17,176 +17,176 @@ spec:
           path: /crdconvert
           port: 443
       conversionReviewVersions:
-        - v2
-        - v1
+      - v2
+      - v1
   group: brupop.bottlerocket.aws
   names:
     kind: BottlerocketShadow
     plural: bottlerocketshadows
     shortNames:
-      - brs
+    - brs
     singular: bottlerocketshadow
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: ".status.current_state"
-          name: State
-          type: string
-        - jsonPath: ".status.current_version"
-          name: Version
-          type: string
-        - jsonPath: ".spec.state"
-          name: Target State
-          type: string
-        - jsonPath: ".spec.version"
-          name: Target Version
-          type: string
-        - jsonPath: ".status.crash_count"
-          name: Crash Count
-          type: string
-      name: v2
-      schema:
-        openAPIV3Schema:
-          description: "Auto-generated derived type for BottlerocketShadowSpec via `CustomResource`"
-          properties:
-            spec:
-              description: "The `BottlerocketShadowSpec` can be used to drive a node through the update state machine. A node linearly drives towards the desired state. The brupop controller updates the spec to specify a node's desired state, and the host agent drives state changes forward and updates the `BottlerocketShadowStatus`."
-              properties:
-                state:
-                  description: "Records the desired state of the `BottlerocketShadow`"
-                  enum:
-                    - Idle
-                    - StagedAndPerformedUpdate
-                    - RebootedIntoUpdate
-                    - MonitoringUpdate
-                    - ErrorReset
-                  type: string
-                state_transition_timestamp:
-                  description: The time at which the most recent state was set as the desired state.
-                  nullable: true
-                  type: string
-                version:
-                  description: "The desired update version, if any."
-                  nullable: true
-                  pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-                  type: string
-              required:
-                - state
-              type: object
-            status:
-              description: "`BottlerocketShadowStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent, while the spec is updated by the brupop controller."
-              nullable: true
-              properties:
-                crash_count:
-                  format: uint32
-                  minimum: 0.0
-                  type: integer
-                current_state:
-                  description: "BottlerocketShadowState represents a node's state in the update state machine."
-                  enum:
-                    - Idle
-                    - StagedAndPerformedUpdate
-                    - RebootedIntoUpdate
-                    - MonitoringUpdate
-                    - ErrorReset
-                  type: string
-                current_version:
-                  pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-                  type: string
-                state_transition_failure_timestamp:
-                  nullable: true
-                  type: string
-                target_version:
-                  pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-                  type: string
-              required:
-                - crash_count
-                - current_state
-                - current_version
-                - target_version
-              type: object
-          required:
-            - spec
-          title: BottlerocketShadow
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: ".status.current_state"
-          name: State
-          type: string
-        - jsonPath: ".status.current_version"
-          name: Version
-          type: string
-        - jsonPath: ".spec.state"
-          name: Target State
-          type: string
-        - jsonPath: ".spec.version"
-          name: Target Version
-          type: string
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Auto-generated derived type for BottlerocketShadowSpec via `CustomResource`"
-          properties:
-            spec:
-              description: "The `BottlerocketShadowSpec` can be used to drive a node through the update state machine. A node linearly drives towards the desired state. The brupop controller updates the spec to specify a node's desired state, and the host agent drives state changes forward and updates the `BottlerocketShadowStatus`."
-              properties:
-                state:
-                  description: "Records the desired state of the `BottlerocketShadow`"
-                  enum:
-                    - Idle
-                    - StagedUpdate
-                    - PerformedUpdate
-                    - RebootedIntoUpdate
-                    - MonitoringUpdate
-                  type: string
-                state_transition_timestamp:
-                  description: The time at which the most recent state was set as the desired state.
-                  nullable: true
-                  type: string
-                version:
-                  description: "The desired update version, if any."
-                  nullable: true
-                  pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-                  type: string
-              required:
-                - state
-              type: object
-            status:
-              description: "`BottlerocketShadowStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent, while the spec is updated by the brupop controller."
-              nullable: true
-              properties:
-                current_state:
-                  description: "BottlerocketShadowState represents a node's state in the update state machine."
-                  enum:
-                    - Idle
-                    - StagedUpdate
-                    - PerformedUpdate
-                    - RebootedIntoUpdate
-                    - MonitoringUpdate
-                  type: string
-                current_version:
-                  pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-                  type: string
-                target_version:
-                  pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-                  type: string
-              required:
-                - current_state
-                - current_version
-                - target_version
-              type: object
-          required:
-            - spec
-          title: BottlerocketShadow
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.current_state
+      name: State
+      type: string
+    - jsonPath: .status.current_version
+      name: Version
+      type: string
+    - jsonPath: .spec.state
+      name: Target State
+      type: string
+    - jsonPath: .spec.version
+      name: Target Version
+      type: string
+    - jsonPath: .status.crash_count
+      name: Crash Count
+      type: string
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for BottlerocketShadowSpec via `CustomResource`
+        properties:
+          spec:
+            description: The `BottlerocketShadowSpec` can be used to drive a node through the update state machine. A node linearly drives towards the desired state. The brupop controller updates the spec to specify a node's desired state, and the host agent drives state changes forward and updates the `BottlerocketShadowStatus`.
+            properties:
+              state:
+                description: Records the desired state of the `BottlerocketShadow`
+                enum:
+                - Idle
+                - StagedAndPerformedUpdate
+                - RebootedIntoUpdate
+                - MonitoringUpdate
+                - ErrorReset
+                type: string
+              state_transition_timestamp:
+                description: The time at which the most recent state was set as the desired state.
+                nullable: true
+                type: string
+              version:
+                description: The desired update version, if any.
+                nullable: true
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+                type: string
+            required:
+            - state
+            type: object
+          status:
+            description: '`BottlerocketShadowStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent, while the spec is updated by the brupop controller.'
+            nullable: true
+            properties:
+              crash_count:
+                format: uint32
+                minimum: 0.0
+                type: integer
+              current_state:
+                description: BottlerocketShadowState represents a node's state in the update state machine.
+                enum:
+                - Idle
+                - StagedAndPerformedUpdate
+                - RebootedIntoUpdate
+                - MonitoringUpdate
+                - ErrorReset
+                type: string
+              current_version:
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+                type: string
+              state_transition_failure_timestamp:
+                nullable: true
+                type: string
+              target_version:
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+                type: string
+            required:
+            - crash_count
+            - current_state
+            - current_version
+            - target_version
+            type: object
+        required:
+        - spec
+        title: BottlerocketShadow
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.current_state
+      name: State
+      type: string
+    - jsonPath: .status.current_version
+      name: Version
+      type: string
+    - jsonPath: .spec.state
+      name: Target State
+      type: string
+    - jsonPath: .spec.version
+      name: Target Version
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for BottlerocketShadowSpec via `CustomResource`
+        properties:
+          spec:
+            description: The `BottlerocketShadowSpec` can be used to drive a node through the update state machine. A node linearly drives towards the desired state. The brupop controller updates the spec to specify a node's desired state, and the host agent drives state changes forward and updates the `BottlerocketShadowStatus`.
+            properties:
+              state:
+                description: Records the desired state of the `BottlerocketShadow`
+                enum:
+                - Idle
+                - StagedUpdate
+                - PerformedUpdate
+                - RebootedIntoUpdate
+                - MonitoringUpdate
+                type: string
+              state_transition_timestamp:
+                description: The time at which the most recent state was set as the desired state.
+                nullable: true
+                type: string
+              version:
+                description: The desired update version, if any.
+                nullable: true
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+                type: string
+            required:
+            - state
+            type: object
+          status:
+            description: '`BottlerocketShadowStatus` surfaces the current state of a bottlerocket node. The status is updated by the host agent, while the spec is updated by the brupop controller.'
+            nullable: true
+            properties:
+              current_state:
+                description: BottlerocketShadowState represents a node's state in the update state machine.
+                enum:
+                - Idle
+                - StagedUpdate
+                - PerformedUpdate
+                - RebootedIntoUpdate
+                - MonitoringUpdate
+                type: string
+              current_version:
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+                type: string
+              target_version:
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+                type: string
+            required:
+            - current_state
+            - current_version
+            - target_version
+            type: object
+        required:
+        - spec
+        title: BottlerocketShadow
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
 ---
 apiVersion: v1
 kind: Namespace
@@ -255,52 +255,52 @@ metadata:
   name: brupop-apiserver-role
   namespace: brupop-bottlerocket-aws
 rules:
-  - apiGroups:
-      - brupop.bottlerocket.aws
-    resources:
-      - bottlerocketshadows
-      - bottlerocketshadows/status
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - patch
-  - apiGroups:
-      - ""
-    resources:
-      - pods/eviction
-    verbs:
-      - create
+- apiGroups:
+  - brupop.bottlerocket.aws
+  resources:
+  - bottlerocketshadows
+  - bottlerocketshadows/status
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - pods/eviction
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -317,9 +317,9 @@ roleRef:
   kind: ClusterRole
   name: brupop-apiserver-role
 subjects:
-  - kind: ServiceAccount
-    name: brupop-apiserver-service-account
-    namespace: brupop-bottlerocket-aws
+- kind: ServiceAccount
+  name: brupop-apiserver-service-account
+  namespace: brupop-bottlerocket-aws
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -334,11 +334,11 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: "system:auth-delegator"
+  name: system:auth-delegator
 subjects:
-  - kind: ServiceAccount
-    name: brupop-apiserver-service-account
-    namespace: brupop-bottlerocket-aws
+- kind: ServiceAccount
+  name: brupop-apiserver-service-account
+  namespace: brupop-bottlerocket-aws
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -368,54 +368,54 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - linux
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - arm64
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
       containers:
-        - command:
-            - "./apiserver"
-          env:
-            - name: APISERVER_INTERNAL_PORT
-              value: "8443"
-          image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.0.0"
-          livenessProbe:
-            httpGet:
-              path: /ping
-              port: 8443
-              scheme: HTTPS
-            initialDelaySeconds: 5
-          name: brupop
-          ports:
-            - containerPort: 8443
-          readinessProbe:
-            httpGet:
-              path: /ping
-              port: 8443
-              scheme: HTTPS
-            initialDelaySeconds: 5
-          resources:
-            limits:
-              cpu: 10m
-              memory: 50Mi
-            requests:
-              cpu: 3m
-              memory: 8Mi
-          volumeMounts:
-            - mountPath: /etc/brupop-tls-keys
-              name: bottlerocket-tls-keys
+      - command:
+        - ./apiserver
+        env:
+        - name: APISERVER_INTERNAL_PORT
+          value: '8443'
+        image: public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.0.0
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 5
+        name: brupop
+        ports:
+        - containerPort: 8443
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 5
+        resources:
+          limits:
+            cpu: 10m
+            memory: 50Mi
+          requests:
+            cpu: 3m
+            memory: 8Mi
+        volumeMounts:
+        - mountPath: /etc/brupop-tls-keys
+          name: bottlerocket-tls-keys
       serviceAccountName: brupop-apiserver-service-account
       volumes:
-        - name: bottlerocket-tls-keys
-          secret:
-            optional: false
-            secretName: brupop-tls
+      - name: bottlerocket-tls-keys
+        secret:
+          optional: false
+          secretName: brupop-tls
 ---
 apiVersion: v1
 kind: Service
@@ -429,8 +429,8 @@ metadata:
   namespace: brupop-bottlerocket-aws
 spec:
   ports:
-    - port: 443
-      targetPort: 8443
+  - port: 443
+    targetPort: 8443
   selector:
     brupop.bottlerocket.aws/component: apiserver
 ---
@@ -458,23 +458,23 @@ metadata:
   name: brupop-agent-role
   namespace: brupop-bottlerocket-aws
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - brupop.bottlerocket.aws
-    resources:
-      - bottlerocketshadows
-      - bottlerocketshadows/status
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - brupop.bottlerocket.aws
+  resources:
+  - bottlerocketshadows
+  - bottlerocketshadows/status
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -491,9 +491,9 @@ roleRef:
   kind: ClusterRole
   name: brupop-agent-role
 subjects:
-  - kind: ServiceAccount
-    name: brupop-agent-service-account
-    namespace: brupop-bottlerocket-aws
+- kind: ServiceAccount
+  name: brupop-agent-service-account
+  namespace: brupop-bottlerocket-aws
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -519,76 +519,76 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - linux
-                  - key: bottlerocket.aws/updater-interface-version
-                    operator: In
-                    values:
-                      - 2.0.0
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - arm64
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: bottlerocket.aws/updater-interface-version
+                operator: In
+                values:
+                - 2.0.0
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
       containers:
-        - command:
-            - "./agent"
-          env:
-            - name: MY_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC
-              value: "0"
-            - name: APISERVER_SERVICE_PORT
-              value: "443"
-          image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.0.0"
-          name: brupop
-          resources:
-            limits:
-              cpu: 10m
-              memory: 50Mi
-            requests:
-              cpu: 5m
-              memory: 8Mi
-          securityContext:
-            seLinuxOptions:
-              level: s0
-              role: system_r
-              type: super_t
-              user: system_u
-          volumeMounts:
-            - mountPath: /run/api.sock
-              name: bottlerocket-api-socket
-            - mountPath: /bin/apiclient
-              name: bottlerocket-apiclient
-            - mountPath: /var/run/secrets/tokens/
-              name: bottlerocket-agent-service-account-token
-            - mountPath: /etc/brupop-tls-keys
-              name: bottlerocket-tls-keys
+      - command:
+        - ./agent
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC
+          value: '0'
+        - name: APISERVER_SERVICE_PORT
+          value: '443'
+        image: public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.0.0
+        name: brupop
+        resources:
+          limits:
+            cpu: 10m
+            memory: 50Mi
+          requests:
+            cpu: 5m
+            memory: 8Mi
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            role: system_r
+            type: super_t
+            user: system_u
+        volumeMounts:
+        - mountPath: /run/api.sock
+          name: bottlerocket-api-socket
+        - mountPath: /bin/apiclient
+          name: bottlerocket-apiclient
+        - mountPath: /var/run/secrets/tokens/
+          name: bottlerocket-agent-service-account-token
+        - mountPath: /etc/brupop-tls-keys
+          name: bottlerocket-tls-keys
       serviceAccountName: brupop-agent-service-account
       volumes:
-        - hostPath:
-            path: /run/api.sock
-            type: Socket
-          name: bottlerocket-api-socket
-        - hostPath:
-            path: /bin/apiclient
-            type: File
-          name: bottlerocket-apiclient
-        - name: bottlerocket-agent-service-account-token
-          projected:
-            sources:
-              - serviceAccountToken:
-                  audience: brupop-apiserver
-                  path: bottlerocket-agent-service-account-token
-        - name: bottlerocket-tls-keys
-          secret:
-            optional: false
-            secretName: brupop-tls
+      - hostPath:
+          path: /run/api.sock
+          type: Socket
+        name: bottlerocket-api-socket
+      - hostPath:
+          path: /bin/apiclient
+          type: File
+        name: bottlerocket-apiclient
+      - name: bottlerocket-agent-service-account-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: brupop-apiserver
+              path: bottlerocket-agent-service-account-token
+      - name: bottlerocket-tls-keys
+        secret:
+          optional: false
+          secretName: brupop-tls
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -614,44 +614,44 @@ metadata:
   name: brupop-controller-role
   namespace: brupop-bottlerocket-aws
 rules:
-  - apiGroups:
-      - brupop.bottlerocket.aws
-    resources:
-      - bottlerocketshadows
-      - bottlerocketshadows/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - brupop.bottlerocket.aws
-    resources:
-      - bottlerocketshadows
-    verbs:
-      - create
-      - patch
-      - update
-      - delete
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - brupop.bottlerocket.aws
+  resources:
+  - bottlerocketshadows
+  - bottlerocketshadows/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - brupop.bottlerocket.aws
+  resources:
+  - bottlerocketshadows
+  verbs:
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -668,9 +668,9 @@ roleRef:
   kind: ClusterRole
   name: brupop-controller-role
 subjects:
-  - kind: ServiceAccount
-    name: brupop-controller-service-account
-    namespace: brupop-bottlerocket-aws
+- kind: ServiceAccount
+  name: brupop-controller-service-account
+  namespace: brupop-bottlerocket-aws
 ---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -707,39 +707,39 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - linux
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - arm64
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
       containers:
-        - command:
-            - "./controller"
-          env:
-            - name: MY_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: MAX_CONCURRENT_UPDATE
-              value: "1"
-            - name: UPDATE_WINDOW_START
-              value: "0:0:0"
-            - name: UPDATE_WINDOW_STOP
-              value: "0:0:0"
-          image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.0.0"
-          name: brupop
-          resources:
-            limits:
-              cpu: 10m
-              memory: 50Mi
-            requests:
-              cpu: 3m
-              memory: 8Mi
+      - command:
+        - ./controller
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MAX_CONCURRENT_UPDATE
+          value: '1'
+        - name: UPDATE_WINDOW_START
+          value: 0:0:0
+        - name: UPDATE_WINDOW_STOP
+          value: 0:0:0
+        image: public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.0.0
+        name: brupop
+        resources:
+          limits:
+            cpu: 10m
+            memory: 50Mi
+          requests:
+            cpu: 3m
+            memory: 8Mi
       priorityClassName: brupop-controller-high-priority
       serviceAccountName: brupop-controller-service-account
 ---
@@ -747,8 +747,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    prometheus.io/port: "8080"
-    prometheus.io/scrape: "true"
+    prometheus.io/port: '8080'
+    prometheus.io/scrape: 'true'
   labels:
     app.kubernetes.io/component: brupop-controller
     app.kubernetes.io/managed-by: brupop
@@ -758,7 +758,7 @@ metadata:
   namespace: brupop-bottlerocket-aws
 spec:
   ports:
-    - port: 80
-      targetPort: 8080
+  - port: 80
+    targetPort: 8080
   selector:
     brupop.bottlerocket.aws/component: brupop-controller


### PR DESCRIPTION
### Issue number:

Closes #333
Closes https://github.com/bottlerocket-os/bottlerocket-update-operator/issues/277

### Description of changes:

```
- Captures formatting changes introduced in new versions of serde.
- Adds `---` delimiters explicitly when generating yaml manifest since
  serde-yaml no longer includes those.
- Upgrades schemars to 0.8.11 which no longer breaks enum serialization
  when combined with kube-rs 0.76
- Removes outdated kube-rs ignore in deny.toml
- Adds a dump of the git diff in the "Evaluate git clean" GitHub action
  in order to see what's changed directly from the action failure.

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

### Testing done:

Integration tests running ... _please hold!_

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
