### PR TITLE
TLS: Utilize leaf certs from root CA for brupop API server and agent

### DIFF
--- a/apiserver/src/client/webclient.rs
+++ b/apiserver/src/client/webclient.rs
@@ -117,17 +117,17 @@ impl K8SAPIServerClient {
 
     /// Returns the https client configured to use self-signed certificate
     fn https_client() -> Result<reqwest::Client> {
-        let mut buf = Vec::new();
+        let mut cert_buf = Vec::new();
 
-        let ca_path = format!("{}/{}", TLS_KEY_MOUNT_PATH, CA_NAME);
-        std::fs::File::open(ca_path)
+        let leaf_cert_path = format!("{}/{}", TLS_KEY_MOUNT_PATH, CA_NAME);
+        std::fs::File::open(leaf_cert_path)
             .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
             .context(error::IOSnafu)?
-            .read_to_end(&mut buf)
+            .read_to_end(&mut cert_buf)
             .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
             .context(error::IOSnafu)?;
 
-        let cert = reqwest::Certificate::from_pem(&buf).context(error::CreateClientSnafu)?;
+        let cert = reqwest::Certificate::from_pem(&cert_buf).context(error::CreateClientSnafu)?;
 
         let client = reqwest::Client::builder()
             .add_root_certificate(cert)

--- a/models/src/agent.rs
+++ b/models/src/agent.rs
@@ -1,7 +1,7 @@
 use crate::brupop_labels;
 use crate::constants::{
     AGENT, AGENT_NAME, APISERVER_SERVICE_NAME, APP_COMPONENT, APP_MANAGED_BY, APP_PART_OF, BRUPOP,
-    BRUPOP_INTERFACE_VERSION, LABEL_BRUPOP_INTERFACE_NAME, LABEL_COMPONENT, NAMESPACE, SECRET_NAME,
+    BRUPOP_INTERFACE_VERSION, LABEL_BRUPOP_INTERFACE_NAME, LABEL_COMPONENT, NAMESPACE,
     TLS_KEY_MOUNT_PATH,
 };
 use k8s_openapi::api::apps::v1::{DaemonSet, DaemonSetSpec};
@@ -20,6 +20,7 @@ use maplit::btreemap;
 
 const BRUPOP_AGENT_SERVICE_ACCOUNT: &str = "brupop-agent-service-account";
 const BRUPOP_AGENT_CLUSTER_ROLE: &str = "brupop-agent-role";
+const BRUPOP_APISERVER_CLIENT_CERT_SECRET_NAME: &str = "brupop-apiserver-client-certificate";
 
 pub const TOKEN_PROJECTION_MOUNT_PATH: &str = "/var/run/secrets/tokens/";
 pub const AGENT_TOKEN_PATH: &str = "bottlerocket-agent-service-account-token";
@@ -273,7 +274,9 @@ pub fn agent_daemonset(
                         Volume {
                             name: "bottlerocket-tls-keys".to_string(),
                             secret: Some(SecretVolumeSource {
-                                secret_name: Some(SECRET_NAME.to_string()),
+                                secret_name: Some(
+                                    BRUPOP_APISERVER_CLIENT_CERT_SECRET_NAME.to_string(),
+                                ),
                                 optional: Some(false),
                                 ..Default::default()
                             }),

--- a/models/src/apiserver.rs
+++ b/models/src/apiserver.rs
@@ -2,7 +2,7 @@ use crate::brupop_labels;
 use crate::constants::{
     APISERVER, APISERVER_HEALTH_CHECK_ROUTE, APISERVER_MAX_UNAVAILABLE, APISERVER_SERVICE_NAME,
     APP_COMPONENT, APP_MANAGED_BY, APP_PART_OF, BRUPOP, BRUPOP_DOMAIN_LIKE_NAME, LABEL_COMPONENT,
-    NAMESPACE, SECRET_NAME, TLS_KEY_MOUNT_PATH,
+    NAMESPACE, TLS_KEY_MOUNT_PATH,
 };
 use crate::node::{K8S_NODE_PLURAL, K8S_NODE_STATUS};
 use k8s_openapi::api::apps::v1::{
@@ -23,6 +23,7 @@ use maplit::btreemap;
 
 const BRUPOP_APISERVER_SERVICE_ACCOUNT: &str = "brupop-apiserver-service-account";
 const BRUPOP_APISERVER_CLUSTER_ROLE: &str = "brupop-apiserver-role";
+const BRUPOP_APISERVER_CERT_SECRET_NAME: &str = "brupop-apiserver-certificate";
 
 // A kubernetes system role which allows a system to use the TokenReview API.
 const AUTH_DELEGATOR_ROLE_NAME: &str = "system:auth-delegator";
@@ -287,7 +288,7 @@ pub fn apiserver_deployment(
                     volumes: Some(vec![Volume {
                         name: "bottlerocket-tls-keys".to_string(),
                         secret: Some(SecretVolumeSource {
-                            secret_name: Some(SECRET_NAME.to_string()),
+                            secret_name: Some(BRUPOP_APISERVER_CERT_SECRET_NAME.to_string()),
                             optional: Some(false),
                             ..Default::default()
                         }),

--- a/models/src/constants.rs
+++ b/models/src/constants.rs
@@ -35,13 +35,12 @@ pub const LABEL_BRUPOP_INTERFACE_NAME: &str = "bottlerocket.aws/updater-interfac
 pub const BRUPOP_INTERFACE_VERSION: &str = "2.0.0";
 
 // In name space secret name for SSL communication in API server.
-pub const SECRET_NAME: &str = "brupop-tls";
 pub const CA_NAME: &str = "ca.crt";
 pub const PUBLIC_KEY_NAME: &str = "tls.crt";
 pub const PRIVATE_KEY_NAME: &str = "tls.key";
 pub const TLS_KEY_MOUNT_PATH: &str = "/etc/brupop-tls-keys";
 // Certificate object name
-pub const CERTIFICATE_NAME: &str = "brupop-apiserver-certificate";
+pub const ROOT_CERTIFICATE_NAME: &str = "root-certificate";
 
 // Label keys
 pub const LABEL_COMPONENT: &str = brupop_domain!("component");

--- a/models/src/node/crd/mod.rs
+++ b/models/src/node/crd/mod.rs
@@ -47,7 +47,7 @@ pub use self::v2::{
     BottlerocketShadow, BottlerocketShadowSpec, BottlerocketShadowState, BottlerocketShadowStatus,
 };
 use crate::constants::{
-    APISERVER_CRD_CONVERT_ENDPOINT, APISERVER_SERVICE_NAME, CERTIFICATE_NAME, NAMESPACE,
+    APISERVER_CRD_CONVERT_ENDPOINT, APISERVER_SERVICE_NAME, NAMESPACE, ROOT_CERTIFICATE_NAME,
 };
 
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
@@ -190,7 +190,7 @@ fn generate_ca_annotations() -> BTreeMap<String, String> {
         format!(
             "{namespace}/{object}",
             namespace = NAMESPACE,
-            object = CERTIFICATE_NAME
+            object = ROOT_CERTIFICATE_NAME
         ),
     );
     cert_manager_annotations

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: brupop-bottlerocket-aws/brupop-apiserver-certificate
+    cert-manager.io/inject-ca-from: brupop-bottlerocket-aws/root-certificate
   name: bottlerocketshadows.brupop.bottlerocket.aws
 spec:
   conversion:
@@ -196,20 +196,37 @@ metadata:
   name: brupop-bottlerocket-aws
 ---
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
   name: selfsigned-issuer
+  namespace: brupop-bottlerocket-aws
 spec:
   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: brupop-selfsigned-ca
+  namespace: brupop-bottlerocket-aws
+spec:
+  isCA: true
+  commonName: brupop-selfsigned-ca
+  secretName: brupop-root-ca-secret
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: my-ca-issuer
+  name: brupop-root-certificate-issuer
   namespace: brupop-bottlerocket-aws
 spec:
   ca:
-    secretName: brupop-tls
+    secretName: brupop-root-ca-secret
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -217,19 +234,41 @@ metadata:
   name: brupop-apiserver-certificate
   namespace: brupop-bottlerocket-aws
 spec:
-  isCA: true
-  commonName: my-selfsigned-ca
-  secretName: brupop-tls
+  secretName: brupop-apiserver-certificate
   privateKey:
     algorithm: RSA
     encoding: PKCS8
   dnsNames:
-    - brupop-apiserver.brupop-bottlerocket-aws.svc.cluster.local
-    - brupop-apiserver.brupop-bottlerocket-aws.svc
+    - "*.brupop-bottlerocket-aws.svc.cluster.local"
+    - "*.brupop-bottlerocket-aws.svc"
+  usages:
+    - server auth
+    - key encipherment
+    - digital signature
   issuerRef:
-    name: selfsigned-issuer
-    kind: ClusterIssuer
-    group: cert-manager.io
+    name: brupop-root-certificate-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: brupop-apiserver-client-certificate
+  namespace: brupop-bottlerocket-aws
+spec:
+  secretName: brupop-apiserver-client-certificate
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+  dnsNames:
+    - "*.brupop-bottlerocket-aws.svc.cluster.local"
+    - "*.brupop-bottlerocket-aws.svc"
+  usages:
+    - client auth
+    - key encipherment
+    - digital signature
+  issuerRef:
+    name: brupop-root-certificate-issuer
+    kind: Issuer
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -415,7 +454,7 @@ spec:
       - name: bottlerocket-tls-keys
         secret:
           optional: false
-          secretName: brupop-tls
+          secretName: brupop-apiserver-certificate
 ---
 apiVersion: v1
 kind: Service
@@ -588,7 +627,7 @@ spec:
       - name: bottlerocket-tls-keys
         secret:
           optional: false
-          secretName: brupop-tls
+          secretName: brupop-apiserver-client-certificate
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/yamlgen/deploy/cert.yaml
+++ b/yamlgen/deploy/cert.yaml
@@ -1,19 +1,36 @@
 ---
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
   name: selfsigned-issuer
+  namespace: brupop-bottlerocket-aws
 spec:
   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: brupop-selfsigned-ca
+  namespace: brupop-bottlerocket-aws
+spec:
+  isCA: true
+  commonName: brupop-selfsigned-ca
+  secretName: brupop-root-ca-secret
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: my-ca-issuer
+  name: brupop-root-certificate-issuer
   namespace: brupop-bottlerocket-aws
 spec:
   ca:
-    secretName: brupop-tls
+    secretName: brupop-root-ca-secret
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -21,16 +38,38 @@ metadata:
   name: brupop-apiserver-certificate
   namespace: brupop-bottlerocket-aws
 spec:
-  isCA: true
-  commonName: my-selfsigned-ca
-  secretName: brupop-tls
+  secretName: brupop-apiserver-certificate
   privateKey:
     algorithm: RSA
     encoding: PKCS8
   dnsNames:
-    - brupop-apiserver.brupop-bottlerocket-aws.svc.cluster.local
-    - brupop-apiserver.brupop-bottlerocket-aws.svc
+    - "*.brupop-bottlerocket-aws.svc.cluster.local"
+    - "*.brupop-bottlerocket-aws.svc"
+  usages:
+    - server auth
+    - key encipherment
+    - digital signature
   issuerRef:
-    name: selfsigned-issuer
-    kind: ClusterIssuer
-    group: cert-manager.io
+    name: brupop-root-certificate-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: brupop-apiserver-client-certificate
+  namespace: brupop-bottlerocket-aws
+spec:
+  secretName: brupop-apiserver-client-certificate
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+  dnsNames:
+    - "*.brupop-bottlerocket-aws.svc.cluster.local"
+    - "*.brupop-bottlerocket-aws.svc"
+  usages:
+    - client auth
+    - key encipherment
+    - digital signature
+  issuerRef:
+    name: brupop-root-certificate-issuer
+    kind: Issuer


### PR DESCRIPTION
### Issue number:

Closes: #232

### Description of changes:

```
- Ensures that the agent does not get the entire cert bundle from the
  brupop api-server. Instead, get's it's own cert that is signed by the
  root cert.
- Renames variable to make more sense for leaf certs on both apiserver
  and client.

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

This change fixes our usage of a root CA as _both_ server and client certificates. The original circular chain of trust meant that the agent always had root certificate privileges and would have the entire server's cert chain mounted.

Instead, this patch creates the following chain of trust:
1. Initialize a self signed "bootstrap" issuer. 
2. The bootstrap issuer is utilized to create the root CA (which is effectively also self signed)
3. Using the root CA, initialize a "Brupop root certificate" issuer that can generate leaf certificates
4. Generate leaf certificates for both the api server and the agent utilizing the brupop root certificate issuer
    -  Set the `dnsName` for the apisever certificate to cover the brupop namespace: `*.brupop-bottlerocket-aws.svc.` addresses
    - Set the `dnsName` for the agent certificate to cover the brupop namespace: `*.brupop-bottlerocket-aws.svc.` addresses
6. The brupop API server mounts and uses the entire chain (it's CA, it's private key, and it's public key) and sends these certs to be validated by the agent.
7. The brupop agent mounts and uses it's cert build a chain of trust it can use to validate the server

### Testing done:

1. Built an image, pushed to ECR and updated the `image` tags in the yaml manifest to point to my testing image
2. Ran the integration tests
3. All looks good 👍🏼 - upgraded to newer version of bottlerocket and no logs indicating a problem
```
❯ k get brs -A
NAMESPACE                 NAME                                                STATE   VERSION   TARGET STATE   TARGET VERSION   CRASH COUNT
brupop-bottlerocket-aws   brs-ip-192-168-135-135.us-west-2.compute.internal   Idle    1.10.1    Idle                            0
brupop-bottlerocket-aws   brs-ip-192-168-150-220.us-west-2.compute.internal   Idle    1.10.1    Idle                            0
brupop-bottlerocket-aws   brs-ip-192-168-158-91.us-west-2.compute.internal    Idle    1.10.1    Idle                            0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
