### PR TITLE
Expose failure output for apiclient

### DIFF
--- a/agent/src/apiclient.rs
+++ b/agent/src/apiclient.rs
@@ -150,6 +150,8 @@ async fn invoke_apiclient(args: Vec<String>) -> Result<Output> {
                             _ => {
                                 // API response was a non-transient error, bail out
                                 return apiclient_error::BadHttpResponseSnafu {
+                                    args: args,
+                                    error_content: &error_content,
                                     statuscode: error_statuscode,
                                 }
                                 .fail();
@@ -361,8 +363,12 @@ pub mod apiclient_error {
             expect_state: String,
             update_state: UpdateState,
         },
-        #[snafu(display("Bad http response, status code: {}", statuscode))]
-        BadHttpResponse { statuscode: String },
+        #[snafu(display("Bad http response when running command {} due to status code {}. Error output: {}", args.join(" "), statuscode, error_content))]
+        BadHttpResponse {
+            args: Vec<String>,
+            error_content: String,
+            statuscode: String,
+        },
 
         #[snafu(display("Unable to process command apiclient {}: update API unavailable: retries exhausted", args.join(" ")))]
         UpdateApiUnavailable { args: Vec<String> },


### PR DESCRIPTION
The agent calls to the bottlerocket API and it could fail for any number of reasons. Currently we only return the status code, so we improve update API invoke functionality to return entire error output for easier debugging.

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes: #335 


**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Thu Nov 17 19:23:43 2022 +0000

    Expose failure output for apiclient

    The agent calls to the bottlerocket API and it could fail for any number
    of reasons. Currently we only return the status code, so we improve
    update API invoke functionality to return entire error output for easier
    debugging.
```

**Testing done:**
:white_check_mark: Integration test


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
