### PR TITLE
improve time window to become cron expression based scheduler

### DIFF
--- a/.env
+++ b/.env
@@ -26,11 +26,20 @@ EXCLUDE_FROM_LB_WAIT_TIME_IN_SEC=0
 # option, which could potential exclude all nodes from load balancer at the same time.
 MAX_CONCURRENT_UPDATE=1
 
-# Update time window setting
-# Brupop will operate node updates within update time window.
-# when you set up time window start and stop time, you should use UTC (24-hour time notation).
-UPDATE_WINDOW_START=0:0:0
-UPDATE_WINDOW_STOP=0:0:0
+# scheduler setting
+# Brupop will operate node updates on scheduled maintenance windows by using cron expressions.
+# When you set up the scheduler, you should follow cron expression rules.
+# ┌───────────── seconds (0 - 59)
+# | ┌───────────── minute (0 - 59)
+# | │ ┌───────────── hour (0 - 23)
+# | │ │ ┌───────────── day of the month (1 - 31)
+# | │ │ │ ┌───────────── month (Jan, Feb, Mar, Apr, Jun, Jul, Aug, Sep, Oct, Nov, Dec)
+# | │ │ │ │ ┌───────────── day of the week (Mon, Tue, Wed, Thu, Fri, Sat, Sun)
+# | │ │ │ │ │ ┌───────────── year (formatted as YYYY)
+# | │ │ │ │ │ |
+# | │ │ │ │ │ |
+# * * * * * * *
+SCHEDULER_CRON_EXPRESSION="* * * * * * *"
 
 # API Server ports
 APISERVER_INTERNAL_PORT=8443

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,15 +979,18 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "chrono",
+ "cron",
  "futures",
  "http",
  "k8s-openapi",
  "kube",
+ "lazy_static",
  "maplit",
  "models",
  "opentelemetry",
  "opentelemetry-prometheus",
  "prometheus",
+ "regex",
  "semver",
  "serde_plain",
  "snafu",
@@ -995,6 +998,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "validator",
 ]
 
 [[package]]
@@ -1046,6 +1050,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff76b51e4c068c52bfd2866e1567bee7c567ae8f24ada09fd4307019e25eab7"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
 ]
 
 [[package]]
@@ -2055,6 +2070,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,6 +2146,16 @@ dependencies = [
  "tokio-retry",
  "tracing",
  "validator",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]

--- a/clarify.toml
+++ b/clarify.toml
@@ -93,7 +93,11 @@ license-files = [
     { path = "LICENSE.Mit", hash = 0xa237d234 },
     { path = "LICENSE.Apache-2.0", hash = 0x7b466be4 },
 ]
-#skip-files = [
-     #Files under zstd/build are for IDE integrations, and are unused.
-    #"zstd/build/LICENSE"
-#]
+
+[clarify.minimal-lexical]
+expression = "(MIT OR Apache-2.0) AND BSD-3-Clause"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0x4fccb6b7 },
+    { path = "LICENSE-MIT", hash = 0x386ca1bc },
+    { path = "LICENSE.md", hash = 0xfe66d806 },
+]

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -8,9 +8,12 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 actix-web = "4"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
+cron = "0.12"
 futures = "0.3"
 http = "0.2.9"
+lazy_static = "1.2"
 maplit = "1.0"
+regex = "1.1"
 semver = "1.0"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.17.0", default-features = false, features = ["v1_20"] }
@@ -26,3 +29,4 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.18"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
+validator = { version = "0.16", features = ["derive"] }

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -1,5 +1,6 @@
 use super::{
     metrics::{BrupopControllerMetrics, BrupopHostsData},
+    scheduler::BrupopCronScheduler,
     statemachine::determine_next_node_spec,
 };
 use models::constants::{BRUPOP_INTERFACE_VERSION, LABEL_BRUPOP_INTERFACE_NAME, NAMESPACE};
@@ -8,7 +9,6 @@ use models::node::{
     Selector,
 };
 
-use chrono::{Duration as chrono_duration, NaiveTime, Utc};
 use k8s_openapi::api::core::v1::Node;
 use kube::api::DeleteParams;
 use kube::runtime::reflector::Store;
@@ -19,6 +19,7 @@ use snafu::ResultExt;
 use std::collections::{BTreeMap, HashMap};
 use std::env;
 use tokio::time::{sleep, Duration};
+
 use tracing::{event, instrument, Level};
 
 // Defines the length time after which the controller will take actions.
@@ -26,11 +27,6 @@ const ACTION_INTERVAL: Duration = Duration::from_secs(2);
 
 // Defines environment variable name used to fetch max concurrent update number.
 const MAX_CONCURRENT_UPDATE_ENV_VAR: &str = "MAX_CONCURRENT_UPDATE";
-
-// Defines the update time window related env variable names
-const UPDATE_WINDOW_START_ENV_VAR: &str = "UPDATE_WINDOW_START";
-const UPDATE_WINDOW_STOP_ENV_VAR: &str = "UPDATE_WINDOW_STOP";
-const UPDATE_WINDOW_BUFFER: i64 = 6;
 
 /// The module-wide result type.
 type Result<T> = std::result::Result<T, controllerclient_error::Error>;
@@ -252,6 +248,19 @@ impl<T: BottlerocketShadowClient> BrupopController<T> {
         Ok(())
     }
 
+    #[instrument(skip(self))]
+    fn nodes_ready_to_update(&self) -> bool {
+        let mut shadows: Vec<BottlerocketShadow> = self.all_brss();
+        for brs in shadows.drain(..) {
+            // If we determine that the spec should change, this node is a candidate to begin updating.
+            let next_spec = determine_next_node_spec(&brs);
+            if next_spec != brs.spec && is_initial_state(&brs) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /// Runs the event loop for the Brupop controller.
     ///
     /// Because the controller wants to gate the number of simultaneously updating nodes, we can't allow the update state machine
@@ -262,61 +271,71 @@ impl<T: BottlerocketShadowClient> BrupopController<T> {
     /// The controller is designed to run on a single node in the cluster and rely on the scheduler to ensure there is always one
     /// running; however, it could be expanded using leader-election and multiple nodes if the scheduler proves to be problematic.
     pub async fn run(&self) -> Result<()> {
+        // generate brupop cron expression schedule
+        let scheduler = BrupopCronScheduler::from_environment()
+            .context(controllerclient_error::GetCronScheduleSnafu)?;
+
         // On every iteration of the event loop, we reconstruct the state of the controller and determine its
         // next actions. This is to ensure that the operator would behave consistently even if suddenly restarted.
         loop {
-            // Brupop typically only operates on a single node at a time. Here we find the set of nodes which is currently undergoing
-            // change, to ensure that errors resulting in multiple nodes changing state simultaneously is not unrecoverable.
             let active_set = self.active_brs_set();
-            let active_set_size = active_set.len();
             event!(Level::TRACE, ?active_set, "Found active set of nodes.");
 
-            // update time window: users can specify a update time window to operate Bottlerocket nodes update. If current time isn't within the time window,
-            // controller shouldn't have any action on it.
-            match within_time_window()? {
-                // If controller has already started a node update but the update time window stops,
-                // controller should respect it, continue to complete the update, and stop actions on remaining nodes.
-                // This logic will cooperate with 6 mins buffer strategy.
-                false => {
-                    // try to find out if any nodes are being updated. If yes, controller
-                    // will complete them and pause actions on other waitingForUpdate nodes.
-                    if !active_set.is_empty() {
-                        self.progress_active_set(active_set).await?;
-                    } else {
-                        sleep(ACTION_INTERVAL).await;
-                        continue;
-                    }
-                }
-                true => {
-                    if !active_set.is_empty() {
-                        self.progress_active_set(active_set).await?;
-                    }
+            // when current is outside of a scheduled maintenance window, controlle should keep updating active nodes
+            // if there are any ongoing updates. Otherwise it should sleep until next maintenance window.
+            let mut maintenance_window = if active_set.is_empty() {
+                // If there are no more active nodes and current is outside of the maintenance window, brupop controller
+                // will sleep until next scheduled time.
+                scheduler
+                    .wait_until_next_maintainence_window()
+                    .await
+                    .context(controllerclient_error::SleepUntilNextScheduleSnafu)?;
+                true
+            } else {
+                // Any ongoing updates are completed even outside of the maintenance window
+                self.progress_active_set(active_set).await?;
+                sleep(ACTION_INTERVAL).await;
+                false
+            };
 
-                    // Bring one more node each time if the active nodes size is less than MAX_CONCURRENT_UPDATE setting.
-                    if active_set_size < get_max_concurrent_update()? {
-                        // If there's nothing to operate on, check to see if any other nodes are ready for action.
-                        let new_active_node = self.find_and_update_ready_brs().await?;
-                        if let Some(brs) = new_active_node {
-                            event!(Level::INFO, name = %brs.name_any(), "Began updating new node.")
-                        }
+            while maintenance_window {
+                // Brupop typically only operates on a single node at a time. Here we find the set of nodes which is currently undergoing
+                // change, to ensure that errors resulting in multiple nodes changing state simultaneously is not unrecoverable.
+                let active_set = self.active_brs_set();
+                let active_set_size = active_set.len();
+                event!(Level::TRACE, ?active_set, "Found active set of nodes.");
+
+                if !active_set.is_empty() {
+                    self.progress_active_set(active_set).await?;
+                }
+                // Bring one more node each time if the active nodes size is less than MAX_CONCURRENT_UPDATE setting.
+                if active_set_size < get_max_concurrent_update()? {
+                    // If there's nothing to operate on, check to see if any other nodes are ready for action.
+                    let new_active_node = self.find_and_update_ready_brs().await?;
+                    if let Some(brs) = new_active_node {
+                        event!(Level::INFO, name = %brs.name_any(), "Began updating new node.")
                     }
                 }
+
+                // Cleanup BRS when the operator is removed from a node
+                let brss_name = self
+                    .all_brss()
+                    .into_iter()
+                    .map(|brs| brs.name_any())
+                    .collect();
+                let nodes = self.all_nodes();
+                self.bottlerocketshadows_cleanup(nodes, brss_name).await?;
+
+                // Emit metrics at the end of the loop in case the loop didn't progress any nodes.
+                self.emit_metrics()?;
+
+                // Sleep until it's time to check for more action.
+                sleep(ACTION_INTERVAL).await;
+
+                // We end the maintenance window if it's unable to find ready node, or the time window has ended.
+                maintenance_window =
+                    !scheduler.should_discontinue_updates() && self.nodes_ready_to_update();
             }
-
-            // Cleanup BRS when the operator is removed from a node
-            let brss_name = self
-                .all_brss()
-                .into_iter()
-                .map(|brs| brs.name_any())
-                .collect();
-            let nodes = self.all_nodes();
-            self.bottlerocketshadows_cleanup(nodes, brss_name).await?;
-
-            // Emit metrics at the end of the loop in case the loop didn't progress any nodes.
-            self.emit_metrics()?;
-
-            // Sleep until it's time to check for more action.
-            sleep(ACTION_INTERVAL).await;
         }
     }
 }
@@ -324,10 +343,7 @@ impl<T: BottlerocketShadowClient> BrupopController<T> {
 // Get node and BottlerocketShadow names
 #[instrument]
 fn get_associated_bottlerocketshadow_name() -> Result<String> {
-    let associated_node_name =
-        env::var("MY_NODE_NAME").context(controllerclient_error::MissingEnvVariableSnafu {
-            variable: "MY_NODE_NAME".to_string(),
-        })?;
+    let associated_node_name = read_env_var("MY_NODE_NAME")?;
     let associated_bottlerocketshadow_name = brs_name_from_node_name(&associated_node_name);
 
     event!(
@@ -372,11 +388,7 @@ fn sort_shadows(shadows: &mut Vec<BottlerocketShadow>, associated_brs_name: &str
 
 /// Fetch the environment variable to determine the max concurrent update nodes number.
 fn get_max_concurrent_update() -> Result<usize> {
-    let max_concurrent_update = env::var(MAX_CONCURRENT_UPDATE_ENV_VAR)
-        .context(controllerclient_error::MissingEnvVariableSnafu {
-            variable: MAX_CONCURRENT_UPDATE_ENV_VAR.to_string(),
-        })?
-        .to_lowercase();
+    let max_concurrent_update = read_env_var(MAX_CONCURRENT_UPDATE_ENV_VAR)?.to_lowercase();
 
     if max_concurrent_update.eq("unlimited") {
         Ok(usize::MAX)
@@ -416,64 +428,10 @@ fn node_has_label(node: &Node) -> bool {
         ));
 }
 
-#[instrument(skip())]
-fn within_time_window() -> Result<bool> {
-    let update_window_start_env = env::var(UPDATE_WINDOW_START_ENV_VAR).context(
-        controllerclient_error::MissingEnvVariableSnafu {
-            variable: UPDATE_WINDOW_START_ENV_VAR.to_string(),
-        },
-    )?;
-
-    let update_window_stop_env = env::var(UPDATE_WINDOW_STOP_ENV_VAR).context(
-        controllerclient_error::MissingEnvVariableSnafu {
-            variable: UPDATE_WINDOW_STOP_ENV_VAR.to_string(),
-        },
-    )?;
-
-    let current_time = Utc::now().time();
-    let update_window_start = NaiveTime::parse_from_str(&update_window_start_env, "%H:%M:%S")
-        .context(controllerclient_error::ConvertToNativeTimeSnafu {
-            date: update_window_start_env,
-        })?;
-    let update_window_stop = NaiveTime::parse_from_str(&update_window_stop_env, "%H:%M:%S")
-        .context(controllerclient_error::ConvertToNativeTimeSnafu {
-            date: update_window_stop_env,
-        })?;
-
-    // Due to the situation that controller has already started a node update but the time window will stop,
-    // we design controller to stop updating any new nodes 6 mins (the time brupop spends to update a node)
-    // before update window stop time except finishing remaining update circle. Therefore, when update window stops,
-    // no nodes are on "in-process" status.
-    let update_window_stop_with_buffer =
-        update_window_stop - chrono_duration::minutes(UPDATE_WINDOW_BUFFER);
-
-    event!(
-        Level::INFO,
-        "Calculating if current time is within update time window."
-    );
-    Ok(update_time_window_calculator(
-        &update_window_start,
-        &update_window_stop_with_buffer,
-        &current_time,
-    ))
-}
-
-fn update_time_window_calculator(
-    update_window_start: &NaiveTime,
-    update_window_stop: &NaiveTime,
-    current_time: &NaiveTime,
-) -> bool {
-    // If update window start time is later than update window stop time, we'll assume a cross day period.
-    // For example, start time 11pm is later than end time 2am, so brupop will recognize it as 11pm - 2 am (next day) slot.
-    if update_window_start > update_window_stop {
-        let is_within_time_window =
-            (current_time >= update_window_start) || (current_time < update_window_stop);
-        return is_within_time_window;
-    } else {
-        let is_within_time_window =
-            (current_time >= update_window_start) && (current_time < update_window_stop);
-        return is_within_time_window;
-    }
+fn read_env_var(env_var: &str) -> Result<String> {
+    env::var(env_var).context(controllerclient_error::MissingEnvVariableSnafu {
+        variable: env_var.to_string(),
+    })
 }
 
 #[cfg(test)]
@@ -649,81 +607,11 @@ pub(crate) mod test {
         assert!(node_has_label(&labeled_node));
         assert_eq!(node_has_label(&unlabeled_node), false);
     }
-    #[test]
-    fn test_time_window_calculator() {
-        let test_cases = vec![
-            (
-                btreemap! {
-                        "update_window_start" =>
-                        NaiveTime::parse_from_str("9:0:0", "%H:%M:%S").unwrap(),
-                        "update_window_stop"=>
-                        NaiveTime::parse_from_str("18:0:0", "%H:%M:%S").unwrap(),
-                        "current_time"=>
-                        NaiveTime::parse_from_str("11:0:0", "%H:%M:%S").unwrap(),
-                },
-                true,
-            ),
-            (
-                btreemap! {
-                        "update_window_start" =>
-                        NaiveTime::parse_from_str("9:0:0", "%H:%M:%S").unwrap(),
-                        "update_window_stop"=>
-                        NaiveTime::parse_from_str("18:0:0", "%H:%M:%S").unwrap(),
-                        "current_time"=>
-                        NaiveTime::parse_from_str("23:0:0", "%H:%M:%S").unwrap(),
-                },
-                false,
-            ),
-            (
-                btreemap! {
-                        "update_window_start" =>
-                        NaiveTime::parse_from_str("23:0:0", "%H:%M:%S").unwrap(),
-                        "update_window_stop"=>
-                        NaiveTime::parse_from_str("5:0:0", "%H:%M:%S").unwrap(),
-                        "current_time"=>
-                        NaiveTime::parse_from_str("3:0:0", "%H:%M:%S").unwrap(),
-                },
-                true,
-            ),
-            (
-                btreemap! {
-                        "update_window_start" =>
-                        NaiveTime::parse_from_str("23:0:0", "%H:%M:%S").unwrap(),
-                        "update_window_stop"=>
-                        NaiveTime::parse_from_str("5:0:0", "%H:%M:%S").unwrap(),
-                        "current_time"=>
-                        NaiveTime::parse_from_str("21:0:0", "%H:%M:%S").unwrap(),
-                },
-                false,
-            ),
-            (
-                btreemap! {
-                        "update_window_start" =>
-                        NaiveTime::parse_from_str("0:0:0", "%H:%M:%S").unwrap(),
-                        "update_window_stop"=>
-                        NaiveTime::parse_from_str("0:0:0", "%H:%M:%S").unwrap(),
-                        "current_time"=>
-                        NaiveTime::parse_from_str("21:0:0", "%H:%M:%S").unwrap(),
-                },
-                false,
-            ),
-        ];
-
-        for (times, is_within_time_window) in test_cases {
-            assert_eq!(
-                update_time_window_calculator(
-                    times.get("update_window_start").unwrap(),
-                    times.get("update_window_stop").unwrap(),
-                    times.get("current_time").unwrap(),
-                ),
-                is_within_time_window
-            );
-        }
-    }
 }
 
 pub mod controllerclient_error {
     use crate::controller::MAX_CONCURRENT_UPDATE_ENV_VAR;
+    use crate::scheduler::scheduler_error;
     use models::node::BottlerocketShadowClientError;
     use models::node::BottlerocketShadowError;
     use snafu::Snafu;
@@ -737,17 +625,14 @@ pub mod controllerclient_error {
             source: serde_plain::Error,
         },
 
-        #[snafu(display("Unable convert {} to Native Time data type due to {}", date, source))]
-        ConvertToNativeTime {
-            date: String,
-            source: chrono::ParseError,
-        },
-
         #[snafu(display("Failed to delete node via kubernetes API: '{}'", source))]
         DeleteNode { source: kube::Error },
 
         #[snafu(display("Unable to get host controller pod node name: {}", source))]
         GetNodeName { source: std::env::VarError },
+
+        #[snafu(display("Unable to get cron expression schedule: {}", source))]
+        GetCronSchedule { source: scheduler_error::Error },
 
         #[snafu(display("Failed to update node spec via kubernetes API: '{}'", source))]
         UpdateNodeSpec {
@@ -773,7 +658,11 @@ pub mod controllerclient_error {
             source
         ))]
         MaxConcurrentUpdateParseError { source: std::num::ParseIntError },
-        #[snafu(display("Unable to get Node UID because of missing Node `UID` value"))]
-        MissingNodeUid {},
+
+        #[snafu(display("Error creating maintenance time: '{}'", source))]
+        MaintenanceTimeError { source: scheduler_error::Error },
+
+        #[snafu(display("Unable to find next scheduled time and sleep: '{}'", source))]
+        SleepUntilNextSchedule { source: scheduler_error::Error },
     }
 }

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -1,6 +1,7 @@
 mod controller;
 mod metrics;
 
+pub mod scheduler;
 pub mod statemachine;
 pub mod telemetry;
 

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -116,9 +116,9 @@ async fn main() -> Result<()> {
         _ = node_drainer => {
             event!(Level::ERROR, "node reflector drained");
         },
-        _ = controller_runner => {
+        controller = controller_runner => {
             event!(Level::ERROR, "controller exited");
-
+            controller.context(controller_error::ControllerSnafu)?
         },
         _ = prometheus_server => {
             event!(Level::ERROR, "metric server exited");

--- a/controller/src/scheduler.rs
+++ b/controller/src/scheduler.rs
@@ -1,0 +1,451 @@
+use chrono::{DateTime, Utc};
+use cron::Schedule;
+use lazy_static::lazy_static;
+use regex::Regex;
+use snafu::{OptionExt, ResultExt};
+use std::env;
+use std::str::FromStr;
+use tracing::{event, Level};
+use validator::Validate;
+
+// Defines the cron expression scheduler related env variable names
+const SCHEDULER_CRON_EXPRESSION_ENV_VAR: &str = "SCHEDULER_CRON_EXPRESSION";
+
+// Defines the update time window related env variable names
+const UPDATE_WINDOW_START_ENV_VAR: &str = "UPDATE_WINDOW_START";
+const UPDATE_WINDOW_STOP_ENV_VAR: &str = "UPDATE_WINDOW_STOP";
+
+const SCHEDULER_DEFAULT: &str = "* * * * * * *";
+
+/// The module-wide result type.
+type Result<T> = std::result::Result<T, scheduler_error::Error>;
+
+// regex format: HH:MM:SS
+lazy_static! {
+    pub(crate) static ref VALID_UPDATE_TIME_WINDOW_VARIABLE: Regex =
+        Regex::new(r"^(2[0-3]|[01]?[0-9]):([0-5]?[0-9]):([0-5]?[0-9])$").unwrap();
+}
+#[derive(Validate)]
+struct LegacyUpdateWindow {
+    #[validate(regex = "VALID_UPDATE_TIME_WINDOW_VARIABLE")]
+    start_time: String,
+    #[validate(regex = "VALID_UPDATE_TIME_WINDOW_VARIABLE")]
+    end_time: String,
+}
+impl LegacyUpdateWindow {
+    fn from_environment() -> Result<Option<Self>> {
+        let start_env_var = env::var(UPDATE_WINDOW_START_ENV_VAR);
+        let stop_env_var = env::var(UPDATE_WINDOW_STOP_ENV_VAR);
+
+        match (start_env_var, stop_env_var) {
+            (Err(_), Ok(_)) | (Ok(_), Err(_)) => {
+                scheduler_error::MissingTimeWindowVariableSnafu {
+                    message: "missing update time start variable or update time start variable, please provide both of them.".to_string(),
+                }.fail()
+            },
+            (Err(_), Err(_)) => {
+                Ok(None)
+            },
+            (Ok(update_window_start), Ok(update_window_stop)) => {
+                Ok(Some(Self::from_string(update_window_start, update_window_stop)))
+            }
+        }
+    }
+
+    fn from_string<S: AsRef<str>>(start_time: S, stop_time: S) -> Self {
+        LegacyUpdateWindow {
+            start_time: start_time.as_ref().to_string(),
+            end_time: stop_time.as_ref().to_string(),
+        }
+    }
+
+    /// Convert update time window values to cron expression
+    /// For overnight schedule, we format it to `{}-23,0-{}` on hour spot.
+    /// For example, start time on 18 and stop time on 5. we format it to `18-23,0-5`
+    fn cron_expression_converter(&self) -> Result<String> {
+        match self.validate() {
+            Ok(_) => {
+                let start_hour: u8 = self
+                    .start_time
+                    .split(":")
+                    .next()
+                    .context(scheduler_error::InvalidTimeWindowSettingsSnafu {})?
+                    .parse()
+                    .context(scheduler_error::UnableParseToU8Snafu {
+                        variable: "start time hour".to_string(),
+                    })?;
+                let stop_hour: u8 = self
+                    .end_time
+                    .split(":")
+                    .next()
+                    .context(scheduler_error::InvalidTimeWindowSettingsSnafu {})?
+                    .parse()
+                    .context(scheduler_error::UnableParseToU8Snafu {
+                        variable: "stop time hour".to_string(),
+                    })?;
+
+                let cron_expression_hour = if start_hour <= stop_hour {
+                    format!("* * {}-{} * * * *", start_hour, stop_hour)
+                } else {
+                    format!("* * {}-23,0-{} * * * *", start_hour, stop_hour)
+                };
+
+                return Ok(cron_expression_hour);
+            }
+            Err(_) => return scheduler_error::InvalidTimeWindowSettingsSnafu {}.fail(),
+        }
+    }
+}
+
+pub struct BrupopCronScheduler {
+    scheduler: cron::Schedule,
+    schedule_type: ScheduleType,
+}
+
+impl BrupopCronScheduler {
+    pub fn from_environment() -> Result<Self> {
+        let legacy_window = LegacyUpdateWindow::from_environment()?;
+        let scheduler_cron_expression = get_cron_schedule_from_env()?;
+
+        let scheduler = match (legacy_window, scheduler_cron_expression) {
+            // it's not allowed to set update time window and scheduler at same time
+            (Some(_), Some(_)) => {
+                return scheduler_error::DisallowSetTimeWindowAndSchedulerSnafu {}.fail();
+            }
+            // set cron expression scheduler to default "* * * * * * *" if no update time window and
+            // scheduler variables are provided.
+            (None, None) => Ok(SCHEDULER_DEFAULT.to_string()),
+            // convert update time window variable to cron expression format if users only provide
+            // update time window variables.
+            (Some(update_time_window), None) => Ok(update_time_window.cron_expression_converter()?),
+            // set cron expression scheduler to the value that users provide
+            (None, Some(cron_schedule)) => Ok(cron_schedule),
+        }?;
+
+        Self::from_string(scheduler)
+    }
+
+    pub async fn wait_until_next_maintainence_window(&self) -> Result<()> {
+        let now = Utc::now();
+        let duration_to_next = self.duration_to_next(now)?;
+        let std_duration = std_duration(&duration_to_next)?;
+        let seconds = std_duration.as_secs();
+        let next_schedule_time = now + duration_to_next;
+        event!(
+            Level::INFO,
+            next_schedule_time = ?next_schedule_time,
+            sleep = seconds,
+            "Sleeping until next scheduled time point."
+        );
+        tokio::time::sleep(std_duration).await;
+        Ok(())
+    }
+
+    /// Determine when controller needs discontinue updates.
+    /// specific trigger time => never discontinue updates.
+    /// maintenance window (time window): discontinue updates when current is outside of a scheduled window.
+    pub fn should_discontinue_updates(&self) -> bool {
+        self.should_discontinue_updates_impl(Utc::now())
+    }
+
+    fn from_string<S: AsRef<str>>(cron_expression: S) -> Result<Self> {
+        let scheduler = Schedule::from_str(cron_expression.as_ref()).context(
+            scheduler_error::GenerateScheduleFailedSnafu {
+                cron: cron_expression.as_ref(),
+            },
+        )?;
+        let schedule_type = determine_schedule_type(&scheduler)?;
+        Ok(BrupopCronScheduler {
+            scheduler,
+            schedule_type,
+        })
+    }
+
+    fn duration_to_next(&self, now: DateTime<Utc>) -> Result<chrono::Duration> {
+        let next_scheduled_time = self
+            .scheduler
+            .after(&now)
+            .next()
+            .context(scheduler_error::GetScheduledDatetimeSnafu)?;
+        Ok(next_scheduled_time - now)
+    }
+
+    fn should_discontinue_updates_impl(&self, now: DateTime<Utc>) -> bool {
+        match self.schedule_type {
+            ScheduleType::Windowed => {
+                if self.scheduler.includes(now) {
+                    return false;
+                }
+            }
+            ScheduleType::Oneshot => return false,
+        }
+        true
+    }
+}
+
+/// Cron expression can be configured to a time window or a specific trigger time.
+/// specific trigger time: 0 0 10 * * Mon */Every Monday at 10AM.
+/// maintenance window (time window): * * 10-12 * * MON */Every Monday between 10:00 and 12:00.
+
+/// brupop controller needs to use different logics to deal with specific trigger time or
+/// maintenance window (time window)
+/// => specific trigger time: trigger brupop update and complete all waitingForUpdate nodes.
+/// => maintenance window (time window): trigger brupop update within time window. If current
+/// time isn't within the time window, controller shouldn't have any action on it.
+pub enum ScheduleType {
+    Windowed,
+    Oneshot,
+}
+
+fn determine_schedule_type(schedule: &Schedule) -> Result<ScheduleType> {
+    let duration_between_each_schedule_datetime =
+        duration_between_next_two_points(&schedule, Utc::now())?;
+    Ok(
+        if duration_between_each_schedule_datetime.num_seconds() == 1 {
+            ScheduleType::Windowed
+        } else {
+            ScheduleType::Oneshot
+        },
+    )
+}
+
+fn duration_between_next_two_points(
+    schedule: &Schedule,
+    from: DateTime<Utc>,
+) -> Result<chrono::Duration> {
+    let first_time = schedule
+        .after(&from)
+        .next()
+        .context(scheduler_error::GetScheduledDatetimeSnafu)?;
+    let second_time = schedule
+        .after(&from)
+        .nth(1)
+        .context(scheduler_error::GetScheduledDatetimeSnafu)?;
+    Ok(second_time - first_time)
+}
+
+fn std_duration(d: &chrono::Duration) -> Result<std::time::Duration> {
+    Ok(d.to_std()
+        .context(scheduler_error::ConvertToStdDurationSnafu)?)
+}
+
+fn get_cron_schedule_from_env() -> Result<Option<String>> {
+    match env::var(SCHEDULER_CRON_EXPRESSION_ENV_VAR) {
+        // SCHEDULER_CRON_EXPRESSION is set
+        Ok(scheduler_cron_expression) => {
+            return Ok(Some(scheduler_cron_expression));
+        }
+        // SCHEDULER_CRON_EXPRESSION is not set
+        Err(_) => {
+            return Ok(None);
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use super::*;
+    use chrono::{NaiveDate, Utc};
+
+    #[test]
+    fn test_duration_between_next_two_points() {
+        let test_cases = vec![
+            (
+                Schedule::from_str("* * * * * * *".as_ref()).unwrap(),
+                DateTime::<Utc>::from_utc(
+                    NaiveDate::from_ymd_opt(2099, 1, 1)
+                        .unwrap()
+                        .and_hms_opt(2, 0, 0)
+                        .unwrap(),
+                    Utc,
+                ),
+                chrono::Duration::seconds(1),
+            ),
+            (
+                Schedule::from_str("10 10 10 * * * *".as_ref()).unwrap(),
+                DateTime::<Utc>::from_utc(
+                    NaiveDate::from_ymd_opt(2099, 1, 1)
+                        .unwrap()
+                        .and_hms_opt(2, 0, 0)
+                        .unwrap(),
+                    Utc,
+                ),
+                chrono::Duration::hours(24),
+            ),
+            (
+                Schedule::from_str("10 10 10 * * Mon *".as_ref()).unwrap(),
+                DateTime::<Utc>::from_utc(
+                    NaiveDate::from_ymd_opt(2099, 1, 1)
+                        .unwrap()
+                        .and_hms_opt(2, 0, 0)
+                        .unwrap(),
+                    Utc,
+                ),
+                chrono::Duration::days(7),
+            ),
+        ];
+        for (schedule, from, result) in test_cases {
+            assert_eq!(
+                duration_between_next_two_points(&schedule, from).unwrap(),
+                result
+            )
+        }
+    }
+
+    #[test]
+    fn test_duration_to_next() {
+        let test_cases = vec![
+            (
+                DateTime::<Utc>::from_utc(
+                    NaiveDate::from_ymd_opt(2099, 12, 1)
+                        .unwrap()
+                        .and_hms_opt(2, 0, 0)
+                        .unwrap(),
+                    Utc,
+                ),
+                "* * 4 1 12 * 2099",
+                chrono::Duration::hours(2),
+            ),
+            (
+                DateTime::<Utc>::from_utc(
+                    NaiveDate::from_ymd_opt(2099, 12, 1)
+                        .unwrap()
+                        .and_hms_opt(0, 0, 0)
+                        .unwrap(),
+                    Utc,
+                ),
+                "* * * 31 12 * 2099",
+                chrono::Duration::days(30),
+            ),
+            (
+                DateTime::<Utc>::from_utc(
+                    NaiveDate::from_ymd_opt(2099, 12, 1)
+                        .unwrap()
+                        .and_hms_opt(0, 0, 0)
+                        .unwrap(),
+                    Utc,
+                ),
+                "1 * * 1 12 * 2099",
+                chrono::Duration::seconds(1),
+            ),
+        ];
+
+        for (now, cron_expression, result) in test_cases {
+            let brupop_cron_scheduler = BrupopCronScheduler::from_string(cron_expression).unwrap();
+            assert_eq!(brupop_cron_scheduler.duration_to_next(now).unwrap(), result);
+        }
+    }
+
+    #[test]
+    fn test_should_discontinue_updates_impl() {
+        let test_cases = vec![
+            (
+                DateTime::<Utc>::from_utc(
+                    NaiveDate::from_ymd_opt(2099, 12, 1)
+                        .unwrap()
+                        .and_hms_opt(2, 0, 0)
+                        .unwrap(),
+                    Utc,
+                ),
+                "* * * * * * *",
+                false,
+            ),
+            (
+                DateTime::<Utc>::from_utc(
+                    NaiveDate::from_ymd_opt(2099, 12, 1)
+                        .unwrap()
+                        .and_hms_opt(0, 0, 0)
+                        .unwrap(),
+                    Utc,
+                ),
+                "10 10 10 * * * *",
+                false,
+            ),
+            (
+                DateTime::<Utc>::from_utc(
+                    NaiveDate::from_ymd_opt(2099, 12, 1)
+                        .unwrap()
+                        .and_hms_opt(0, 0, 0)
+                        .unwrap(),
+                    Utc,
+                ),
+                "* * 10 * * * *",
+                true,
+            ),
+        ];
+        for (now, cron_expression, result) in test_cases {
+            let brupop_cron_scheduler = BrupopCronScheduler::from_string(cron_expression).unwrap();
+            assert_eq!(
+                brupop_cron_scheduler.should_discontinue_updates_impl(now),
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn test_cron_expression_converter() {
+        let test_cases = vec![
+            ("0:0:0", "5:0:0", "* * 0-5 * * * *"),
+            ("21:0:0", "8:30:0", "* * 21-23,0-8 * * * *"),
+            ("15:0:0", "3:30:34", "* * 15-23,0-3 * * * *"),
+        ];
+
+        for (start_time, end_time, result) in test_cases {
+            let update_time_window = LegacyUpdateWindow::from_string(start_time, end_time);
+            assert_eq!(
+                update_time_window.cron_expression_converter().unwrap(),
+                result
+            );
+        }
+    }
+}
+
+pub mod scheduler_error {
+    use snafu::Snafu;
+    use std::num::ParseIntError;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub))]
+    pub enum Error {
+        #[snafu(display("Unable convert to Std duration due to {}", source))]
+        ConvertToStdDuration { source: chrono::OutOfRangeError },
+
+        #[snafu(display("Failed to generate corn expression '{}' due to `{}`", cron, source))]
+        GenerateScheduleFailed {
+            cron: String,
+            source: cron::error::Error,
+        },
+
+        #[snafu(display("Unable to get cron expression schedule scheduled datetime"))]
+        GetScheduledDatetime {},
+
+        #[snafu(display(
+            "Unable to get environment variable '{}' due to : '{}'",
+            variable,
+            source
+        ))]
+        MissingEnvVariable {
+            source: std::env::VarError,
+            variable: String,
+        },
+
+        #[snafu(display("Failed to find update time window due to '{}'", message))]
+        MissingTimeWindowVariable { message: String },
+
+        #[snafu(display(
+            "Update time window and scheduler are't allowed to be set simultaneously"
+        ))]
+        DisallowSetTimeWindowAndScheduler {},
+
+        #[snafu(display(
+            "Failed to generate update window settings due to invalid input, please follow HH:MM:SS format."
+        ))]
+        InvalidTimeWindowSettings {},
+
+        #[snafu(display("Failed to parse {} to u8 due to {}.", variable, source))]
+        UnableParseToU8 {
+            variable: String,
+            source: ParseIntError,
+        },
+    }
+}

--- a/models/src/controller.rs
+++ b/models/src/controller.rs
@@ -129,8 +129,7 @@ pub fn controller_deployment(
     brupop_image: String,
     image_pull_secret: Option<String>,
     max_concurrent_update: String,
-    update_window_start: String,
-    update_window_stop: String,
+    scheduler_cron_expression: String,
 ) -> Deployment {
     let image_pull_secrets =
         image_pull_secret.map(|secret| vec![LocalObjectReference { name: Some(secret) }]);
@@ -212,18 +211,13 @@ pub fn controller_deployment(
                                 ..Default::default()
                             },
                             EnvVar {
+                                name: "SCHEDULER_CRON_EXPRESSION".to_string(),
+                                value: Some(scheduler_cron_expression),
+                                ..Default::default()
+                            },
+                            EnvVar {
                                 name: "MAX_CONCURRENT_UPDATE".to_string(),
                                 value: Some(max_concurrent_update),
-                                ..Default::default()
-                            },
-                            EnvVar {
-                                name: "UPDATE_WINDOW_START".to_string(),
-                                value: Some(update_window_start),
-                                ..Default::default()
-                            },
-                            EnvVar {
-                                name: "UPDATE_WINDOW_STOP".to_string(),
-                                value: Some(update_window_stop),
                                 ..Default::default()
                             },
                         ]),

--- a/yamlgen/build.rs
+++ b/yamlgen/build.rs
@@ -63,8 +63,7 @@ fn main() {
         .unwrap()
         .parse()
         .unwrap();
-    let update_window_start: String = env::var("UPDATE_WINDOW_START").ok().unwrap();
-    let update_window_stop: String = env::var("UPDATE_WINDOW_STOP").ok().unwrap();
+    let scheduler_cron_expression: String = env::var("SCHEDULER_CRON_EXPRESSION").ok().unwrap();
 
     let max_concurrent_update: String = env::var("MAX_CONCURRENT_UPDATE")
         .ok()
@@ -182,8 +181,7 @@ fn main() {
             brupop_image,
             brupop_image_pull_secrets,
             max_concurrent_update,
-            update_window_start,
-            update_window_stop,
+            scheduler_cron_expression,
         ),
     )
     .unwrap();

--- a/yamlgen/deploy/bottlerocket-update-operator.yaml
+++ b/yamlgen/deploy/bottlerocket-update-operator.yaml
@@ -764,12 +764,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: SCHEDULER_CRON_EXPRESSION
+          value: '* * * * * * *'
         - name: MAX_CONCURRENT_UPDATE
           value: '1'
-        - name: UPDATE_WINDOW_START
-          value: 0:0:0
-        - name: UPDATE_WINDOW_STOP
-          value: 0:0:0
         image: public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.1.0
         name: brupop
         resources:


### PR DESCRIPTION
Right now, we only support time window scheduler to allow brupop update on specific a time slot around a day. Cron expression would be a better choice to enhance time window scheduler, so users are more flexible to schedule maintenance time window on their purpose.

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes: #343


**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Thu Dec 1 01:43:17 2022 +0000

    improve time window to become cron expression based scheduler

    Right now, we only support time window scheduler to allow brupop update
    on specific a time slot around a day. Cron expression would be a better
    choice to enhance time window scheduler, so users are more flexible to
    schedule maintenance time window on their purpose.
```

cron expression is a time-based job scheduler user to run a specified job periodically at fixed times or periods of time (time window).
fixed times: `0 10 * * * */At 10:00 on Monday`.
 periods of time (time window): `* 10-12 * * mon */At every minute on every Monday from 10 through 12`

brupop controller needs to use different logics to deal with fixed times or periods of time (time window)
    => fixed times: trigger brupop update and complete all waitingForUpdate nodes.
    => periods of time (time window): trigger brupop update within time window. If current time isn't within the time window,
controller shouldn't have any action on it.

**Testing done:**

- [x] integration test on fix times
- [x] integration test on time window




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
