### PR TITLE
actions-workflow: use github larger 16 core runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
 
   build-binary:
     name: build
-    runs-on: ubuntu-latest
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v3
       - run: rustup update stable
@@ -35,7 +37,9 @@ jobs:
 
   build-container:
     name: brupop-image
-    runs-on: ubuntu-latest
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v3
       - run: make brupop-image


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Trying out 16-core runner first and adjusting if it's not fast enough
```
actions-workflow: use github larger 16 core runners
```


**Testing done:**
See workflow checks


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
