### PR TITLE
kube-rs: Bumps to 0.77 and creates explicit k8s client configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
@@ -1746,12 +1746,13 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f995a3c8f2bc3dd52a18a583e90f9ec109c047fa1603a853e46bcda14d2e279d"
+checksum = "e712e62827c382a77b87f590532febb1f8b2fdbc3eefa1ee37fe7281687075ef"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror",
  "treediff",
 ]
 
@@ -1782,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.76.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf241a3a42bca4a2d1c21f2f34a659655032a7858270c7791ad4433aa8d79cb"
+checksum = "9ba77b857a9581e3d1cb1165f9cb1d1732d65ce52642498addae8fa2c6d5e037"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1795,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.76.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e442b4e6d55c4b3d0c0c70d79a8865bf17e2c33725f9404bfcb8a29ee002ffe"
+checksum = "e80db3ca107e89da5f7eae37ea5274e06cefdcf9689d0ebd5ec3575a6f983e4e"
 dependencies = [
  "base64 0.13.1",
  "bytes",
@@ -1833,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.76.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca2e1b1528287ba61602bbd17d0aa717fbb4d0fb257f4fa3a5fa884116ef778"
+checksum = "fce686d2fbdaf6cb18d19cdb0692e9485dd9945f79f944b8772bdb2a07e8d39d"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1851,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.76.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1af50996adb7e1251960d278859772fa30df99879dc154d792e36832209637cb"
+checksum = "93ef49d30d03c5de8041e2ab5dc421d671d6225ffd53975571d4a5b18d5e50fb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1864,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.76.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9b312c38884a3f41d67e2f7580824b6f45d360b98497325b5630664b3a359d"
+checksum = "acc59ede459fd8e944ab1e6ff798aca83188b08aeb44e8c3d6f028db2d74233c"
 dependencies = [
  "ahash 0.8.0",
  "backoff",
@@ -3171,18 +3172,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3506,9 +3507,9 @@ dependencies = [
 
 [[package]]
 name = "treediff"
-version = "3.0.2"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761e8d5ad7ce14bb82b7e61ccc0ca961005a275a060b9644a2431aa11553c2ff"
+checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
 dependencies = [
  "serde_json",
 ]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -18,7 +18,7 @@ tracing-opentelemetry = "0.18"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.76.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
+kube = { version = "0.77.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
 
 semver = { version = "1.0", features = [ "serde" ] }
 serde = { version = "1", features = [ "derive" ] }

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -28,7 +28,7 @@ tracing-opentelemetry = "0.18"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.76.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
+kube = { version = "0.77.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
 
 async-trait = "0.1"
 futures = "0.3"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -14,7 +14,7 @@ maplit = "1.0"
 semver = "1.0"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.76.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
+kube = { version = "0.77.0", default-features = true, features = [ "derive", "runtime", "rustls-tls" ] }
 models = { path = "../models", version = "0.1.0" }
 opentelemetry = { version = "0.18", features = ["rt-tokio-current-thread"] }
 opentelemetry-prometheus = "0.11"

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -35,7 +35,7 @@ uuid = { version = "0.8", default-features = false, features = ["serde", "v4"] }
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.76", default-features = true, features = [ "derive", "runtime" ] }
+kube = { version = "0.77", default-features = true, features = [ "derive", "runtime" ] }
 
 
 [dev-dependencies]

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -11,7 +11,7 @@ chrono = "0.4"
 futures = "0.3"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.76.0", default-features = true, features = [ "derive", "runtime" ] }
+kube = { version = "0.77.0", default-features = true, features = [ "derive", "runtime" ] }
 
 lazy_static = "1.4"
 maplit = "1.0"

--- a/yamlgen/Cargo.toml
+++ b/yamlgen/Cargo.toml
@@ -8,5 +8,5 @@ license = "Apache-2.0 OR MIT"
 [build-dependencies]
 models = { path = "../models", version = "0.1.0" }
 dotenv = "0.15"
-kube = { version = "0.76.0", default-features = true, features = [ "derive", "runtime" ] }
+kube = { version = "0.77.0", default-features = true, features = [ "derive", "runtime" ] }
 serde_yaml = "0.9"


### PR DESCRIPTION
**Issue number:**

Closes: https://github.com/bottlerocket-os/bottlerocket-update-operator/pull/371
Related to: https://github.com/kube-rs/kube/issues/1109

**Description of changes:**

```
- Fixes breaking change from kube on how cluster URLs are derived and used 
  in kubes rustls-tls feature. Now, when we build the kubernetes clients, we explicitly
  derive the `kubernetes.default.svc` url via the `incluster_dns` config option.

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

**Testing done:**

Integration tests on:
- ipv4 👍🏼 
- ipv6 👍🏼 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
