### PR TITLE
Remove webpki-root from license check deny.yaml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,8 +23,6 @@ allow = [
 ]
 
 exceptions = [
-    # Explicitly allows MPL-2 being pulled in through newer versions of awslabs/smithy-rs (which uses webpki)
-    { name = "webpki-roots", allow = ["MPL-2.0"], version = "*" },
     { name = "unicode-ident", version = "1.0.2", allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016"] },
 ]
 


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This crate is a transitive dependency, but it is not directly included in our Cargo.toml, resulting in cargo-deny complaining about an "unmatched license exception" in deny.yaml.

```txt
warning[L005]: license exception was not encountered
   ┌─ /src/deny.toml:27:14
   │
27 │     { name = "webpki-roots", allow = ["MPL-2.0"], version = "*" },
   │              ^^^^^^^^^^^^^^ unmatched license exception
```

**Testing done:**

Ran `make check-licenses` and verified the warning goes away. Performed `make build` to verify there were no other side effects.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
