### PR TITLE
Update deprecated method calls

### DIFF
--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -500,7 +500,7 @@ pub(crate) mod test {
                 Version::from_str(&target_version).unwrap(),
                 current_state,
                 0,
-                Some(Utc.ymd(2022, 1, 1).and_hms_milli(0, 0, 1, 444)),
+                Some(Utc.with_ymd_and_hms(2022, 1, 1, 0, 0, 1).unwrap()),
             )),
             metadata: ObjectMeta {
                 name: Some(name),

--- a/integ/src/nodegroup_provider.rs
+++ b/integ/src/nodegroup_provider.rs
@@ -3,6 +3,8 @@
   Meanwhile, terminating all created ec2 instances when integration test is running 'clean' subcommand.
 !*/
 
+use base64::engine::general_purpose::STANDARD as base64_engine;
+use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::process::Command;
@@ -465,7 +467,7 @@ fn userdata(
         _ => return Err(ProviderError::new_with_context("Invalid dns ip")),
     };
 
-    Ok(base64::encode(format!(
+    Ok(base64_engine.encode(format!(
         r#"[settings.updates]
         ignore-waves = true
 


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Our builds have been emitting a few warnings for use of deprecated calls. This updates these instances to use their replacement calls.

**Testing done:**

For the change in `base64::encode`, [tested with Rust Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=7720ee1d0651009436de97923d55ddfc) to verify the output matches with the new call.

There is a loss of millisecond precision with the `Utc.with_ymd_and_hms()`, but verified with `cargo test` that we weren't expecting that for the `fake_shadow` results.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
