### PR TITLE
integration-test: enforce IMDSv2 calls when launching instances

### DIFF
--- a/integ/src/nodegroup_provider.rs
+++ b/integ/src/nodegroup_provider.rs
@@ -15,7 +15,8 @@ use aws_sdk_eks::model::IpFamily;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::error::DescribeLaunchTemplatesError;
 use aws_sdk_ec2::model::{
-    ArchitectureValues, InstanceType, LaunchTemplateTagSpecificationRequest,
+    ArchitectureValues, InstanceType, LaunchTemplateHttpTokensState,
+    LaunchTemplateInstanceMetadataOptionsRequest, LaunchTemplateTagSpecificationRequest,
     RequestLaunchTemplateData, ResourceType, Tag,
 };
 
@@ -205,6 +206,11 @@ async fn create_launch_template(
                         cluster.dns_ip_info.clone(),
                     )?)
                     .tag_specifications(tag_specifications(&cluster.name))
+                    .metadata_options(
+                        LaunchTemplateInstanceMetadataOptionsRequest::builder()
+                            .http_tokens(LaunchTemplateHttpTokensState::Required)
+                            .build(),
+                    )
                     .build(),
             )
             .send()


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
closes: #395 


**Description of changes:**
```
Author: Tianhao Geng <tianhg@amazon.com>
Date:   Mon Jan 30 01:00:18 2023 +0000

    integration-test:  enforce IMDSv2 calls when launching **instances**
```


**Testing done:**
integration-test and confirm those instances had been enforced IMDSv2 calls.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
