### PR TITLE
Removes unnecessary dep on older "time" crate from chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.17",
+ "time",
  "url",
 ]
 
@@ -433,7 +433,7 @@ dependencies = [
  "http",
  "hyper",
  "ring",
- "time 0.3.17",
+ "time",
  "tokio",
  "tower",
  "tracing",
@@ -670,7 +670,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "sha2",
- "time 0.3.17",
+ "time",
  "tracing",
 ]
 
@@ -776,7 +776,7 @@ dependencies = [
  "itoa",
  "num-integer",
  "ryu",
- "time 0.3.17",
+ "time",
 ]
 
 [[package]]
@@ -931,12 +931,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1013,7 +1010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.17",
+ "time",
  "version_check",
 ]
 
@@ -1463,7 +1460,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -2073,7 +2070,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -3073,17 +3070,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
@@ -3522,12 +3508,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -25,5 +25,5 @@ serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 snafu = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-chrono = { version = "0.4.23", features = [ "serde" ] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 tokio-retry = "0.3"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 actix-web = "4"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 futures = "0.3"
 http = "0.2.8"
 maplit = "1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -37,8 +37,6 @@ skip-tree = [
     # actix-http uses older and newer versions of crates like rustc_version and
     # semver, for build vs. runtime dependencies.
     { name = "actix-http", version = "3.0.0-beta.10" },
-    # chrono uses an older version of time, which clashes with the one used by actix-web.
-    { name = "chrono", version = "0.4.19" },
     # clap uses an older version of strsim, which clashed with the one used by darling_core.
     { name = "clap", version = "2.34.0" },
     # structopt-derive uses an older version of heck, which clashed with the one used by strum_macros.

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -15,7 +15,7 @@ aws-sdk-iam = "0.24.0"
 aws-sdk-ssm = "0.24.0"
 async-trait = "0.1"
 base64 = "0.21.0"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 console_log = { version = "0.2", features = ["color"] }
 env_logger = "0.10"
 hex ="0.4.3"

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 async-trait = "0.1"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 futures = "0.3"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.17.0", default-features = false, features = ["v1_20"] }


### PR DESCRIPTION

**Issue number:**

N/a - inspired by https://github.com/awslabs/tough/pull/506 and https://github.com/bottlerocket-os/bottlerocket/pull/2748 (shout out to @jpculp for bringing this to our attention!). This should also resolve any references to [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071).

**Description of changes:**

Removes the unnecessary dependency on the older `time` version brought in by `chrono`

**Testing done:**

_Doing integration tests now ... stay tuned!_

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
