### PR TITLE
Makefile: refactors `brupop-image` target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,13 @@ USER root
 # Required to build in --offline mode
 ENV CARGO_HOME=/src/.cargo
 
+# Add brupop source
 ADD ./ /src/
+
+# Ensure cargo dependencies are fetched and available in the Docker context
+RUN cargo fetch --locked --manifest-path /src/Cargo.toml
+
+# Builds brupop binaries
 RUN cargo install --offline --locked --target ${UNAME_ARCH}-bottlerocket-linux-musl --path /src/agent --root /src/agent && \
     cargo install --offline --locked --target ${UNAME_ARCH}-bottlerocket-linux-musl --path /src/apiserver --root /src/apiserver && \
     cargo install --offline --locked --target ${UNAME_ARCH}-bottlerocket-linux-musl --path /src/controller --root /src/controller


### PR DESCRIPTION
Ensures that building the brupop image works without needing to have the rust and cargo toolchain installed. This is useful for release and CI/CD where an environment may not have these tools installed.

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/a - related to useful changes for releasing brupop

**Description of changes:**

```
Ensures that building the brupop image works without needing to have the
rust and cargo toolchain installed. This is useful for release and CI/CD
where an environment may not have these tools installed.

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

See comments below for further explanation 

**Testing done:**

Able to run:
- `make brupop-image` without cargo/rust toolchain installed
- `make`, the default target, which builds the image but also checks licenses, fetches sources locally, etc
- `make build` which fetches sources, checks licenses, but builds binaries locally (not in the docker environment or as part of an image)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
