### PR TITLE
Give cron expressions precedence over time windows when both are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,33 +145,6 @@ For example:
               value: "1"
 ```
 
-#### Set an Update Time Window - DEPRECATED
-
-Note!! that these settings are deprecated and will be removed in a future release.
-You should use the Scheduler settings below.
-If you still decide to use these settings, please use "hour:00:00" format only instead of "HH:MM:SS".
-
-`UPDATE_WINDOW_START` and `UPDATE_WINDOW_STOP` can be used to specify the time window in which updates are permitted.
-
-To enable this feature, go to `bottlerocket-update-operator.yaml`, change `UPDATE_WINDOW_START` and `UPDATE_WINDOW_STOP` to a `hour:minute:second` formatted value (UTC (24-hour time notation)). Note that `UPDATE_WINDOW_START` is inclusive and `UPDATE_WINDOW_STOP` is exclusive.
-
-Note: brupop uses UTC (24-hour time notation), please convert your local time to UTC.
-For example:
-```yaml
-      containers:
-        - command:
-            - "./controller"
-          env:
-            - name: MY_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: UPDATE_WINDOW_START
-              value: "09:00:00"
-            - name: UPDATE_WINDOW_STOP
-              value: "21:00:00"
-```
-
 #### Set scheduler
 `SCHEDULER_CRON_EXPRESSION` can be used to specify the scheduler in which updates are permitted.
 When `SCHEDULER_CRON_EXPRESSION` is "* * * * * * *" (default), the feature is disabled.
@@ -206,6 +179,34 @@ For example (schedule to run update operator at 03:00 PM on Monday ):
                   fieldPath: spec.nodeName
             - name: SCHEDULER_CRON_EXPRESSION
               value: "* * * * * * *"
+```
+
+#### Set an Update Time Window - DEPRECATED
+
+**Note**: these settings are deprecated and will be removed in a future release.
+Time window settings cannot be used in combination with the preferred cron expression format and will be ignored.
+
+If you still decide to use these settings, please use "hour:00:00" format only instead of "HH:MM:SS".
+
+`UPDATE_WINDOW_START` and `UPDATE_WINDOW_STOP` can be used to specify the time window in which updates are permitted.
+
+To enable this feature, go to `bottlerocket-update-operator.yaml`, change `UPDATE_WINDOW_START` and `UPDATE_WINDOW_STOP` to a `hour:minute:second` formatted value (UTC (24-hour time notation)). Note that `UPDATE_WINDOW_START` is inclusive and `UPDATE_WINDOW_STOP` is exclusive.
+
+Note: brupop uses UTC (24-hour time notation), please convert your local time to UTC.
+For example:
+```yaml
+      containers:
+        - command:
+            - "./controller"
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: UPDATE_WINDOW_START
+              value: "09:00:00"
+            - name: UPDATE_WINDOW_STOP
+              value: "21:00:00"
 ```
 
 ### Label nodes

--- a/controller/src/scheduler.rs
+++ b/controller/src/scheduler.rs
@@ -196,6 +196,7 @@ impl BrupopCronScheduler {
 /// => specific trigger time: trigger brupop update and complete all waitingForUpdate nodes.
 /// => maintenance window (time window): trigger brupop update within time window. If current
 /// time isn't within the time window, controller shouldn't have any action on it.
+#[derive(PartialEq, Debug)]
 pub enum ScheduleType {
     Windowed,
     Oneshot,
@@ -401,6 +402,65 @@ pub(crate) mod test {
                 result
             );
         }
+    }
+
+    #[test]
+    fn test_from_environment() {
+        // These would normally be separate unit tests for each case, but since
+        // they rely on environment variables as input they are done sequentally
+        // here.
+
+        // Legacy update window usage
+        env::remove_var(SCHEDULER_CRON_EXPRESSION_ENV_VAR);
+        env::set_var(UPDATE_WINDOW_START_ENV_VAR, "09:00:00");
+        env::set_var(UPDATE_WINDOW_STOP_ENV_VAR, "21:00:00");
+
+        let result = BrupopCronScheduler::from_environment().unwrap();
+        let expected = Schedule::from_str("* * 9-21 * * * *").unwrap();
+        assert!(result.scheduler.timeunitspec_eq(&expected));
+
+        // Legacy update window missing start time
+        env::remove_var(SCHEDULER_CRON_EXPRESSION_ENV_VAR);
+        env::remove_var(UPDATE_WINDOW_START_ENV_VAR);
+        env::set_var(UPDATE_WINDOW_STOP_ENV_VAR, "21:00:00");
+
+        let result = LegacyUpdateWindow::from_environment();
+        assert!(result.is_err());
+
+        // Legacy update window missing stop time
+        env::remove_var(SCHEDULER_CRON_EXPRESSION_ENV_VAR);
+        env::set_var(UPDATE_WINDOW_START_ENV_VAR, "09:00:00");
+        env::remove_var(UPDATE_WINDOW_STOP_ENV_VAR);
+
+        let result = LegacyUpdateWindow::from_environment();
+        assert!(result.is_err());
+
+        // Cron expression
+        env::set_var(SCHEDULER_CRON_EXPRESSION_ENV_VAR, "* * 5 * * * *");
+        env::remove_var(UPDATE_WINDOW_START_ENV_VAR);
+        env::remove_var(UPDATE_WINDOW_STOP_ENV_VAR);
+
+        let result = BrupopCronScheduler::from_environment().unwrap();
+        let expected = Schedule::from_str("* * 5 * * * *").unwrap();
+        assert!(result.scheduler.timeunitspec_eq(&expected));
+
+        // Cron expression as the default result
+        env::remove_var(SCHEDULER_CRON_EXPRESSION_ENV_VAR);
+        env::remove_var(UPDATE_WINDOW_START_ENV_VAR);
+        env::remove_var(UPDATE_WINDOW_STOP_ENV_VAR);
+
+        let result = BrupopCronScheduler::from_environment().unwrap();
+        let expected = Schedule::from_str("* * * * * * *").unwrap();
+        assert!(result.scheduler.timeunitspec_eq(&expected));
+
+        // Cron expression and legacy window both provided
+        env::set_var(SCHEDULER_CRON_EXPRESSION_ENV_VAR, "* * 5 * * * *");
+        env::set_var(UPDATE_WINDOW_START_ENV_VAR, "09:00:00");
+        env::set_var(UPDATE_WINDOW_STOP_ENV_VAR, "21:00:00");
+
+        let result = BrupopCronScheduler::from_environment().unwrap();
+        let expected = Schedule::from_str("* * 5 * * * *").unwrap();
+        assert!(result.scheduler.timeunitspec_eq(&expected));
     }
 }
 

--- a/controller/src/scheduler.rs
+++ b/controller/src/scheduler.rs
@@ -108,9 +108,13 @@ impl BrupopCronScheduler {
         let scheduler_cron_expression = get_cron_schedule_from_env()?;
 
         let scheduler = match (legacy_window, scheduler_cron_expression) {
-            // it's not allowed to set update time window and scheduler at same time
-            (Some(_), Some(_)) => {
-                return scheduler_error::DisallowSetTimeWindowAndSchedulerSnafu {}.fail();
+            // it's not allowed to set update time window and scheduler at same time, cron expression takes precendent
+            (Some(_), Some(cron_schedule)) => {
+                event!(
+                    Level::WARN,
+                    "Both time window and cron expression provided - using cron expression for schedule."
+                );
+                Ok(cron_schedule)
             }
             // set cron expression scheduler to default "* * * * * * *" if no update time window and
             // scheduler variables are provided.


### PR DESCRIPTION
**Issue number:**

Related: #428

**Description of changes:**

This adds a minor behavior change. In the existing `from_environment` call we would error out if both the new cron based expressions and the old time window settings were both provided. Rather than erroring out here, it's probably a better user experience to have a warning, but use the non-deprecated setting to run.

This also updates the documentation to focus more on cron settings and to make an explicit statement of what the expected behavior will be if both the new and old are present.

**Testing done:**

Stepped through new unit tests to make sure values are parsed correctly and the expected logic path is taken.

This testing doesn't explain [the behavior users have seen](https://github.com/bottlerocket-os/bottlerocket-update-operator/issues/428#issuecomment-1546446212) with actually needing both set, but it may make it more obvious what has happened to help gather more data on that.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
