### PR TITLE
Cargo: use env vars when calling cargo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,14 @@ BOTTLEROCKET_SDK_ARCH = $(UNAME_ARCH)
 
 BUILDER_IMAGE = public.ecr.aws/bottlerocket/bottlerocket-sdk-$(BOTTLEROCKET_SDK_ARCH):$(BOTTLEROCKET_SDK_VERSION)
 
+export CARGO_ENV_VARS = CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 export CARGO_HOME = $(TOP)/.cargo
 
 image: check-licenses brupop-image
 
 # Fetches crates from upstream
 fetch:
-	cargo fetch --locked
+	$(CARGO_ENV_VARS) cargo fetch --locked
 
 # Checks allowed/denied upstream licenses against the deny.toml
 check-licenses: fetch
@@ -52,13 +53,13 @@ check-licenses: fetch
 		--volume "$(TOP):/src" \
 		--workdir "/src/" \
 		"$(BUILDER_IMAGE)" \
-		bash -c "cargo deny --all-features check --disable-fetch licenses bans sources"
+		bash -c "$(CARGO_ENV_VARS) cargo deny --all-features check --disable-fetch licenses bans sources"
 
 # Builds, Lints, and Tests the Rust workspace locally
 build: check-licenses
-	cargo fmt -- --check
-	cargo test --locked
-	cargo build --locked
+	$(CARGO_ENV_VARS) cargo fmt -- --check
+	$(CARGO_ENV_VARS) cargo test --locked
+	$(CARGO_ENV_VARS) cargo build --locked
 
 # Builds only the brupop image. Useful target for CI/CD, releasing, etc.
 brupop-image:


### PR DESCRIPTION
**Issue number:**

#461 - stopgap

**Description of changes:**

This is a stopgap for a breaking change when consuming 1.70 of cargo/rust. This ensures that _both_ the newer version of rust and the older version in the SDK are using the "sparse" protocol for pulling dependencies from crates.io

**Testing done:**

```
❯ make check-licenses
CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo fetch --locked
docker run --rm \
        --network none \
        --user "1000:1000" \
        --security-opt label=disable \
        --env CARGO_HOME="/src/.cargo" \
        --volume "/home/ubuntu/workspace/bottlerocket-os/bottlerocket-update-operator/:/src" \
        --workdir "/src/" \
        "public.ecr.aws/bottlerocket/bottlerocket-sdk-x86_64:v0.32.0" \
        bash -c "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo deny --all-features check --disable-fetch licenses bans sources"
bans ok, licenses ok, sources ok

❯ cargo --version
cargo 1.70.0 (ec8a8a0ca 2023-04-25)
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
