### PR TITLE
Add UPDATE_WINDOW_START & UPDATE_WINDOW_STOP to controller-deploy template

### DIFF
--- a/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
@@ -48,6 +48,7 @@ spec:
               value: "{{ .Values.max_concurrent_updates }}"
             - name: SCHEDULER_CRON_EXPRESSION
               value: "{{ .Values.scheduler_cron_expression}}"
+              # UPDATE_WINDOW_STOP & UPDATE_WINDOW_START are being deprecated
             - name: UPDATE_WINDOW_STOP
               value: "{{ .Values.update_window_stop}}"
             - name: UPDATE_WINDOW_START

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
@@ -48,6 +48,10 @@ spec:
               value: "{{ .Values.max_concurrent_updates }}"
             - name: SCHEDULER_CRON_EXPRESSION
               value: "{{ .Values.scheduler_cron_expression}}"
+            - name: UPDATE_WINDOW_STOP
+              value: "{{ .Values.update_window_stop}}"
+            - name: UPDATE_WINDOW_START
+              value: "{{ .Values.update_window_start}}"                         
           image: {{ .Values.image }}
           name: brupop
       priorityClassName: brupop-controller-high-priority


### PR DESCRIPTION
Add UPDATE_WINDOW_START & UPDATE_WINDOW_STOP to controller-deployment template

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#428
#469

**Description of changes:**
Add missing environment variables to the controller deployment template


**Testing done:**
Deployed the helm chart without and with the changes. Controller works only after the changes are added.
Everything is working afterwards.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
