### PR TITLE
[integ-monitor] add namespace value to integration test

### DIFF
--- a/integ/src/main.rs
+++ b/integ/src/main.rs
@@ -34,6 +34,8 @@ const AMI_ARCH: &str = "x86_64";
 // The default name for the nodegroup
 const NODEGROUP_NAME: &str = "brupop-integ-test-nodegroup";
 
+const NAMESPACE: &str = "brupop-bottlerocket-aws";
+
 const WAIT_CERT_MANAGER_COMPLETE: tokio::time::Duration = tokio::time::Duration::from_secs(90);
 
 lazy_static! {
@@ -218,13 +220,11 @@ async fn run() -> Result<()> {
             .await
             .context(error::LoadKubeConfigSnafu)?;
 
-            // infer the default namespace from the loaded kubeconfig
-            let namespace = config.default_namespace.to_string();
             let k8s_client =
                 kube::client::Client::try_from(config).context(error::CreateK8sClientSnafu)?;
 
             info!("monitoring brupop");
-            let monitor_client = BrupopMonitor::new(IntegBrupopClient::new(k8s_client, &namespace));
+            let monitor_client = BrupopMonitor::new(IntegBrupopClient::new(k8s_client, NAMESPACE));
             monitor_client
                 .run_monitor()
                 .await

--- a/integ/src/monitor.rs
+++ b/integ/src/monitor.rs
@@ -53,6 +53,7 @@ impl BrupopClient for IntegBrupopClient {
     async fn fetch_shadows(&self) -> Result<ObjectList<BottlerocketShadow>> {
         let brss: Api<BottlerocketShadow> =
             Api::namespaced(self.k8s_client.clone(), &self.namespace);
+
         let brss_object_list = brss
             .list(&ListParams::default())
             .await


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
```
Date:   Fri Jul 7 22:40:04 2023 +0000

    add namespace value to integration test

    we tried to infer the default namespace from the loaded kubeconfig, but
    the default namespace is `default` instead of `brupop-bottlerocket-aws`
    where BottlerocketShadow object locates on. Therefore, add namespace
    value on integration test.
```


**Testing done:**

```
     Running `target/debug/integ monitor --cluster-name br-test --region us-west-2`
brs: "brs-ip-192-168-113-41.us-west-2.compute.internal"      current_version: "1.14.2"       current_state: Idle
brs: "brs-ip-192-168-113-91.us-west-2.compute.internal"      current_version: "1.14.2"       current_state: Idle
brs: "brs-ip-192-168-119-159.us-west-2.compute.internal"      current_version: "1.14.2"       current_state: Idle
[Complete]: All nodes have been successfully updated to latest version!
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
