### PR TITLE
integ test: use policy/v1 PodDisruptionBudget on testing pod template

### DIFF
--- a/integ/src/pods-template.yaml
+++ b/integ/src/pods-template.yaml
@@ -69,7 +69,7 @@ spec:
         - containerPort: 80
 # pod disruption budget
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pod-disruption-budget-test


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes: #488 


**Description of changes:**
```
integ test: use policy/v1 PodDisruptionBudget on testing pod template
```


**Testing done:**
ran intergration test on above k8s 1.25 and it worked.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
