### PR TITLE
Enable configuration of log formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,6 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -359,7 +358,6 @@ dependencies = [
  "tokio-retry",
  "tracing",
  "tracing-actix-web",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "webpki",
 ]
@@ -1029,7 +1027,6 @@ dependencies = [
  "snafu",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "validator",
 ]
@@ -3415,20 +3412,6 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
-dependencies = [
- "once_cell",
- "opentelemetry",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,6 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "models",
- "opentelemetry",
  "semver",
  "serde",
  "serde_json",
@@ -254,7 +253,6 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -358,7 +356,6 @@ dependencies = [
  "tokio-retry",
  "tracing",
  "tracing-actix-web",
- "tracing-subscriber",
  "webpki",
 ]
 
@@ -1023,11 +1020,11 @@ dependencies = [
  "prometheus",
  "regex",
  "semver",
+ "serde",
  "serde_plain",
  "snafu",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "validator",
 ]
 
@@ -2167,16 +2164,19 @@ dependencies = [
  "lazy_static",
  "maplit",
  "mockall",
+ "opentelemetry",
  "regex",
  "reqwest",
  "schemars",
  "semver",
  "serde",
  "serde_json",
+ "serde_plain",
  "snafu",
  "tokio",
  "tokio-retry",
  "tracing",
+ "tracing-subscriber",
  "validator",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3415,6 +3415,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3424,12 +3434,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ scheduler_cron_expression: "* * * * * * *"
 apiserver_internal_port: "8443"
 # API server internal address where the CRD version conversion webhook is served
 apiserver_service_port: "443"
+
+# Formatter for the logs emitted by brupop.
+# Options are:
+# * full - Human-readable, single-line logs
+# * compact - A variant of full optimized for shorter line lengths
+# * pretty - "Excessively pretty" logs optimized for human-readable terminal output.
+# * json - Newline-delimited JSON-formatted logs.
+logging_formatter: "pretty"
+# Whether or not to enable ANSI colors on log messages.
+# Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
+logging_ansi_enabled: "true"
 ```
 
 #### Configure API server ports

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -14,7 +14,6 @@ futures = "0.3"
 opentelemetry = { version = "0.18", features = ["rt-tokio-current-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
-tracing-opentelemetry = "0.18"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -11,9 +11,7 @@ apiserver = { path = "../apiserver", version = "0.1.0", default-features = false
 
 dotenv = "0.15"
 futures = "0.3"
-opentelemetry = { version = "0.18", features = ["rt-tokio-current-thread"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -26,7 +26,6 @@ opentelemetry-prometheus = "0.11"
 tracing = "0.1"
 tracing-actix-web = "0.7"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
-tracing-opentelemetry = "0.18"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -25,7 +25,6 @@ opentelemetry = { version = "0.18", features = ["rt-tokio-current-thread"]}
 opentelemetry-prometheus = "0.11"
 tracing = "0.1"
 tracing-actix-web = "0.7"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }

--- a/apiserver/src/main.rs
+++ b/apiserver/src/main.rs
@@ -1,7 +1,7 @@
 use apiserver::api::{self, APIServerSettings};
-use apiserver::telemetry::init_telemetry;
 use apiserver_error::{StartServerSnafu, StartTelemetrySnafu};
 use models::node::K8SBottlerocketShadowClient;
+use models::telemetry;
 use tracing::{event, Level};
 
 use opentelemetry::sdk::export::metrics::aggregation;
@@ -33,7 +33,7 @@ async fn main() {
 }
 
 async fn run_server() -> Result<(), apiserver_error::Error> {
-    init_telemetry().context(StartTelemetrySnafu)?;
+    telemetry::init_telemetry_from_env().context(StartTelemetrySnafu)?;
     let controller = controllers::basic(
         processors::factory(
             selectors::simple::histogram([1.0, 2.0, 5.0, 10.0, 20.0, 50.0]),
@@ -102,7 +102,7 @@ pub mod apiserver_error {
 
         #[snafu(display("Unable to start API server telemetry: '{}'", source))]
         StartTelemetry {
-            source: apiserver::telemetry::telemetry_error::Error,
+            source: models::telemetry::TelemetryConfigError,
         },
 
         #[snafu(display("Unable to start API server: '{}'", source))]

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -15,6 +15,8 @@ lazy_static = "1.2"
 maplit = "1.0"
 regex = "1.1"
 semver = "1.0"
+serde = "1"
+serde_plain = "1"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
 kube = { version = "0.82", default-features = false, features = [ "derive", "runtime", "rustls-tls" ] }
@@ -22,10 +24,8 @@ models = { path = "../models", version = "0.1.0" }
 opentelemetry = { version = "0.18", features = ["rt-tokio-current-thread"] }
 opentelemetry-prometheus = "0.11"
 prometheus = "0.13.0"
-serde_plain = "1.0.1"
 
 snafu = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 validator = { version = "0.16", features = ["derive"] }

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -27,6 +27,5 @@ serde_plain = "1.0.1"
 snafu = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.18"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 validator = { version = "0.16", features = ["derive"] }

--- a/deploy/charts/bottlerocket-update-operator/README.md
+++ b/deploy/charts/bottlerocket-update-operator/README.md
@@ -135,4 +135,15 @@ scheduler_cron_expression: "* * * * * * *"
 apiserver_internal_port: "8443"
 # API server internal address where the CRD version conversion webhook is served
 apiserver_service_port: "443"
+
+# Formatter for the logs emitted by brupop.
+# Options are:
+# * full - Human-readable, single-line logs
+# * compact - A variant of full optimized for shorter line lengths
+# * pretty - "Excessively pretty" logs optimized for human-readable terminal output.
+# * json - Newline-delimited JSON-formatted logs.
+logging_formatter: "pretty"
+# Whether or not to enable ANSI colors on log messages.
+# Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
+logging_ansi_enabled: "true"
 ```

--- a/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
@@ -49,6 +49,10 @@ spec:
               value: "{{ .Values.exclude_from_lb_wait_time_in_sec }}"
             - name: APISERVER_SERVICE_PORT
               value: "{{ .Values.apiserver_service_port }}"
+            - name: LOGGING_FORMATTER
+              value: "{{ .Values.logging_formatter }}"
+            - name: LOGGING_ANSI_ENABLED
+              value: "{{ .Values.logging_ansi_enabled }}"
           image: {{ .Values.image }}
           name: brupop
           resources:

--- a/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
@@ -43,6 +43,10 @@ spec:
           env:
             - name: APISERVER_INTERNAL_PORT
               value: "{{ .Values.apiserver_internal_port }}"
+            - name: LOGGING_FORMATTER
+              value: "{{ .Values.logging_formatter }}"
+            - name: LOGGING_ANSI_ENABLED
+              value: "{{ .Values.logging_ansi_enabled }}"
           image: {{ .Values.image }}
           livenessProbe:
             httpGet:

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
@@ -48,6 +48,10 @@ spec:
               value: "{{ .Values.max_concurrent_updates }}"
             - name: SCHEDULER_CRON_EXPRESSION
               value: "{{ .Values.scheduler_cron_expression}}"
+            - name: LOGGING_FORMATTER
+              value: "{{ .Values.logging_formatter }}"
+            - name: LOGGING_ANSI_ENABLED
+              value: "{{ .Values.logging_ansi_enabled }}"
           image: {{ .Values.image }}
           name: brupop
       priorityClassName: brupop-controller-high-priority

--- a/deploy/charts/bottlerocket-update-operator/values.yaml
+++ b/deploy/charts/bottlerocket-update-operator/values.yaml
@@ -56,3 +56,14 @@ scheduler_cron_expression: "* * * * * * *"
 # API server ports
 apiserver_internal_port: "8443"
 apiserver_service_port: "443"
+
+# Formatter for the logs emitted by brupop.
+# Options are:
+# * full - Human-readable, single-line logs
+# * compact - A variant of full optimized for shorter line lengths
+# * pretty - "Excessively pretty" logs optimized for human-readable terminal output.
+# * json - Newline-delimited JSON-formatted logs.
+logging_formatter: "pretty"
+# Whether or not to enable ANSI colors on log messages.
+# Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
+logging_ansi_enabled: "true"

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -16,14 +16,17 @@ kube = { version = "0.82", default-features = false, features = [ "client", "der
 lazy_static = "1.4"
 maplit = "1.0"
 mockall = { version = "0.11", optional = true }
+opentelemetry = { version = "0.18", features = ["rt-tokio-current-thread"] }
 regex = "1.7"
 reqwest = { version = "0.11", default-features = false, features =  [ "json" ] }
 schemars = "0.8.11"
 semver = "1.0"
 serde = { version = "1", features = [ "derive" ] }
+serde_plain = "1"
 serde_json = "1"
 snafu = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tokio-retry = "0.3"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 validator = { version = "0.16", features = ["derive"] }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -28,5 +28,5 @@ snafu = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tokio-retry = "0.3"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "json"] }
 validator = { version = "0.16", features = ["derive"] }

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod constants;
 pub mod node;
+pub mod telemetry;

--- a/models/src/telemetry.rs
+++ b/models/src/telemetry.rs
@@ -1,0 +1,37 @@
+//! Project-wide utility for initializing OpenTelemetry.
+use opentelemetry::sdk::propagation::TraceContextPropagator;
+use snafu::ResultExt;
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Registry};
+
+const DEFAULT_TRACE_LEVEL: &str = "info";
+
+pub fn init_telemetry_from_env() -> Result<()> {
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_TRACE_LEVEL));
+    let stdio_formatting_layer = fmt::layer().pretty();
+    let subscriber = Registry::default()
+        .with(env_filter)
+        .with(stdio_formatting_layer);
+    tracing::subscriber::set_global_default(subscriber)
+        .context(error::TracingConfigurationSnafu)?;
+
+    Ok(())
+}
+
+pub mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub))]
+    pub enum TelemetryConfigError {
+        #[snafu(display("Error configuring tracing: '{}'", source))]
+        TracingConfiguration {
+            source: tracing::subscriber::SetGlobalDefaultError,
+        },
+    }
+}
+
+type Result<T> = std::result::Result<T, TelemetryConfigError>;
+pub use error::TelemetryConfigError;

--- a/models/src/telemetry.rs
+++ b/models/src/telemetry.rs
@@ -1,19 +1,111 @@
 //! Project-wide utility for initializing OpenTelemetry.
 use opentelemetry::sdk::propagation::TraceContextPropagator;
+use serde::Deserialize;
 use snafu::ResultExt;
+use std::env;
+use tracing::Subscriber;
 use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Registry};
 
 const DEFAULT_TRACE_LEVEL: &str = "info";
+const LOGGING_FORMATTER_ENV_VAR: &str = "LOGGING_FORMATTER";
+const LOGGING_ANSI_ENABLED_ENV_VAR: &str = "LOGGING_ANSI_ENABLED";
+
+/// The formatter for logging tracing events.
+///
+/// Controls the format of the message as well as whether or not to enable ANSI colors.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+pub struct LogFormatter {
+    message_format: MessageFormat,
+    ansi_enabled: bool,
+}
+
+impl LogFormatter {
+    pub fn try_from_env() -> Result<Self> {
+        let message_format = MessageFormat::try_from_env()?;
+        let ansi_enabled = Self::ansi_enabled_from_env()?;
+
+        Ok(Self {
+            message_format,
+            ansi_enabled,
+        })
+    }
+
+    fn ansi_enabled_from_env() -> Result<bool> {
+        env::var(LOGGING_ANSI_ENABLED_ENV_VAR)
+            .ok()
+            .map(|ansi_enabled_str| {
+                ansi_enabled_str
+                    .to_lowercase()
+                    .parse()
+                    .context(error::LogAnsiEnvSnafu {
+                        env_value: ansi_enabled_str.to_string(),
+                    })
+            })
+            .unwrap_or(Ok(false))
+    }
+
+    /// Adds a formatting layer to a tracing event subscriber.
+    fn add_format_layer<S>(&self, event_subscriber: S) -> Box<dyn Subscriber + Send + Sync>
+    where
+        S: SubscriberExt + Send + Sync + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    {
+        // Quite repitious, but the layers are all different types and we can't Box them, the subscriber won't allow it.
+        match self.message_format {
+            MessageFormat::Full => {
+                Box::new(event_subscriber.with(fmt::layer().with_ansi(self.ansi_enabled)))
+            }
+            MessageFormat::Compact => {
+                Box::new(event_subscriber.with(fmt::layer().compact().with_ansi(self.ansi_enabled)))
+            }
+            MessageFormat::Pretty => {
+                Box::new(event_subscriber.with(fmt::layer().pretty().with_ansi(self.ansi_enabled)))
+            }
+            MessageFormat::Json => {
+                Box::new(event_subscriber.with(fmt::layer().json().with_ansi(self.ansi_enabled)))
+            }
+        }
+    }
+}
+
+/// The message format for logging tracing events.
+///
+/// See https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/index.html
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageFormat {
+    /// Human-readable, single-line logs for each event.
+    Full,
+    /// A variant of the default formatter optimized for short line lengths.
+    Compact,
+    #[default]
+    /// Pretty-formatted multi-line logs optimized for human readability.
+    Pretty,
+    /// Newline-delimited JSON logs.
+    Json,
+}
+
+impl MessageFormat {
+    pub fn try_from_env() -> Result<Self> {
+        env::var(LOGGING_FORMATTER_ENV_VAR)
+            .ok()
+            .map(|formatter| {
+                serde_plain::from_str(&formatter).context(error::LogFormatterEnvSnafu {
+                    env_value: formatter,
+                })
+            })
+            .unwrap_or(Ok(Default::default()))
+    }
+}
 
 pub fn init_telemetry_from_env() -> Result<()> {
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
 
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_TRACE_LEVEL));
-    let stdio_formatting_layer = fmt::layer().pretty();
-    let subscriber = Registry::default()
-        .with(env_filter)
-        .with(stdio_formatting_layer);
+
+    let subscriber = Registry::default().with(env_filter);
+    let subscriber = LogFormatter::try_from_env()?.add_format_layer(subscriber);
+
     tracing::subscriber::set_global_default(subscriber)
         .context(error::TracingConfigurationSnafu)?;
 
@@ -21,6 +113,9 @@ pub fn init_telemetry_from_env() -> Result<()> {
 }
 
 pub mod error {
+    use std::str::ParseBoolError;
+
+    use super::*;
     use snafu::Snafu;
 
     #[derive(Debug, Snafu)]
@@ -29,6 +124,28 @@ pub mod error {
         #[snafu(display("Error configuring tracing: '{}'", source))]
         TracingConfiguration {
             source: tracing::subscriber::SetGlobalDefaultError,
+        },
+
+        #[snafu(display(
+            "Could not parse formatter from environment variable '{}={}': '{}'",
+            LOGGING_FORMATTER_ENV_VAR,
+            env_value,
+            source
+        ))]
+        LogFormatterEnv {
+            source: serde_plain::Error,
+            env_value: String,
+        },
+
+        #[snafu(display(
+            "Could not parse ANSI enablement from environment variable '{}={}': '{}'",
+            LOGGING_ANSI_ENABLED_ENV_VAR,
+            env_value,
+            source
+        ))]
+        LogAnsiEnv {
+            source: ParseBoolError,
+            env_value: String,
         },
     }
 }


### PR DESCRIPTION
**Issue number:**
Closes #493


**Description of changes:**
This provides the ability to specify log formatting options via helm. You can control:
* The log format of the messages
* Whether or not ANSI colors are enabled


See the updated README for more details

**Testing done:**
Launched a cluster with `logging_ansi_enabled: "false"` and `logging_formatter: "full"` and noted the logs:
```
[ec2-user@ip-10-0-0-27 bottlerocket-update-operator]$ kubectl logs brupop-agent-5cfsv
2023-08-08T05:55:58.598600Z  INFO apiserver::client::webclient: Created K8s API Server client using service port service_port=443
2023-08-08T05:55:58.695562Z  INFO run:create_shadow_if_not_exist:create_metadata_shadow: agent::agentclient: Brs has been created. brs_name="ip-192-168-68-199.us-west-2.compute.internal"
```

Then again with `logging_formatter: "json"`:
```
[ec2-user@ip-10-0-0-27 bottlerocket-update-operator]$ kubectl logs brupop-agent-cmklc
{"timestamp":"2023-08-08T05:57:10.737628Z","level":"INFO","fields":{"message":"Created K8s API Server client using service port","service_port":"443"},"target":"apiserver::client::webclient"}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
