### PR TITLE
Implement backoff for k8s watcher retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,27 +1228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,6 +1531,10 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1599,6 +1588,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1932,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd990069640f9db34b3b0f7a1afc62a05ffaa3be9b66aa3c313f58346df7f788"
+checksum = "95578de7d6eac4fba42114bc751e38c59a739968769df1be56feba6f17fd148e"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -1946,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bd236a6f6ddeac3fefa2863eb4e363cb3a2c49d66619e181b5b8f8f0787575"
+checksum = "a189cb8721a47de68d883040713bbb9c956763d784fcf066828018d32c180b96"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1959,16 +1957,16 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a28620131ca89b2509e52f5e1b71bfa3e61a50321836b2ae373bc18e0309e6"
+checksum = "98989b6e1f27695afe22aa29c94136fa06be5e8d28b91222e6dfbe5a460c803f"
 dependencies = [
  "base64 0.20.0",
  "bytes",
  "chrono",
- "dirs-next",
  "either",
  "futures",
+ "home",
  "http",
  "http-body",
  "hyper",
@@ -1995,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8227a989f1eeee3bcbf045165d6aca462af3744ecd4dfdcfba81051fb7de428e"
+checksum = "c24d23bf764ec9a5652f943442ff062b91fd52318ea6d2fc11115f19d8c84d13"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2013,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d227fcf3e12f53ea1a38d4766a8c29f8b27795579e4146464effb88d52dd99"
+checksum = "0bbec4da219dcb02bb32afd762a7ac4dffd47ed92b7e35ac9a7b961d21327117"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2026,15 +2024,16 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6834a4a1f53a8528d5f346cdd141a77dbda31beb33dab4bf24fa4ecf6c508744"
+checksum = "381224caa8a6fc16f8251cf1fd6d8678cdf5366f33000a923e4c54192e4b25b5"
 dependencies = [
  "ahash 0.8.3",
  "async-trait",
  "backoff",
  "derivative",
  "futures",
+ "hashbrown 0.14.0",
  "json-patch",
  "k8s-openapi",
  "kube-client",
@@ -2657,17 +2656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -16,8 +16,8 @@ lazy_static = "1"
 tracing = "0.1"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
-kube = { version = "0.84", default-features = false, features = [ "derive", "runtime", "rustls-tls" ] }
+k8s-openapi = { version = "0.19", default-features = false, features = ["v1_24"] }
+kube = { version = "0.85", default-features = false, features = [ "derive", "runtime", "rustls-tls" ] }
 
 semver = { version = "1.0", features = [ "serde" ] }
 serde = { version = "1", features = [ "derive" ] }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -65,7 +65,8 @@ async fn run_agent() -> Result<()> {
         .fields(format!("metadata.name={}", associated_bottlerocketshadow_name).as_str());
     let brs_store = reflector::store::Writer::<BottlerocketShadow>::default();
     let brs_reader = brs_store.as_reader();
-    let brs_reflector = reflector::reflector(brs_store, watcher(brss, brs_config));
+    let brs_reflector =
+        reflector::reflector(brs_store, watcher(brss, brs_config).default_backoff());
     let brs_drainer = brs_reflector
         .touched_objects()
         .filter_map(|x| async move { std::result::Result::ok(x) })
@@ -80,7 +81,8 @@ async fn run_agent() -> Result<()> {
     let nodes: Api<Node> = Api::all(k8s_client.clone());
     let nodes_store = reflector::store::Writer::<Node>::default();
     let node_reader = nodes_store.as_reader();
-    let node_reflector = reflector::reflector(nodes_store, watcher(nodes, node_config));
+    let node_reflector =
+        reflector::reflector(nodes_store, watcher(nodes, node_config).default_backoff());
     let node_drainer = node_reflector
         .touched_objects()
         .filter_map(|x| async move { std::result::Result::ok(x) })

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -27,8 +27,8 @@ tracing = "0.1"
 tracing-actix-web = "0.7"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
-kube = { version = "0.84", default-features = false, features = [ "client", "derive", "runtime", "rustls-tls" ] }
+k8s-openapi = { version = "0.19", default-features = false, features = ["v1_24"] }
+kube = { version = "0.85", default-features = false, features = [ "client", "derive", "runtime", "rustls-tls" ] }
 
 async-trait = "0.1"
 futures = "0.3"

--- a/apiserver/src/api/mod.rs
+++ b/apiserver/src/api/mod.rs
@@ -131,7 +131,8 @@ pub async fn run_server<T: 'static + BottlerocketShadowClient>(
         watcher(
             pods,
             Config::default().labels(&format!("{}={}", LABEL_COMPONENT, AGENT)),
-        ),
+        )
+        .default_backoff(),
     );
     let drainer = pod_reflector.touched_objects()
         .filter_map(|x| async move {

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -18,8 +18,8 @@ semver = "1.0"
 serde = "1"
 serde_plain = "1"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
-kube = { version = "0.84", default-features = false, features = [ "derive", "runtime", "rustls-tls" ] }
+k8s-openapi = { version = "0.19", default-features = false, features = ["v1_24"] }
+kube = { version = "0.85", default-features = false, features = [ "derive", "runtime", "rustls-tls" ] }
 models = { path = "../models", version = "0.1.0" }
 opentelemetry = { version = "0.18", features = ["rt-tokio-current-thread"] }
 opentelemetry-prometheus = "0.11"

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -64,7 +64,10 @@ async fn main() -> Result<()> {
     let exporter = opentelemetry_prometheus::exporter(controller).init();
 
     // Setup and run a reflector, ensuring that `BottlerocketShadow` updates are reflected to the controller.
-    let brs_reflector = reflector::reflector(brs_store, watcher(brss, Config::default()));
+    let brs_reflector = reflector::reflector(
+        brs_store,
+        watcher(brss, Config::default()).default_backoff(),
+    );
     let brs_drainer = brs_reflector
         .touched_objects()
         .filter_map(|x| async move { std::result::Result::ok(x) })
@@ -80,7 +83,10 @@ async fn main() -> Result<()> {
     let nodes: Api<Node> = Api::all(k8s_client.clone());
     let nodes_store = reflector::store::Writer::<Node>::default();
     let node_reader = nodes_store.as_reader();
-    let node_reflector = reflector::reflector(nodes_store, watcher(nodes, Config::default()));
+    let node_reflector = reflector::reflector(
+        nodes_store,
+        watcher(nodes, Config::default()).default_backoff(),
+    );
     let node_drainer = node_reflector
         .touched_objects()
         .filter_map(|x| async move { std::result::Result::ok(x) })

--- a/deploy/Cargo.toml
+++ b/deploy/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 OR MIT"
 [build-dependencies]
 models = { path = "../models", version = "0.1.0" }
 dotenv = "0.15"
-kube = { version = "0.84", default-features = false, features = [ "derive", "runtime" ] }
+kube = { version = "0.85", default-features = false, features = [ "derive", "runtime" ] }
 serde_yaml = "0.9"
 
 [dev-dependencies]

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -34,8 +34,8 @@ tokio-retry = "0.3"
 uuid = { version = "0.8", default-features = false, features = ["serde", "v4"] }
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
-kube = { version = "0.84", default-features = false, features = [ "derive", "runtime" ] }
+k8s-openapi = { version = "0.19", default-features = false, features = ["v1_24"] }
+kube = { version = "0.85", default-features = false, features = [ "derive", "runtime" ] }
 
 
 [dev-dependencies]

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -10,8 +10,8 @@ async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 futures = "0.3"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
-kube = { version = "0.84", default-features = false, features = [ "client", "derive", "runtime" ] }
+k8s-openapi = { version = "0.19", default-features = false, features = ["v1_24"] }
+kube = { version = "0.85", default-features = false, features = [ "client", "derive", "runtime" ] }
 
 lazy_static = "1.4"
 maplit = "1.0"


### PR DESCRIPTION
**Issue number:**
#478


**Description of changes:**
The `kube::runtime` provides us utilities for watching for events from Kubernetes `watch` APIs and updating an internal cache of state, which is much more efficient than polling the k8s API for changes.

If the brupop CRD is not installed, these watchers end up in an extremely tight retry loop to begin watching.

This PR:
* Updates `kube` to get access to some nice default backoff functionality that was added in a recent release.
* Uses aforementioned backoff functionality
* Unrelatedly, lets the `controller` sleep for a longer fixed interval if there is nothing to do (which is true if the CRD is not installed)


**Testing done:**
Deployed the changes to a cluster without the CRD installed.

Prior to this change, the agent logs were, several times per second, spammed with messages like this:
```
2023-08-08T20:23:28.561457Z  WARN kube_client::client: Unsuccessful data error parse: 404 page not found

    at /src/.cargo/registry/src/index.crates.io-6f17d22bba15001f/kube-client-0.85.0/src/client/mod.rs:445
```

After this change, these messages are clearly backed-off exponentially, with a short initial burst followed by longer waits of 15+ seconds.

The controller also emits this log every 10 seconds:
```
2023-08-08T20:24:59.897841Z  INFO controller::controller: Nothing to do: The bottlerocket-update-operator is not aware of any BottlerocketShadow objects. Is the bottlerocket-shadow CRD installed? Are nodes labelled so that the agent is deployed to them? See the project's README for more information.
    at controller/src/controller.rs:285
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
