### PR TITLE
Remove unnecessary deployment management permissions from brupop

### DIFF
--- a/deploy/charts/bottlerocket-update-operator/README.md
+++ b/deploy/charts/bottlerocket-update-operator/README.md
@@ -36,7 +36,7 @@ To install the bottlerocket-shadow CRD locally, run:
 ```
 helm install \
   brupop-crd \
-  deploy/charts/bottlerocket-shadow \
+  deploy/charts/bottlerocket-shadow
 ```
 
 ### Cert-manager

--- a/deploy/charts/bottlerocket-update-operator/templates/api-server-cluster-role.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/api-server-cluster-role.yaml
@@ -23,18 +23,6 @@ rules:
       - update
       - watch
   - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-  - apiGroups:
       - ""
     resources:
       - pods

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-cluster-role.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-cluster-role.yaml
@@ -29,18 +29,6 @@ rules:
       - update
       - delete
   - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-  - apiGroups:
       - ""
     resources:
       - nodes


### PR DESCRIPTION
**Issue number:**
Closes #466 


**Description of changes:**
These were originally added when a different design was being considered for the operator, and have managed to remain here undetected since. We don't do any management of deployments.


**Testing done:**
Integration tests pass, the operator successfully updates a cluster.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
