### PR TITLE
controller: disable prometheus metric processor memory

### DIFF
--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -29,3 +29,6 @@ snafu = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1"
 validator = { version = "0.16", features = ["derive"] }
+
+[dev-dependencies]
+maplit = "1"

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
             selectors::simple::histogram([1.0, 2.0, 5.0, 10.0, 20.0, 50.0]),
             aggregation::cumulative_temporality_selector(),
         )
-        .with_memory(true),
+        .with_memory(false),
     )
     .build();
 

--- a/controller/src/metrics.rs
+++ b/controller/src/metrics.rs
@@ -1,7 +1,8 @@
+use models::node::BottlerocketShadow;
 use opentelemetry::{metrics::Meter, Key};
+use snafu::ResultExt;
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tracing::instrument;
 
 const HOST_VERSION_KEY: Key = Key::from_static_str("bottlerocket_version");
@@ -12,32 +13,35 @@ pub struct BrupopControllerMetrics {
     brupop_shared_hosts_data: Arc<Mutex<BrupopHostsData>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BrupopHostsData {
-    hosts_version_count_map: HashMap<String, u64>,
-    hosts_state_count_map: HashMap<String, u64>,
+    hosts_version_count: HashMap<String, u64>,
+    hosts_state_count: HashMap<String, u64>,
 }
 
 impl BrupopHostsData {
-    pub fn new(
-        hosts_version_count_map: HashMap<String, u64>,
-        hosts_state_count_map: HashMap<String, u64>,
-    ) -> Self {
-        BrupopHostsData {
-            hosts_version_count_map,
-            hosts_state_count_map,
-        }
-    }
-}
+    /// Computes point-in-time metrics for the cluster's hosts based on a set of BottlerocketShadows.
+    pub fn from_shadows(brss: &[BottlerocketShadow]) -> Result<Self, error::MetricsError> {
+        let mut hosts_version_count = HashMap::new();
+        let mut hosts_state_count = HashMap::new();
 
-impl Default for BrupopHostsData {
-    fn default() -> Self {
-        let hosts_version_count_map = HashMap::new();
-        let hosts_state_count_map = HashMap::new();
-        BrupopHostsData {
-            hosts_version_count_map,
-            hosts_state_count_map,
-        }
+        brss.iter()
+            .filter_map(|brs| brs.status.as_ref())
+            .try_for_each(|brs_status| {
+                let host_version = brs_status.current_version().to_string();
+                let host_state = brs_status.current_state;
+
+                *hosts_version_count.entry(host_version).or_default() += 1;
+                *hosts_state_count
+                    .entry(serde_plain::to_string(&host_state).context(error::SerializeStateSnafu)?)
+                    .or_default() += 1;
+
+                Ok(())
+            })?;
+        Ok(Self {
+            hosts_version_count,
+            hosts_state_count,
+        })
     }
 }
 
@@ -62,16 +66,16 @@ impl BrupopControllerMetrics {
 
         let _ = meter.register_callback(move |cx| {
             let data = hosts_data_clone_for_version.lock().unwrap();
-            for (host_version, count) in &data.hosts_version_count_map {
-                let labels = vec![HOST_VERSION_KEY.string(host_version.clone())];
+            for (host_version, count) in &data.hosts_version_count {
+                let labels = vec![HOST_VERSION_KEY.string(host_version.to_string())];
                 brupop_hosts_version_observer.observe(cx, *count, &labels);
             }
         });
 
         let _ = meter.register_callback(move |cx| {
             let data = hosts_data_clone_for_state.lock().unwrap();
-            for (host_state, count) in &data.hosts_state_count_map {
-                let labels = vec![HOST_STATE_KEY.string(host_state.clone())];
+            for (host_state, count) in &data.hosts_state_count {
+                let labels = vec![HOST_STATE_KEY.string(host_state.to_string())];
                 brupop_hosts_state_observer.observe(cx, *count, &labels);
             }
         });
@@ -86,5 +90,16 @@ impl BrupopControllerMetrics {
         if let Ok(mut host_data) = self.brupop_shared_hosts_data.try_lock() {
             *host_data = data;
         }
+    }
+}
+
+pub mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub))]
+    pub enum MetricsError {
+        #[snafu(display("Failed to serialize Shadow state: '{}'", source))]
+        SerializeState { source: serde_plain::Error },
     }
 }


### PR DESCRIPTION
**Issue number:**
Closes #441


**Description of changes:**
Per #441 and testing, the gauges reported by the controller's `/metrics` endpoint would often report stale data, double-counting hosts as it showed the historic state alongside the current state.

This is because [`with_memory()`](https://docs.rs/opentelemetry_sdk/0.18.0/src/opentelemetry_sdk/metrics/processors/basic.rs.html#41) was enabled, which explicitly maintains previous metrics when only new subsets are reported.

This change disables metric processor memory to make it truly stateless, which is how we were computing the metrics anyways.

In this case, prometheus will still report old state until the metrics are stale. In order to attempt to clear old state faster, we also explicitly report `0` counts for prior metrics when we can. Because the controller is supposed to be stateless and can be rescheduled, this is done as a best-effort.

**Testing done:**
Watched the controller `/metrics` endpoint with and without this change.

After the change was made, the metrics endpoint always surfaced the current state of the cluster, e.g.:

```
# HELP brupop_hosts_state Brupop host's state
# TYPE brupop_hosts_state gauge
brupop_hosts_state{service_name="unknown_service",state="Idle"} 2
brupop_hosts_state{service_name="unknown_service",state="RebootedIntoUpdate"} 1
brupop_hosts_state{service_name="unknown_service",state="StagedAndPerformedUpdate"} 0
# HELP brupop_hosts_version Brupop host's bottlerocket version
# TYPE brupop_hosts_version gauge
brupop_hosts_version{bottlerocket_version="1.14.0",service_name="unknown_service"} 2
brupop_hosts_version{bottlerocket_version="1.14.2",service_name="unknown_service"} 1
```

(Note that `StagedAndPerformedUpdate` has a count of `0`, because the host that is now in `RebootedIntoUpdate` had it's prior count intentionally wiped)



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
