### PR TITLE
Allow configuration of log level via helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ logging_formatter: "pretty"
 # Whether or not to enable ANSI colors on log messages.
 # Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
 logging_ansi_enabled: "true"
+# Controls the filter for tracing/log messages.
+# This can be as simple as a log-level (e.g. "info", "debug", "error"), but also supports more complex directives.
+# See https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html#directives
+controller_tracing_filter: "info"
+agent_tracing_filter: "info"
+apiserver_tracing_filter: "info"
 ```
 
 #### Configure API server ports

--- a/deploy/charts/bottlerocket-update-operator/README.md
+++ b/deploy/charts/bottlerocket-update-operator/README.md
@@ -146,4 +146,10 @@ logging_formatter: "pretty"
 # Whether or not to enable ANSI colors on log messages.
 # Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
 logging_ansi_enabled: "true"
+# Controls the filter for tracing/log messages.
+# This can be as simple as a log-level (e.g. "info", "debug", "error"), but also supports more complex directives.
+# See https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html#directives
+controller_tracing_filter: "info"
+agent_tracing_filter: "info"
+apiserver_tracing_filter: "info"
 ```

--- a/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
@@ -53,6 +53,8 @@ spec:
               value: "{{ .Values.logging_formatter }}"
             - name: LOGGING_ANSI_ENABLED
               value: "{{ .Values.logging_ansi_enabled }}"
+            - name: TRACING_FILTER_DIRECTIVE
+              value: "{{ .Values.agent_tracing_filter }}"
           image: {{ .Values.image }}
           name: brupop
           resources:

--- a/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
@@ -47,6 +47,8 @@ spec:
               value: "{{ .Values.logging_formatter }}"
             - name: LOGGING_ANSI_ENABLED
               value: "{{ .Values.logging_ansi_enabled }}"
+            - name: TRACING_FILTER_DIRECTIVE
+              value: "{{ .Values.apiserver_tracing_filter }}"
           image: {{ .Values.image }}
           livenessProbe:
             httpGet:

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
@@ -52,6 +52,8 @@ spec:
               value: "{{ .Values.logging_formatter }}"
             - name: LOGGING_ANSI_ENABLED
               value: "{{ .Values.logging_ansi_enabled }}"
+            - name: TRACING_FILTER_DIRECTIVE
+              value: "{{ .Values.controller_tracing_filter }}"
           image: {{ .Values.image }}
           name: brupop
       priorityClassName: brupop-controller-high-priority

--- a/deploy/charts/bottlerocket-update-operator/values.yaml
+++ b/deploy/charts/bottlerocket-update-operator/values.yaml
@@ -67,3 +67,9 @@ logging_formatter: "pretty"
 # Whether or not to enable ANSI colors on log messages.
 # Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
 logging_ansi_enabled: "true"
+# Controls the filter for tracing/log messages.
+# This can be as simple as a log-level (e.g. "info", "debug", "error"), but also supports more complex directives.
+# See https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html#directives
+controller_tracing_filter: "info"
+agent_tracing_filter: "info"
+apiserver_tracing_filter: "info"


### PR DESCRIPTION
**Issue number:**
Closes #509


**Description of changes:**
This change allows users to apply tracing filter directives to any of the brupop components.

Filter directives at their most simple act like log-levels; however, you can also apply [more complex filters](https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html#directives)


**Testing done:**
Ran a brupop cluster with various tracing directives, e.g.
```
controller_tracing_filter: "hyper=info,debug"
agent_tracing_filter: "warn"
apiserver_tracing_filter: "h2=info,debug"
```

```
controller_tracing_filter: "debug"
agent_tracing_filter: "debug"
apiserver_tracing_filter: "debug"
```

And noted that the log filtering appeared to be correct.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
