### PR TITLE
Allow placement control via helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,35 @@ namespace: "brupop-bottlerocket-aws"
 # The image to use for brupop
 image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.2.0"
 
+# Placement controls
+# The agent is a daemonset, so the only controls that apply to it are tolerations.
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+agent_tolerations: []
+controller_tolerations: []
+apiserver_tolerations: []
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+controller_nodeSelector: {}
+apiserver_nodeSelector: {}
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+controller_podAffinity: {}
+apiserver_podAffinity:  {}
+controller_podAntiAffinity: {}
+# By default, apiserver pods prefer not to be scheduled to the same node.
+apiserver_podAntiAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 1
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: brupop.bottlerocket.aws/component
+            operator: In
+            values:
+            - apiserver
+        topologyKey: kubernetes.io/hostname
+
 # If testing against a private image registry, you can set the pull secret to fetch images.
 # This can likely remain as `brupop` so long as you run something like the following:
 # kubectl create secret docker-registry brupop \

--- a/deploy/charts/bottlerocket-update-operator/README.md
+++ b/deploy/charts/bottlerocket-update-operator/README.md
@@ -80,6 +80,35 @@ namespace: "brupop-bottlerocket-aws"
 # The image to use for brupop
 image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.2.0"
 
+# Placement controls
+# The agent is a daemonset, so the only controls that apply to it are tolerations.
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+agent_tolerations: []
+controller_tolerations: []
+apiserver_tolerations: []
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+controller_nodeSelector: {}
+apiserver_nodeSelector: {}
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+controller_podAffinity: {}
+apiserver_podAffinity:  {}
+controller_podAntiAffinity: {}
+# By default, apiserver pods prefer not to be scheduled to the same node.
+apiserver_podAntiAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 1
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: brupop.bottlerocket.aws/component
+            operator: In
+            values:
+            - apiserver
+        topologyKey: kubernetes.io/hostname
+
 # If testing against a private image registry, you can set the pull secret to fetch images.
 # This can likely remain as `brupop` so long as you run something like the following:
 # kubectl create secret docker-registry brupop \

--- a/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
@@ -37,6 +37,10 @@ spec:
                     values:
                       - amd64
                       - arm64
+      {{- with .Values.agent_tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - command:
             - "./agent"

--- a/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
@@ -24,6 +24,14 @@ spec:
       namespace: {{ .Values.namespace }}
     spec:
       affinity:
+        {{- with .Values.apiserver_podAffinity }}
+        podAffinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.apiserver_podAntiAffinity }}
+        podAntiAffinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -37,6 +45,14 @@ spec:
                     values:
                       - amd64
                       - arm64
+      {{- with .Values.apiserver_tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.apiserver_nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - command:
             - "./apiserver"

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
@@ -23,6 +23,14 @@ spec:
       namespace: {{ .Values.namespace }}
     spec:
       affinity:
+        {{- with .Values.controller_podAffinity }}
+        podAffinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.controller_podAntiAffinity }}
+        podAntiAffinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -36,6 +44,14 @@ spec:
                     values:
                       - amd64
                       - arm64
+      {{- with .Values.controller_tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller_nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - command:
             - "./controller"

--- a/deploy/charts/bottlerocket-update-operator/values.yaml
+++ b/deploy/charts/bottlerocket-update-operator/values.yaml
@@ -6,6 +6,36 @@ namespace: "brupop-bottlerocket-aws"
 # The image to use for brupop
 image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.2.0"
 
+
+# Placement controls
+# The agent is a daemonset, so the only controls that apply to it are tolerations.
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+agent_tolerations: []
+controller_tolerations: []
+apiserver_tolerations: []
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+controller_nodeSelector: {}
+apiserver_nodeSelector: {}
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+controller_podAffinity: {}
+apiserver_podAffinity:  {}
+controller_podAntiAffinity: {}
+# By default, apiserver pods prefer not to be scheduled to the same node.
+apiserver_podAntiAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 1
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: brupop.bottlerocket.aws/component
+            operator: In
+            values:
+            - apiserver
+        topologyKey: kubernetes.io/hostname
+
 # If testing against a private image registry, you can set the pull secret to fetch images.
 # This can likely remain as `brupop` so long as you run something like the following:
 # kubectl create secret docker-registry brupop \


### PR DESCRIPTION
**Issue number:**
Closes #500 

**Description of changes:**
This allows users to control tolerations, nodeSelector, and podAffinity/AntiAffinity via the helm values.yaml file.

apiserver pods have also been changed to have a podAntiAffinity for eachother by default.


**Testing done:**
* Scheduled the agent onto a node with a taint by adding a toleration
* Noted apiserver nodes weren't colocated unless forced by a taint
* Constrained the controller with `nodeSelector` to a tainted node, causing it to become unschedulable. Fixed it by labeling an untainted node and also with a toleration.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
