### PR TITLE
Automate helm chart releases

### DIFF
--- a/.github/workflows/deploy-helm-charts.yaml
+++ b/.github/workflows/deploy-helm-charts.yaml
@@ -7,11 +7,13 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+permissions:
+  id-token: write
+  pull-requests: write
+  contents: write
 
 jobs:
   release:
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout brupop
@@ -19,19 +21,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.10.0
-
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
-        with:
-          charts_dir: deploy/charts
+      - run: make install-charts-toolchain
+      - run: make verify-charts
+      - run: make package-charts publish-charts
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_REPO_OWNER: ${{ github.repository_owner }}
+          GITHUB_REPO_NAME: ${{ github.event.repository.name }}

--- a/scripts/LICENSE
+++ b/scripts/LICENSE
@@ -1,0 +1,174 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,2 @@
+# Helm Chart Management Scripts
+These scripts are modified versions of scripts used to managed the chart release lifecycle in https://github.com/aws/eks-charts

--- a/scripts/install-toolchain.sh
+++ b/scripts/install-toolchain.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
+
+mkdir -p "${CHART_TMP_DIR}"
+
+## Install kubeconform
+mkdir -p "${CHART_TMP_DIR}/kubeconform"
+curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-${PLATFORM}-${ARCH}.tar.gz" | tar xz -C "${CHART_TMP_DIR}/kubeconform"
+mv "${CHART_TMP_DIR}/kubeconform/kubeconform" "${CHART_TOOLS_DIR}/kubeconform"
+
+## Install helm v3
+mkdir -p "${CHART_TMP_DIR}/helmv3"
+curl -sSL "https://get.helm.sh/helm-${HELMV3_VERSION}-${PLATFORM}-${ARCH}.tar.gz" | tar xz -C "${CHART_TMP_DIR}/helmv3"
+mv "${CHART_TMP_DIR}/helmv3/${PLATFORM}-${ARCH}/helm" "${CHART_TOOLS_DIR}/helmv3"
+
+rm -rf "${CHART_TMP_DIR}"

--- a/scripts/lint-charts.sh
+++ b/scripts/lint-charts.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FAILED_V3=()
+
+cd "${CHARTS_DIR}"
+for d in */; do
+    echo "Linting chart ${d} w/ helm v3"
+    helmv3 lint "${CHARTS_DIR}/${d}" || FAILED_V3+=("${d}")
+done
+
+if [[ "${#FAILED_V3[@]}" -eq 0 ]]; then
+    echo "All charts passed linting!"
+    exit 0
+else
+    echo "Helm v3:"
+    for chart in "${FAILED_V3[@]}"; do
+        printf "%40s ❌\n" "$chart"
+    done
+    exit 1
+fi

--- a/scripts/package-charts.sh
+++ b/scripts/package-charts.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+helmv3 package "${CHARTS_DIR}/"* \
+    --destination "${CHART_BUILD_DIR}/charts" \
+    --dependency-update

--- a/scripts/publish-charts.sh
+++ b/scripts/publish-charts.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="$(git describe --tags --always)"
+
+if [[ "${VERSION}" =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
+    git fetch --all
+    git config user.name "${GITHUB_ACTOR}"
+    git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+    git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPO}"
+    git config pull.rebase false
+    git checkout gh-pages
+    git checkout -b "gh-pages-release-${VERSION}"
+    mv -n "${CHART_BUILD_DIR}"/charts/*.tgz .
+    helmv3 repo index . --url "https://${GITHUB_REPO_OWNER}.github.io/${GITHUB_REPO_NAME}"
+    git add ./*.tgz index.yaml
+    git commit -m "Publish helm charts for ${VERSION}"
+
+    git push origin "gh-pages-release-${VERSION}"
+    gh pr create -B gh-pages -H "gh-pages-release-${VERSION}" \
+        --title "Publish helm charts for ${VERSION}" \
+        --body "This publishes charts for the Bottlerocket Update Operator version ${VERSION} to the helm repository."
+else
+    echo "Not a valid semver release tag! Skip charts publish"
+    exit 1
+fi

--- a/scripts/validate-chart-versions.sh
+++ b/scripts/validate-chart-versions.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXIT_CODE=0
+
+# Determine the commit hash and tag of the previous release:
+#
+#     * If the repository head is at a release tag (e.g. v1.2.3-rc4), select
+#       the release before that (e.g. v1.2.3-rc3)
+#     * If the repository head has advanced from a release tag (e.g. v1.0-g0123abcd),
+#       select the release the current head is based on (e.g. v1.0)
+if $(git describe HEAD --tags | grep -Eq "^v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"); then
+    LAST_RELEASE_HASH=$(git rev-list --tags --max-count=1 --skip=1 --no-walk)
+else
+    TAG=$(git describe HEAD --tags | grep -Eo "^v[0-9]+(\.[0-9]+)*")
+    LAST_RELEASE_HASH=$(git rev-list -1 "${TAG}")
+fi
+LAST_RELEASE_TAG=$(git describe "${LAST_RELEASE_HASH}" --tags)
+
+cd "${CHARTS_DIR}"
+echo "📝 Checking for updated Chart versions since the last brupop release ${LAST_RELEASE_TAG}"
+for d in */; do
+    LAST_COMMIT_HASH=$(git --no-pager log --pretty=tformat:"%H" -- "${d}" | awk 'FNR <= 1')
+    if [[ -z "${LAST_COMMIT_HASH}" ]]; then
+        echo "✅ Chart ${d} has not been commited and appears to be in development"
+        continue
+    fi
+
+    ## If LAST_RELEASE_HASH does not include the chart, then it's a new chart and does not need a version increment
+    if [[ -z $(git ls-tree -d "${LAST_RELEASE_HASH}" "${d}") ]]; then
+        echo "✅ Chart ${d} is a new chart since the last release"
+        continue
+    fi
+
+    ## If LAST_RELEASE_HASH is NOT an ancestor of LAST_COMMIT_HASH then it has not been modified
+    if [[ -z $(git rev-list "${LAST_COMMIT_HASH}" | grep "${LAST_RELEASE_HASH}") || "${LAST_COMMIT_HASH}" == "${LAST_RELEASE_HASH}" ]]; then
+        echo "✅ Chart ${d} had no changes since the last eks-charts release"
+        continue
+    fi
+
+    LAST_RELEASE_CHART_VERSION=$(git --no-pager show "${LAST_RELEASE_HASH}":deploy/charts/"${d}"Chart.yaml | awk '$1 == "version:" { print $2 }' | tr -d '[:space:]')
+    LAST_COMMIT_CHART_VERSION=$(git --no-pager show "${LAST_COMMIT_HASH}":deploy/charts/"${d}"Chart.yaml | awk '$1 == "version:" { print $2 }' | tr -d '[:space:]')
+    if [[ "${LAST_RELEASE_CHART_VERSION}" == "${LAST_COMMIT_CHART_VERSION}" ]]; then
+        echo "❌ Chart ${d} has the same Chart version as the last release ${LAST_COMMIT_CHART_VERSION}"
+        EXIT_CODE=1
+    else
+        echo "✅ Chart ${d} has a different version since the last eks-charts release (${LAST_RELEASE_CHART_VERSION} -> ${LAST_COMMIT_CHART_VERSION})"
+    fi
+done
+exit $EXIT_CODE

--- a/scripts/validate-charts.sh
+++ b/scripts/validate-charts.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FAILED_V3=()
+
+cd "${CHARTS_DIR}"
+for d in */; do
+    EXTRA_ARGS=""
+    if [ -f "${CHARTS_DIR}/${d}/ci/extra_args" ]; then
+        EXTRA_ARGS=$(cat "${CHARTS_DIR}/${d}/ci/extra_args")
+    fi
+    echo "Validating chart ${d} w/ helm v3"
+    helmv3 template "${CHARTS_DIR}/${d}" $EXTRA_ARGS | kubeconform -strict -ignore-missing-schemas || FAILED_V3+=("${d}")
+done
+
+if [[ "${#FAILED_V3[@]}" -eq 0 ]]; then
+    echo "All charts passed validations!"
+    exit 0
+else
+    echo "Helm v3:"
+    for chart in "${FAILED_V3[@]}"; do
+        printf "%40s ❌\n" "$chart"
+    done
+    exit 1
+fi


### PR DESCRIPTION
**Issue number:**
Closes #492

**Description of changes:**
Our current github workflow for publishing charts would create a GitHub release for each new chart, but what we want is for the Releases page to focus on the operator, and for new charts to be available in the helm repository to reflect those.

The [eks-charts](https://github.com/aws/eks-charts) repo does something like this, so this commit uses a modified version of their workflow to automatically publish charts.

**Testing done:**
* I performed [several releases](https://github.com/cbgbt/bottlerocket-update-operator/releases) in my fork of brupop
* Noted that new charts were added to a PR against `gh-pages`: https://github.com/cbgbt/bottlerocket-update-operator/pull/4
* I added my github.io page as a helm repository and used it to install brupop, and then updated a cluster with that installation
* Sample [Actions workflow](https://github.com/cbgbt/bottlerocket-update-operator/actions/runs/5835899909)

**Limitations**
We have to manage our external dependencies on Helm and Kubeconform in the Makefile. Ideally we move these dependencies to the Bottlerocket SDK.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
