### PR TITLE
Clean up namespacing of new configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,22 +180,28 @@ apiserver_internal_port: "8443"
 # API server internal address where the CRD version conversion webhook is served
 apiserver_service_port: "443"
 
-# Formatter for the logs emitted by brupop.
-# Options are:
-# * full - Human-readable, single-line logs
-# * compact - A variant of full optimized for shorter line lengths
-# * pretty - "Excessively pretty" logs optimized for human-readable terminal output.
-# * json - Newline-delimited JSON-formatted logs.
-logging_formatter: "pretty"
-# Whether or not to enable ANSI colors on log messages.
-# Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
-logging_ansi_enabled: "true"
-# Controls the filter for tracing/log messages.
-# This can be as simple as a log-level (e.g. "info", "debug", "error"), but also supports more complex directives.
-# See https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html#directives
-controller_tracing_filter: "info"
-agent_tracing_filter: "info"
-apiserver_tracing_filter: "info"
+logging:
+  # Formatter for the logs emitted by brupop.
+  # Options are:
+  # * full - Human-readable, single-line logs
+  # * compact - A variant of full optimized for shorter line lengths
+  # * pretty - "Excessively pretty" logs optimized for human-readable terminal output.
+  # * json - Newline-delimited JSON-formatted logs.
+  formatter: "pretty"
+  # Whether or not to enable ANSI colors on log messages.
+  # Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
+  ansi_enabled: "true"
+
+  # Controls the filter for tracing/log messages.
+  # This can be as simple as a log-level (e.g. "info", "debug", "error"), but also supports more complex directives.
+  # See https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html#directives
+  controller:
+    tracing_filter: "info"
+  agent:
+    tracing_filter: "info"
+  apiserver:
+    tracing_filter: "info"
+
 ```
 
 #### Configure API server ports

--- a/README.md
+++ b/README.md
@@ -92,33 +92,37 @@ namespace: "brupop-bottlerocket-aws"
 image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.2.0"
 
 # Placement controls
-# The agent is a daemonset, so the only controls that apply to it are tolerations.
+# See the Kubernetes documentation about placement controls for more details:
+# * https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+# * https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+# * https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+placement:
+  agent:
+    # The agent is a daemonset, so the only controls that apply to it are tolerations.
+    tolerations: []
 
-# https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-agent_tolerations: []
-controller_tolerations: []
-apiserver_tolerations: []
+  controller:
+    tolerations: []
+    nodeSelector: {}
+    podAffinity: {}
+    podAntiAffinity: {}
 
-# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
-controller_nodeSelector: {}
-apiserver_nodeSelector: {}
-
-# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
-controller_podAffinity: {}
-apiserver_podAffinity:  {}
-controller_podAntiAffinity: {}
-# By default, apiserver pods prefer not to be scheduled to the same node.
-apiserver_podAntiAffinity:
-  preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 1
-      podAffinityTerm:
-        labelSelector:
-          matchExpressions:
-          - key: brupop.bottlerocket.aws/component
-            operator: In
-            values:
-            - apiserver
-        topologyKey: kubernetes.io/hostname
+  apiserver:
+    tolerations: []
+    nodeSelector: {}
+    podAffinity: {}
+    # By default, apiserver pods prefer not to be scheduled to the same node.
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: brupop.bottlerocket.aws/component
+                operator: In
+                values:
+                - apiserver
+            topologyKey: kubernetes.io/hostname
 
 # If testing against a private image registry, you can set the pull secret to fetch images.
 # This can likely remain as `brupop` so long as you run something like the following:

--- a/deploy/charts/bottlerocket-update-operator/README.md
+++ b/deploy/charts/bottlerocket-update-operator/README.md
@@ -81,33 +81,37 @@ namespace: "brupop-bottlerocket-aws"
 image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.2.0"
 
 # Placement controls
-# The agent is a daemonset, so the only controls that apply to it are tolerations.
+# See the Kubernetes documentation about placement controls for more details:
+# * https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+# * https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+# * https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+placement:
+  agent:
+    # The agent is a daemonset, so the only controls that apply to it are tolerations.
+    tolerations: []
 
-# https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-agent_tolerations: []
-controller_tolerations: []
-apiserver_tolerations: []
+  controller:
+    tolerations: []
+    nodeSelector: {}
+    podAffinity: {}
+    podAntiAffinity: {}
 
-# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
-controller_nodeSelector: {}
-apiserver_nodeSelector: {}
-
-# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
-controller_podAffinity: {}
-apiserver_podAffinity:  {}
-controller_podAntiAffinity: {}
-# By default, apiserver pods prefer not to be scheduled to the same node.
-apiserver_podAntiAffinity:
-  preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 1
-      podAffinityTerm:
-        labelSelector:
-          matchExpressions:
-          - key: brupop.bottlerocket.aws/component
-            operator: In
-            values:
-            - apiserver
-        topologyKey: kubernetes.io/hostname
+  apiserver:
+    tolerations: []
+    nodeSelector: {}
+    podAffinity: {}
+    # By default, apiserver pods prefer not to be scheduled to the same node.
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: brupop.bottlerocket.aws/component
+                operator: In
+                values:
+                - apiserver
+            topologyKey: kubernetes.io/hostname
 
 # If testing against a private image registry, you can set the pull secret to fetch images.
 # This can likely remain as `brupop` so long as you run something like the following:

--- a/deploy/charts/bottlerocket-update-operator/README.md
+++ b/deploy/charts/bottlerocket-update-operator/README.md
@@ -169,20 +169,25 @@ apiserver_internal_port: "8443"
 # API server internal address where the CRD version conversion webhook is served
 apiserver_service_port: "443"
 
-# Formatter for the logs emitted by brupop.
-# Options are:
-# * full - Human-readable, single-line logs
-# * compact - A variant of full optimized for shorter line lengths
-# * pretty - "Excessively pretty" logs optimized for human-readable terminal output.
-# * json - Newline-delimited JSON-formatted logs.
-logging_formatter: "pretty"
-# Whether or not to enable ANSI colors on log messages.
-# Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
-logging_ansi_enabled: "true"
-# Controls the filter for tracing/log messages.
-# This can be as simple as a log-level (e.g. "info", "debug", "error"), but also supports more complex directives.
-# See https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html#directives
-controller_tracing_filter: "info"
-agent_tracing_filter: "info"
-apiserver_tracing_filter: "info"
+logging:
+  # Formatter for the logs emitted by brupop.
+  # Options are:
+  # * full - Human-readable, single-line logs
+  # * compact - A variant of full optimized for shorter line lengths
+  # * pretty - "Excessively pretty" logs optimized for human-readable terminal output.
+  # * json - Newline-delimited JSON-formatted logs.
+  formatter: "pretty"
+  # Whether or not to enable ANSI colors on log messages.
+  # Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
+  ansi_enabled: "true"
+
+  # Controls the filter for tracing/log messages.
+  # This can be as simple as a log-level (e.g. "info", "debug", "error"), but also supports more complex directives.
+  # See https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html#directives
+  controller:
+    tracing_filter: "info"
+  agent:
+    tracing_filter: "info"
+  apiserver:
+    tracing_filter: "info"
 ```

--- a/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
@@ -37,7 +37,7 @@ spec:
                     values:
                       - amd64
                       - arm64
-      {{- with .Values.agent_tolerations }}
+      {{- with .Values.placement.agent.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
@@ -54,11 +54,11 @@ spec:
             - name: APISERVER_SERVICE_PORT
               value: "{{ .Values.apiserver_service_port }}"
             - name: LOGGING_FORMATTER
-              value: "{{ .Values.logging_formatter }}"
+              value: "{{ .Values.logging.formatter }}"
             - name: LOGGING_ANSI_ENABLED
-              value: "{{ .Values.logging_ansi_enabled }}"
+              value: "{{ .Values.logging.ansi_enabled }}"
             - name: TRACING_FILTER_DIRECTIVE
-              value: "{{ .Values.agent_tracing_filter }}"
+              value: "{{ .Values.logging.agent.tracing_filter }}"
           image: {{ .Values.image }}
           name: brupop
           resources:

--- a/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
@@ -60,11 +60,11 @@ spec:
             - name: APISERVER_INTERNAL_PORT
               value: "{{ .Values.apiserver_internal_port }}"
             - name: LOGGING_FORMATTER
-              value: "{{ .Values.logging_formatter }}"
+              value: "{{ .Values.logging.formatter }}"
             - name: LOGGING_ANSI_ENABLED
-              value: "{{ .Values.logging_ansi_enabled }}"
+              value: "{{ .Values.logging.ansi_enabled }}"
             - name: TRACING_FILTER_DIRECTIVE
-              value: "{{ .Values.apiserver_tracing_filter }}"
+              value: "{{ .Values.logging.apiserver.tracing_filter }}"
           image: {{ .Values.image }}
           livenessProbe:
             httpGet:

--- a/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
@@ -24,11 +24,11 @@ spec:
       namespace: {{ .Values.namespace }}
     spec:
       affinity:
-        {{- with .Values.apiserver_podAffinity }}
+        {{- with .Values.placement.apiserver.podAffinity }}
         podAffinity:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- with .Values.apiserver_podAntiAffinity }}
+        {{- with .Values.placement.apiserver.podAntiAffinity }}
         podAntiAffinity:
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -45,11 +45,11 @@ spec:
                     values:
                       - amd64
                       - arm64
-      {{- with .Values.apiserver_tolerations }}
+      {{- with .Values.placement.apiserver.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.apiserver_nodeSelector }}
+      {{- with .Values.placement.apiserver.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
@@ -23,11 +23,11 @@ spec:
       namespace: {{ .Values.namespace }}
     spec:
       affinity:
-        {{- with .Values.controller_podAffinity }}
+        {{- with .Values.placement.controller.podAffinity }}
         podAffinity:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- with .Values.controller_podAntiAffinity }}
+        {{- with .Values.placement.controller.podAntiAffinity }}
         podAntiAffinity:
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -44,11 +44,11 @@ spec:
                     values:
                       - amd64
                       - arm64
-      {{- with .Values.controller_tolerations }}
+      {{- with .Values.placement.controller.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.controller_nodeSelector }}
+      {{- with .Values.placement.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
@@ -65,11 +65,11 @@ spec:
             - name: SCHEDULER_CRON_EXPRESSION
               value: "{{ .Values.scheduler_cron_expression}}"
             - name: LOGGING_FORMATTER
-              value: "{{ .Values.logging_formatter }}"
+              value: "{{ .Values.logging.formatter }}"
             - name: LOGGING_ANSI_ENABLED
-              value: "{{ .Values.logging_ansi_enabled }}"
+              value: "{{ .Values.logging.ansi_enabled }}"
             - name: TRACING_FILTER_DIRECTIVE
-              value: "{{ .Values.controller_tracing_filter }}"
+              value: "{{ .Values.logging.controller.tracing_filter }}"
           image: {{ .Values.image }}
           name: brupop
       priorityClassName: brupop-controller-high-priority

--- a/deploy/charts/bottlerocket-update-operator/values.yaml
+++ b/deploy/charts/bottlerocket-update-operator/values.yaml
@@ -6,35 +6,38 @@ namespace: "brupop-bottlerocket-aws"
 # The image to use for brupop
 image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.2.0"
 
-
 # Placement controls
-# The agent is a daemonset, so the only controls that apply to it are tolerations.
+# See the Kubernetes documentation about placement controls for more details:
+# * https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+# * https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+# * https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+placement:
+  agent:
+    # The agent is a daemonset, so the only controls that apply to it are tolerations.
+    tolerations: []
 
-# https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-agent_tolerations: []
-controller_tolerations: []
-apiserver_tolerations: []
+  controller:
+    tolerations: []
+    nodeSelector: {}
+    podAffinity: {}
+    podAntiAffinity: {}
 
-# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
-controller_nodeSelector: {}
-apiserver_nodeSelector: {}
-
-# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
-controller_podAffinity: {}
-apiserver_podAffinity:  {}
-controller_podAntiAffinity: {}
-# By default, apiserver pods prefer not to be scheduled to the same node.
-apiserver_podAntiAffinity:
-  preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 1
-      podAffinityTerm:
-        labelSelector:
-          matchExpressions:
-          - key: brupop.bottlerocket.aws/component
-            operator: In
-            values:
-            - apiserver
-        topologyKey: kubernetes.io/hostname
+  apiserver:
+    tolerations: []
+    nodeSelector: {}
+    podAffinity: {}
+    # By default, apiserver pods prefer not to be scheduled to the same node.
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: brupop.bottlerocket.aws/component
+                operator: In
+                values:
+                - apiserver
+            topologyKey: kubernetes.io/hostname
 
 # If testing against a private image registry, you can set the pull secret to fetch images.
 # This can likely remain as `brupop` so long as you run something like the following:

--- a/deploy/charts/bottlerocket-update-operator/values.yaml
+++ b/deploy/charts/bottlerocket-update-operator/values.yaml
@@ -90,19 +90,24 @@ scheduler_cron_expression: "* * * * * * *"
 apiserver_internal_port: "8443"
 apiserver_service_port: "443"
 
-# Formatter for the logs emitted by brupop.
-# Options are:
-# * full - Human-readable, single-line logs
-# * compact - A variant of full optimized for shorter line lengths
-# * pretty - "Excessively pretty" logs optimized for human-readable terminal output.
-# * json - Newline-delimited JSON-formatted logs.
-logging_formatter: "pretty"
-# Whether or not to enable ANSI colors on log messages.
-# Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
-logging_ansi_enabled: "true"
-# Controls the filter for tracing/log messages.
-# This can be as simple as a log-level (e.g. "info", "debug", "error"), but also supports more complex directives.
-# See https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html#directives
-controller_tracing_filter: "info"
-agent_tracing_filter: "info"
-apiserver_tracing_filter: "info"
+logging:
+  # Formatter for the logs emitted by brupop.
+  # Options are:
+  # * full - Human-readable, single-line logs
+  # * compact - A variant of full optimized for shorter line lengths
+  # * pretty - "Excessively pretty" logs optimized for human-readable terminal output.
+  # * json - Newline-delimited JSON-formatted logs.
+  formatter: "pretty"
+  # Whether or not to enable ANSI colors on log messages.
+  # Makes the output "pretty" in terminals, but may add noise to web-based log utilities.
+  ansi_enabled: "true"
+
+  # Controls the filter for tracing/log messages.
+  # This can be as simple as a log-level (e.g. "info", "debug", "error"), but also supports more complex directives.
+  # See https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html#directives
+  controller:
+    tracing_filter: "info"
+  agent:
+    tracing_filter: "info"
+  apiserver:
+    tracing_filter: "info"


### PR DESCRIPTION
**Description of changes:**
This more cleanly namespaces new configuration options in the Helm values file. Thanks for the suggestion @hofalk!


**Testing done:**
Deployed a cluster, then ran through several `helm upgrades` changing these values
* Modified the formatter, disabled ansi, changed the tracing filter
* Noted that tolerations were respected
* Noted that the apiservers followed antiAffinity
* Used nodeselector to run the controller on a particular node


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
