### PR TITLE
Fetch upstream crates in a docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 .cargo/*
 !.cargo/config.toml
+chartbuild/

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,14 @@ image: check-licenses brupop-image
 
 # Fetches crates from upstream
 fetch:
-	$(CARGO_ENV_VARS) cargo fetch --locked
+	docker run --rm \
+		--user "$(shell id -u):$(shell id -g)" \
+		--security-opt label=disable \
+		--env CARGO_HOME="/src/.cargo" \
+		--volume "$(TOP):/src" \
+		--workdir "/src/" \
+		"$(BUILDER_IMAGE)" \
+		bash -c "$(CARGO_ENV_VARS) cargo fetch --locked"
 
 dev-tools:
 	cargo install cargo-insta


### PR DESCRIPTION
**Description of changes:**
```
    Fetch upstream crates in a docker container
    
    This allows `make image` to be run without having the Rust toolchain
    installed.
```


**Testing done:**
`make fetch` several times consecutively.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
