### PR TITLE
Improve cluster-wide update performance, as well as various small fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "kube",
  "lazy_static",
  "models",
+ "nonzero_ext",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,15 +326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "apiserver"
 version = "0.1.0"
 dependencies = [
@@ -370,6 +361,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "argh"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af5ba06967ff7214ce4c7419c7d185be7ecd6cc4965a8f6e1d8ce0398aad219"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56df0aeedf6b7a2fc67d06db35b09684c3e8da0c95f8f27685cb17e08413d87a"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,17 +400,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.28",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -974,21 +985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,7 +1145,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 1.0.109",
 ]
 
@@ -1540,27 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1816,6 +1794,7 @@ dependencies = [
 name = "integ"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "async-trait",
  "aws-config",
  "aws-sdk-ec2",
@@ -1838,7 +1817,6 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "structopt",
  "strum_macros",
  "tokio",
  "tokio-retry",
@@ -3097,7 +3075,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3121,39 +3099,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "strum_macros"
@@ -3161,7 +3109,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3210,15 +3158,6 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "thiserror"
@@ -3572,18 +3511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3678,12 +3605,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -13,6 +13,7 @@ dotenv = "0.15"
 futures = "0.3"
 governor = "0.6"
 lazy_static = "1"
+nonzero_ext = "0.3"
 tracing = "0.1"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature

--- a/agent/src/agentclient.rs
+++ b/agent/src/agentclient.rs
@@ -572,7 +572,8 @@ impl<T: APIServerClient> BrupopAgent<T> {
                         _ => {
                             event!(
                                 Level::WARN,
-                                "An error occurred when invoking Bottlerocket Update API"
+                                "An error occurred when invoking Bottlerocket Update API: '{}'",
+                                e
                             );
                             match self
                                 .update_status_in_shadow(

--- a/agent/src/agentclient.rs
+++ b/agent/src/agentclient.rs
@@ -5,15 +5,21 @@ use apiserver::{
     RemoveNodeExclusionFromLoadBalancerRequest, UncordonBottlerocketShadowRequest,
     {CreateBottlerocketShadowRequest, UpdateBottlerocketShadowRequest},
 };
+use chrono::{DateTime, Utc};
+use governor::{
+    clock::DefaultClock,
+    middleware::NoOpMiddleware,
+    state::{InMemoryState, NotKeyed},
+    Quota, RateLimiter,
+};
+use k8s_openapi::api::core::v1::Node;
+use kube::runtime::reflector::Store;
+use kube::Api;
+use lazy_static::lazy_static;
 use models::node::{
     BottlerocketShadow, BottlerocketShadowSelector, BottlerocketShadowSpec,
     BottlerocketShadowState, BottlerocketShadowStatus,
 };
-
-use chrono::{DateTime, Utc};
-use k8s_openapi::api::core::v1::Node;
-use kube::runtime::reflector::Store;
-use kube::Api;
 use snafu::{OptionExt, ResultExt};
 use std::env;
 use tokio::time::{sleep, Duration};
@@ -30,6 +36,14 @@ const RETRY_MAX_DELAY: Duration = Duration::from_secs(30);
 const NUM_RETRIES: usize = 5;
 
 const AGENT_SLEEP_DURATION: Duration = Duration::from_secs(5);
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(120);
+
+type SimpleRateLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>;
+
+lazy_static! {
+    static ref CHECK_UPDATE_RATE_LIMITER: SimpleRateLimiter =
+        RateLimiter::direct(Quota::with_period(UPDATE_CHECK_INTERVAL).unwrap());
+}
 
 /// The module-wide result type.
 pub type Result<T> = std::result::Result<T, agentclient_error::Error>;
@@ -189,14 +203,23 @@ impl<T: APIServerClient> BrupopAgent<T> {
         let os_info = apiclient::get_os_info()
             .await
             .context(agentclient_error::BottlerocketShadowStatusVersionSnafu)?;
-        let update_version = match apiclient::get_chosen_update()
-            .await
-            .context(agentclient_error::BottlerocketShadowStatusChosenUpdateSnafu)?
-        {
-            Some(chosen_update) => chosen_update.version,
-            // if chosen update is null which means current node already in latest version, assign current version value to it.
-            _ => os_info.version_id.clone(),
-        };
+
+        // If enough time has elapsed, ask the Bottlerocket API if any updates are available.
+        let update_version = if CHECK_UPDATE_RATE_LIMITER.check().is_ok() {
+            event!(Level::INFO, "Checking for Bottlerocket updates.");
+            apiclient::get_chosen_update()
+                .await
+                .context(agentclient_error::BottlerocketShadowStatusChosenUpdateSnafu)?
+                .map(|chosen_update| chosen_update.version)
+        } else {
+            // Rate limited, don't check for updates, just return whatever version we last returned.
+            self.fetch_shadow()
+                .await?
+                .status
+                .map(|status| status.target_version())
+        }
+        // If we can't determine a version to update to, just return our current version
+        .unwrap_or(os_info.version_id.clone());
 
         Ok(BottlerocketShadowStatus::new(
             os_info.version_id.clone(),

--- a/agent/src/apiclient.rs
+++ b/agent/src/apiclient.rs
@@ -109,6 +109,7 @@ pub(super) mod api {
         Quota, RateLimiter,
     };
     use lazy_static::lazy_static;
+    use nonzero_ext::nonzero;
     use semver::Version;
     use serde::Deserialize;
     use snafu::ResultExt;
@@ -132,8 +133,11 @@ pub(super) mod api {
     type SimpleRateLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>;
 
     lazy_static! {
-        static ref UPDATE_API_RATE_LIMITER: SimpleRateLimiter =
-            RateLimiter::direct(Quota::with_period(Duration::from_secs(10)).unwrap());
+        static ref UPDATE_API_RATE_LIMITER: SimpleRateLimiter = RateLimiter::direct(
+            Quota::with_period(Duration::from_secs(10))
+                .unwrap()
+                .allow_burst(nonzero!(2u32))
+        );
     }
 
     pub(super) fn get_raw_args(mut args: Vec<String>) -> Vec<String> {

--- a/agent/src/apiclient.rs
+++ b/agent/src/apiclient.rs
@@ -21,6 +21,8 @@ pub async fn get_os_info() -> Result<OsInfo> {
 
 // get chosen update which contains latest Bottlerocket OS can update to.
 pub async fn get_chosen_update() -> Result<Option<UpdateImage>> {
+    api::refresh_updates().await?;
+
     let update_status = api::get_update_status().await?;
 
     ensure!(
@@ -364,8 +366,6 @@ pub(super) mod api {
 
     #[instrument]
     pub(super) async fn get_update_status() -> Result<UpdateStatus> {
-        refresh_updates().await?;
-
         let raw_args = vec![UPDATES_STATUS_URI.to_string()];
         let update_status_output =
             invoke_apiclient(get_raw_args(raw_args), Some(&UPDATE_API_RATE_LIMITER)).await?;

--- a/apiserver/src/client/ratelimited.rs
+++ b/apiserver/src/client/ratelimited.rs
@@ -2,15 +2,16 @@
 use crate::client::prelude::*;
 use async_trait::async_trait;
 use governor::{
-    clock::{DefaultClock, ReasonablyRealtime},
+    clock::{Clock, DefaultClock, ReasonablyRealtime},
     middleware::NoOpMiddleware,
     state::{DirectStateStore, InMemoryState, NotKeyed},
-    Jitter, Quota, RateLimiter,
+    Quota, RateLimiter,
 };
 use models::node::{BottlerocketShadow, BottlerocketShadowStatus};
 use nonzero_ext::nonzero;
 use std::{fmt::Debug, sync::Arc};
-use std::{num::NonZeroU32, ops::Deref, time::Duration};
+use std::{num::NonZeroU32, ops::Deref};
+use tracing::{event, Level};
 
 type Result<T> = std::result::Result<T, ClientError>;
 
@@ -19,7 +20,7 @@ pub struct RateLimitedAPIServerClient<WC, S, C, RL>
 where
     WC: APIServerClient,
     S: DirectStateStore + Debug,
-    C: ReasonablyRealtime + Debug,
+    C: ReasonablyRealtime + Clock + Debug,
     RL: Deref<Target = RateLimiter<NotKeyed, S, C, NoOpMiddleware<C::Instant>>>
         + Send
         + Sync
@@ -27,40 +28,39 @@ where
 {
     rate_limiter: RL,
     wrapped_client: WC,
-    jitter: Option<Jitter>,
 }
 
 impl<WC, S, C, RL> RateLimitedAPIServerClient<WC, S, C, RL>
 where
     WC: APIServerClient,
     S: DirectStateStore + Debug,
-    C: ReasonablyRealtime + Debug,
+    C: ReasonablyRealtime + Clock + Debug,
     RL: Deref<Target = RateLimiter<NotKeyed, S, C, NoOpMiddleware<C::Instant>>>
         + Send
         + Sync
         + Debug,
 {
-    pub fn new(wrapped_client: WC, rate_limiter: RL, jitter: Option<Jitter>) -> Self {
+    pub fn new(wrapped_client: WC, rate_limiter: RL) -> Self {
         Self {
             wrapped_client,
             rate_limiter,
-            jitter,
         }
     }
 
     async fn rate_limit(&self) {
-        if let Some(jitter) = self.jitter {
-            self.rate_limiter.until_ready_with_jitter(jitter).await;
-        } else {
+        if let Err(e) = self.rate_limiter.check() {
+            event!(
+                Level::DEBUG,
+                "Rate limited while calling api server for {}.",
+                e
+            );
             self.rate_limiter.until_ready().await;
         }
     }
 }
 
 /// Rate at which request token bucket refills.
-const DEFAULT_REQUESTS_PER_MINUTE: NonZeroU32 = nonzero!(8u32);
-/// Maximum jitter between tokens being added to the bucket.
-const DEFAULT_MAX_JITTER: Duration = Duration::from_secs(10);
+const DEFAULT_REQUESTS_PER_MINUTE: NonZeroU32 = nonzero!(4u32);
 
 /// Default rate limiter.
 type SimpleRateLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>;
@@ -74,11 +74,9 @@ where
         let rate_limiter = Arc::new(SimpleRateLimiter::direct(Quota::per_minute(
             DEFAULT_REQUESTS_PER_MINUTE,
         )));
-        let jitter = Some(Jitter::up_to(DEFAULT_MAX_JITTER));
         Self {
             wrapped_client,
             rate_limiter,
-            jitter,
         }
     }
 }
@@ -88,7 +86,7 @@ impl<WC, S, C, RL> APIServerClient for RateLimitedAPIServerClient<WC, S, C, RL>
 where
     WC: APIServerClient,
     S: DirectStateStore + Sync + Send + Debug,
-    C: ReasonablyRealtime + Sync + Send + Debug,
+    C: ReasonablyRealtime + Clock + Sync + Send + Debug,
     RL: Deref<Target = RateLimiter<NotKeyed, S, C, NoOpMiddleware<C::Instant>>>
         + Send
         + Sync

--- a/apiserver/src/client/ratelimited.rs
+++ b/apiserver/src/client/ratelimited.rs
@@ -58,9 +58,7 @@ where
 }
 
 /// Rate at which request token bucket refills.
-const DEFAULT_REQUESTS_PER_MINUTE: NonZeroU32 = nonzero!(2u32);
-/// Maximum request tokens that can be stored.
-const DEFAULT_BURST_TOKENS: NonZeroU32 = nonzero!(5u32);
+const DEFAULT_REQUESTS_PER_MINUTE: NonZeroU32 = nonzero!(8u32);
 /// Maximum jitter between tokens being added to the bucket.
 const DEFAULT_MAX_JITTER: Duration = Duration::from_secs(10);
 
@@ -73,9 +71,9 @@ where
     WC: APIServerClient,
 {
     pub fn default(wrapped_client: WC) -> Self {
-        let rate_limiter = Arc::new(SimpleRateLimiter::direct(
-            Quota::per_minute(DEFAULT_REQUESTS_PER_MINUTE).allow_burst(DEFAULT_BURST_TOKENS),
-        ));
+        let rate_limiter = Arc::new(SimpleRateLimiter::direct(Quota::per_minute(
+            DEFAULT_REQUESTS_PER_MINUTE,
+        )));
         let jitter = Some(Jitter::up_to(DEFAULT_MAX_JITTER));
         Self {
             wrapped_client,

--- a/deny.toml
+++ b/deny.toml
@@ -37,10 +37,6 @@ skip-tree = [
     # actix-http uses older and newer versions of crates like rustc_version and
     # semver, for build vs. runtime dependencies.
     { name = "actix-http", version = "3.0.0-beta.10" },
-    # clap uses an older version of strsim, which clashed with the one used by darling_core.
-    { name = "clap", version = "2.34.0" },
-    # structopt-derive uses an older version of heck, which clashed with the one used by strum_macros.
-    { name = "structopt-derive", version = "0.4.18"},
     # aws-smithy-client brings in several lagging dependencies that can be ignored
     # since it is only used in the integration tests
     { name = "integ" }

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 models = { path = "../models", version = "0.1.0" }
 
+argh = "0.1"
 aws-config = "0.54.1"
 aws-sdk-ec2 = "0.24.0"
 aws-sdk-eks = "0.24.0"
@@ -27,7 +28,6 @@ semver = "1.0"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 snafu = "0.7"
-structopt = "0.3.26"
 strum_macros = "0.24.3"
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-retry = "0.3"

--- a/integ/src/nodegroup_provider.rs
+++ b/integ/src/nodegroup_provider.rs
@@ -115,7 +115,7 @@ pub async fn create_nodegroup(
 
     // Ensure the nodegroup reach a active state.
     tokio::time::timeout(
-        Duration::from_secs(300),
+        Duration::from_secs(900),
         wait_for_conforming_nodegroup(&eks_client, &cluster.name, "create", nodegroup_name),
     )
     .await
@@ -143,7 +143,7 @@ pub async fn terminate_nodegroup(cluster: ClusterInfo, nodegroup_name: &str) -> 
 
     // Ensure the instances reach a terminated state.
     tokio::time::timeout(
-        Duration::from_secs(500),
+        Duration::from_secs(900),
         wait_for_conforming_nodegroup(&eks_client, &cluster.name, "delete", nodegroup_name),
     )
     .await


### PR DESCRIPTION
**Description of changes:**
Addresses various problems found while testing larger clusters for the 1.3.0 release:

* In rare cases, we could still starve the brupop agent of access to the udpate API. This adds exponential backoff instead of fixed interval retries.
* `structopt` is unmaintained and has a dependency on `atty`, which has [a published vulnerability](https://github.com/advisories/GHSA-g98v-hv3f-hcfr), so we moved to `argh`
* The integration tests can time out too early, so the timeouts were bumped.
* The rate limits for Brupop's `apiserver` and Bottlerocket's `apiclient` were too restrictive, and caused the update process to take several minutes longer to complete. This adds some of the telemetry used to figure out ideal values, as well as the changes to go faster.
* Bottlerocket nodes check the TUF repo for updates with `refresh-updates` *far* too often. It was not a reasonable default, and with rate-limiting implemented we end up always out of burst tokens. This refrains from calling `refresh-updates` not but every 2 minutes.

**Testing done:**
* Ran the `integ` tool with a cluster of size 12, monitoring the logs


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
