### PR TITLE
Bump rustls from 0.20 to 0.21, bump actix-web to 4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
  "reqwest",
- "rustls 0.20.8",
+ "rustls 0.21.1",
  "rustls-pemfile",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617a8268e3537fe1d8c9ead925fca49ef6400927ee7bc26750e90ecee14ce4b8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2079246596c18b4a33e274ae10c0e50613f4d32a4198e09c7b93771013fed74"
+checksum = "a92ef85799cba03f76e4f7c10f533e66d87c9a7e7055f3391f09000ad8351bc9"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -32,7 +32,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.8.3",
  "base64 0.21.2",
- "bitflags",
+ "bitflags 2.4.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -123,21 +123,24 @@ dependencies = [
 
 [[package]]
 name = "actix-tls"
-version = "3.0.3"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde0cf292f7cdc7f070803cb9a0d45c018441321a78b1042ffbbb81ec333297"
+checksum = "72616e7fbec0aa99c6f3164677fa48ff5a60036d0799c98cab894a44f3e0efc3"
 dependencies = [
- "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "futures-core",
  "http",
- "log",
+ "impl-more",
  "pin-project-lite",
- "tokio-rustls 0.23.4",
+ "rustls 0.21.7",
+ "rustls-webpki",
+ "tokio",
+ "tokio-rustls 0.24.0",
  "tokio-util",
- "webpki-roots",
+ "tracing",
+ "webpki-roots 0.25.2",
 ]
 
 [[package]]
@@ -152,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.3.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3cb42f9566ab176e1ef0b8b3a896529062b4efc6be0123046095914c4c1c96"
+checksum = "0e4a5b5e29603ca8c94a77c65cf874718ceb60292c5a5c3e5f4ace041af462b9"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -166,7 +169,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.7.6",
+ "ahash 0.8.3",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -175,7 +178,6 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http",
  "itoa",
  "language-tags",
  "log",
@@ -187,7 +189,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "time",
  "url",
 ]
@@ -348,7 +350,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus",
  "reqwest",
- "rustls 0.21.1",
+ "rustls 0.21.7",
  "rustls-pemfile",
  "schemars",
  "serde",
@@ -895,6 +897,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -1674,7 +1682,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.21.1",
+ "rustls 0.21.7",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.24.0",
@@ -1747,6 +1755,12 @@ name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
+name = "impl-more"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
 
 [[package]]
 name = "indexmap"
@@ -1958,7 +1972,7 @@ dependencies = [
  "kube-core",
  "pem",
  "pin-project",
- "rustls 0.21.1",
+ "rustls 0.21.7",
  "rustls-pemfile",
  "secrecy",
  "serde",
@@ -2627,7 +2641,7 @@ version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2636,7 +2650,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2706,7 +2720,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.1",
+ "rustls 0.21.7",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2718,7 +2732,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -2758,7 +2772,7 @@ version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2780,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.1"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -2813,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.2"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
@@ -2898,7 +2912,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3322,7 +3336,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
- "rustls 0.21.1",
+ "rustls 0.21.7",
  "tokio",
 ]
 
@@ -3376,7 +3390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
  "base64 0.20.0",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3750,6 +3764,12 @@ checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "winapi"

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -18,7 +18,7 @@ models = { path = "../models", version = "0.1.0" }
 actix-web = { version = "4", features = ["rustls"] }
 awc = "3"
 actix-web-opentelemetry = { version = "0.13", features = ["metrics", "metrics-prometheus"] }
-rustls = { version = "0.20" }
+rustls = { version = "0.21" }
 rustls-pemfile = { version = "1" }
 webpki = { version = "0.22.0", features = ["std"] }
 opentelemetry = { version = "0.18", features = ["rt-tokio-current-thread"]}

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -15,7 +15,7 @@ server = []
 models = { path = "../models", version = "0.1.0" }
 
 # tracing-actix-web version must align with actix-web version
-actix-web = { version = "4", features = ["rustls"] }
+actix-web = { version = "4.4", features = ["rustls-0_21"] }
 awc = "3"
 actix-web-opentelemetry = { version = "0.13", features = ["metrics", "metrics-prometheus"] }
 rustls = { version = "0.21" }

--- a/apiserver/src/api/error.rs
+++ b/apiserver/src/api/error.rs
@@ -53,7 +53,7 @@ pub enum Error {
     CertExtract { path: String, source: io::Error },
 
     #[snafu(display("Failed to add CA to cert store: {}", source))]
-    CertStore { source: webpki::Error },
+    CertStore { source: rustls::Error },
 
     #[snafu(display("Failed to build TLS config from loaded certs: {}", source))]
     TLSConfigBuild { source: rustls::Error },

--- a/clarify.toml
+++ b/clarify.toml
@@ -115,5 +115,4 @@ license-files = [
 expression = "ISC"
 license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
-    { path = "third-party/chromium/LICENSE", hash = 0x9b209a1a },
 ]

--- a/models/src/node/mod.rs
+++ b/models/src/node/mod.rs
@@ -4,11 +4,13 @@ mod drain;
 
 pub use self::client::client_error::Error as BottlerocketShadowClientError;
 pub use self::client::*;
-pub use self::crd::*;
-pub use self::error::Error as BottlerocketShadowError;
-
-/// The module-wide result type.
-type Result<T> = std::result::Result<T, error::Error>;
+// pub use self::crd::*;
+pub use self::crd::{
+    brs_name_from_node_name, combined_crds, error, v1, v2, BottlerocketShadow,
+    BottlerocketShadowResource, BottlerocketShadowSelector, BottlerocketShadowSpec,
+    BottlerocketShadowState, BottlerocketShadowStatus, Result, Selector,
+};
+pub use crd::error::Error as BottlerocketShadowError;
 
 use lazy_static::lazy_static;
 pub use semver::Version;


### PR DESCRIPTION
**Issue number:**
Closes: #458 

**Description of changes:**
A few minor changes to support a newer version of rustls, including bumping to the latest actix-web.

**Testing done:**
Monitored a cluster that successfully updated.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
