### PR TITLE
agent: clarify log messages about update lock

### DIFF
--- a/agent/src/apiclient.rs
+++ b/agent/src/apiclient.rs
@@ -258,7 +258,7 @@ pub(super) mod api {
     /// Apiclient binary has been volume mounted into the agent container, so agent is able to
     /// invoke `/bin apiclient` to interact with the Bottlerocket Update API.
     /// This function helps to invoke apiclient raw command.
-    #[instrument(skip(rate_limiter))]
+    #[instrument(err, skip(rate_limiter))]
     pub(super) async fn invoke_apiclient(
         args: Vec<String>,
         rate_limiter: Option<&SimpleRateLimiter>,
@@ -296,7 +296,7 @@ pub(super) mod api {
                         match error_statuscode {
                             UPDATE_API_BUSY_STATUSCODE => {
                                 event!(
-                                    Level::INFO,
+                                    Level::DEBUG,
                                     "The lock for the update API is held by another process ..."
                                 );
                                 apiclient_error::UpdateApiUnavailableSnafu { args: args.clone() }
@@ -442,7 +442,7 @@ pub mod apiclient_error {
             statuscode: String,
         },
 
-        #[snafu(display("Unable to process command apiclient {}: update API unavailable: retries exhausted", args.join(" ")))]
+        #[snafu(display("Unable to process command apiclient {}: The lock for the update API is held by another process. Retries exhausted.", args.join(" ")))]
         UpdateApiUnavailable { args: Vec<String> },
 
         #[snafu(display("Unable to parse version information: '{}'", source))]


### PR DESCRIPTION
When the update lock is held, we now emit DEBUG-level messages unless we exhaust all retries, in which case an ERROR-level message is emitted.

As a note for reviewers, `#[tracing::instrument(err)]` means that if a function returns a `Result` type, `tracing` will automatically write `ERROR`-level log messages if an error is returned. This guarantees that we get the ERROR-level log message if we exhaust our retries.

**Issue number:**
#538

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
