### PR TITLE
feat: allow resource overwrites

### DIFF
--- a/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
@@ -62,12 +62,7 @@ spec:
           image: {{ .Values.image }}
           name: brupop
           resources:
-            limits:
-              cpu: 10m
-              memory: 50Mi
-            requests:
-              cpu: 5m
-              memory: 8Mi
+            {{- toYaml .Values.resources.agent.resources | nindent 12 }}
           securityContext:
             seLinuxOptions:
               level: s0

--- a/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
@@ -81,6 +81,8 @@ spec:
               port: {{ .Values.apiserver_internal_port }}
               scheme: HTTPS
             initialDelaySeconds: 5
+          resources:
+            {{- toYaml .Values.resources.apiserver.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/brupop-tls-keys
               name: bottlerocket-tls-keys

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
@@ -72,6 +72,8 @@ spec:
               value: "{{ .Values.logging.controller.tracing_filter }}"
           image: {{ .Values.image }}
           name: brupop
+          resources:
+            {{- toYaml .Values.resources.controller.resources | nindent 12 }}
       priorityClassName: brupop-controller-high-priority
       {{ if ((.Values.image_pull_secrets)) }}
       image_pull_secrets: 

--- a/deploy/charts/bottlerocket-update-operator/values.yaml
+++ b/deploy/charts/bottlerocket-update-operator/values.yaml
@@ -111,3 +111,27 @@ logging:
     tracing_filter: "info"
   apiserver:
     tracing_filter: "info"
+
+resources:
+  agent:
+    resources:
+      limits:
+        cpu: 10m
+        memory: 50Mi
+      requests:
+        cpu: 5m
+        memory: 8Mi
+  apiserver:
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 40Mi
+  controller:
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 40Mi


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes: #557


**Description of changes:**
Add a new key in values.yaml `resources`, move currently hard coded resources of agent-daemonset to the resources key and add new requests/limits for api-server and controller. I went with the resources for controller & apiserver with defaults from the ebs-csi-driver, feel free to remove the limits or adjust to some sane defaults.


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
