### PR TITLE
Rename root-certificate to brupop-selfsigned-ca

### DIFF
--- a/bottlerocket-update-operator.yaml
+++ b/bottlerocket-update-operator.yaml
@@ -196,6 +196,15 @@ spec:
     subresources:
       status: {}
 ---
+# Source: bottlerocket-update-operator/templates/controller-priority-class.yaml
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: brupop-controller-high-priority
+  namespace: brupop-bottlerocket-aws
+preemptionPolicy: Never
+value: 1000000
+---
 # Source: bottlerocket-update-operator/templates/agent-service-account.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -470,6 +479,7 @@ spec:
   ports:
     - port: 80
       targetPort: 8080
+      name: main
   selector:
     brupop.bottlerocket.aws/component: brupop-controller
 ---
@@ -653,6 +663,12 @@ spec:
               port: 8443
               scheme: HTTPS
             initialDelaySeconds: 5
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
           volumeMounts:
             - mountPath: /etc/brupop-tls-keys
               name: bottlerocket-tls-keys
@@ -721,7 +737,13 @@ spec:
               value: "info"
           image: public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.3.0
           name: brupop
-      priorityClassName: brupop-controller-high-priority
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
+      priorityClassName: "brupop-controller-high-priority"
       
       serviceAccountName: brupop-controller-service-account
 ---
@@ -804,12 +826,3 @@ metadata:
   namespace: brupop-bottlerocket-aws
 spec:
   selfSigned: {}
----
-# Source: bottlerocket-update-operator/templates/controller-priority-class.yaml
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: brupop-controller-high-priority
-  namespace: brupop-bottlerocket-aws
-preemptionPolicy: Never
-value: 1000000

--- a/deploy/tests/snapshots/insta_tests__generated_crds.snap.new
+++ b/deploy/tests/snapshots/insta_tests__generated_crds.snap.new
@@ -1,3 +1,8 @@
+---
+source: deploy/tests/insta_tests.rs
+assertion_line: 30
+expression: crds
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -185,3 +190,4 @@ spec:
     storage: false
     subresources:
       status: {}
+

--- a/models/src/constants.rs
+++ b/models/src/constants.rs
@@ -39,7 +39,7 @@ pub const PUBLIC_KEY_NAME: &str = "tls.crt";
 pub const PRIVATE_KEY_NAME: &str = "tls.key";
 pub const TLS_KEY_MOUNT_PATH: &str = "/etc/brupop-tls-keys";
 // Certificate object name
-pub const ROOT_CERTIFICATE_NAME: &str = "root-certificate";
+pub const ROOT_CERTIFICATE_NAME: &str = "brupop-selfsigned-ca";
 
 // Label keys
 pub const LABEL_COMPONENT: &str = brupop_domain!("component");


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

https://github.com/bottlerocket-os/bottlerocket-update-operator/issues/486

**Description of changes:**

This attempts to address #486. 

Changes root certificate referenced based on current findings of the issue.

**Testing done:**

Ran test suite.

Our own cluster already relies on `brupop-selfsigned-ca`. But I have not ran this specific PR against the cluster and could use an additional verification/eye there. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
