### PR TITLE
Update dependencies, Fix clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,6 @@ version = "0.1.0"
 dependencies = [
  "apiserver",
  "chrono",
- "dotenv",
  "futures",
  "governor",
  "k8s-openapi",
@@ -1199,7 +1198,6 @@ dependencies = [
 name = "deploy"
 version = "0.1.0"
 dependencies = [
- "dotenv",
  "insta",
  "kube",
  "models",
@@ -1261,12 +1259,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "downcast"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -32,7 +32,7 @@ dependencies = [
  "actix-utils",
  "ahash",
  "base64 0.22.1",
- "bitflags 2.6.0",
+ "bitflags",
  "brotli",
  "bytes",
  "bytestring",
@@ -136,11 +136,11 @@ dependencies = [
  "http 1.1.0",
  "impl-more",
  "pin-project-lite",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tracing",
- "webpki-roots",
 ]
 
 [[package]]
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web-opentelemetry"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e0327e7b731c61b77fb54b278477aa3ebd09752bde38d169863167636e2d48"
+checksum = "923b53a2a54dd0b6fb3e737a036b497321b693d16c120806ba4009478f06109b"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -342,8 +342,8 @@ dependencies = [
  "opentelemetry_sdk",
  "prometheus",
  "reqwest",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.23.10",
+ "rustls-pemfile 2.1.2",
  "schemars",
  "serde",
  "serde_json",
@@ -457,7 +457,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.29",
  "ring 0.16.20",
  "time",
  "tokio",
@@ -492,7 +492,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "lazy_static",
  "percent-encoding",
  "pin-project-lite",
@@ -713,12 +713,12 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
+ "hyper-rustls 0.24.2",
  "lazy_static",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
  "tower",
  "tracing",
@@ -735,8 +735,8 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -756,7 +756,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "pin-project-lite",
  "tower",
  "tracing",
@@ -795,7 +795,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -904,12 +904,6 @@ dependencies = [
  "outref",
  "vsimd",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1119,15 +1113,6 @@ dependencies = [
  "chrono",
  "nom",
  "once_cell",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1605,6 +1590,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http-range-header"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,7 +1648,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1653,6 +1661,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,12 +1687,30 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.29",
  "log",
- "rustls",
+ "rustls 0.21.12",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls 0.23.10",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1674,10 +1719,30 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1919,17 +1984,17 @@ dependencies = [
  "futures",
  "home",
  "http 0.2.12",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
+ "hyper-rustls 0.24.2",
  "hyper-timeout",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
  "pin-project",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "secrecy",
  "serde",
  "serde_json",
@@ -2153,6 +2218,7 @@ dependencies = [
  "opentelemetry_sdk",
  "regex",
  "reqwest",
+ "rustls 0.23.10",
  "schemars",
  "semver",
  "serde",
@@ -2267,9 +2333,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2277,14 +2343,13 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bbcf6341cab7e2193e5843f0ac36c446a5b3fccb28747afaeda17996dcd02e"
+checksum = "5e1a24eafe47b693cb938f8505f240dc26c71db60df9aca376b4f857e9653ec7"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -2295,22 +2360,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+checksum = "1869fb4bb9b35c5ba8a1e40c9b128a7b4c010d07091e864a29da19e4fe2ca4d7"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
+ "lazy_static",
  "once_cell",
  "opentelemetry",
  "ordered-float 4.2.0",
@@ -2597,6 +2662,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring 0.17.8",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,7 +2753,7 @@ version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2650,7 +2762,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2705,20 +2817,20 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http 0.2.12",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls 0.27.2",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -2726,15 +2838,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "quinn",
+ "rustls 0.23.10",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2781,6 +2894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,8 +2916,23 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2808,7 +2942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework",
 ]
@@ -2823,12 +2957,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -2909,7 +3070,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3184,30 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "termcolor"
@@ -3357,7 +3497,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.10",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -3410,12 +3561,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.6.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "http-range-header",
  "mime",
  "pin-project-lite",
@@ -3780,9 +3931,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -3965,9 +4119,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,14 +39,14 @@ nonzero_ext = "0.3"
 
 # actix & opentelemetry dependencies
 # these package versions should be moved in lockstep to match upstream
-actix-web = { version = "4.4", features = ["rustls-0_21"] }
+actix-web = { version = "4.8", features = ["rustls-0_23"] }
 tracing-actix-web = "0.7"
-actix-web-opentelemetry = { version = "0.17", features = ["metrics", "metrics-prometheus"] }
+actix-web-opentelemetry = { version = "0.18", features = ["metrics", "metrics-prometheus"] }
 
 # opentelemetry dependencies
-opentelemetry = { version = "0.22"}
-opentelemetry_sdk = { version = "0.22", features = ["rt-tokio-current-thread"]}
-opentelemetry-prometheus = "0.15"
+opentelemetry = { version = "0.23"}
+opentelemetry_sdk = { version = "0.23", features = ["rt-tokio-current-thread"]}
+opentelemetry-prometheus = "0.16"
 prometheus = "0.13.0"
 
 # k8s-openapi must match the version required by kube and enable a k8s version feature
@@ -54,9 +54,9 @@ k8s-openapi = { version = "0.21", default-features = false, features = ["v1_24"]
 kube = { version = "0.88", default-features = false, features = [ "derive", "runtime", "rustls-tls" ] }
 
 regex = "1.9"
-reqwest = { version = "0.11", default-features = false, features =  [ "json", "rustls-tls" ] }
-rustls = { version = "0.21" }
-rustls-pemfile = { version = "1" }
+reqwest = { version = "0.12", default-features = false, features =  [ "json", "rustls-tls" ] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
+rustls-pemfile = { version = "2" }
 schemars = "0.8.11"
 semver = "1.0"
 serde = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ members = [
     "integ",
 ]
 
+[workspace.lints.clippy]
+# tracing::instrument macro unhelpfully triggers this clippy warning
+blocks_in_conditions = "allow"
+
 [workspace.dependencies]
 argh = "0.1"
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,64 @@ members = [
     "deploy",
     "integ",
 ]
+
+[workspace.dependencies]
+argh = "0.1"
+async-trait = "0.1"
+awc = "3"
+aws-config = "0.56.1"
+aws-sdk-ec2 = "0.33.1"
+aws-sdk-eks = "0.34.0"
+aws-sdk-iam = "0.30.0"
+aws-sdk-ssm = "0.30.0"
+base64 = "0.21.0"
+chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
+console_log = { version = "1.0", features = ["color"] }
+cron = "0.12"
+env_logger = "0.10"
+futures = "0.3"
+governor = "0.6"
+hex ="0.4.3"
+insta = { version = "1.34.0", features = ["yaml"] }
+lazy_static = "1"
+log = "0.4"
+http = "0.2"
+maplit = "1"
+mockall = { version = "0.11" }
+nonzero_ext = "0.3"
+
+# actix & opentelemetry dependencies
+# these package versions should be moved in lockstep to match upstream
+actix-web = { version = "4.4", features = ["rustls-0_21"] }
+tracing-actix-web = "0.7"
+actix-web-opentelemetry = { version = "0.17", features = ["metrics", "metrics-prometheus"] }
+
+# opentelemetry dependencies
+opentelemetry = { version = "0.22"}
+opentelemetry_sdk = { version = "0.22", features = ["rt-tokio-current-thread"]}
+opentelemetry-prometheus = "0.15"
+prometheus = "0.13.0"
+
+# k8s-openapi must match the version required by kube and enable a k8s version feature
+k8s-openapi = { version = "0.21", default-features = false, features = ["v1_24"] }
+kube = { version = "0.88", default-features = false, features = [ "derive", "runtime", "rustls-tls" ] }
+
+regex = "1.9"
+reqwest = { version = "0.11", default-features = false, features =  [ "json", "rustls-tls" ] }
+rustls = { version = "0.21" }
+rustls-pemfile = { version = "1" }
+schemars = "0.8.11"
+semver = "1.0"
+serde = "1"
+serde_json = "1"
+serde_plain = "1"
+serde_yaml = "0.9"
+snafu = "0.7"
+strum_macros = "0.24.3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+tokio-retry = "0.3"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "json"] }
+uuid = { version = "0.8", default-features = false, features = ["serde", "v4"] }
+validator = { version = "0.16", features = ["derive"] }
+webpki = { version = "0.22.4", features = ["std"] }

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TOP := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
-.PHONY: image fetch check-licenses build brupop-image clean
+.PHONY: image fetch check-licenses build brupop-image clean check clippy fmt
 
 # IMAGE_NAME is the full name of the container image being built. This may be
 # specified to fully control the name of the container image's tag.
@@ -74,8 +74,16 @@ check-licenses: fetch
 		"$(BUILDER_IMAGE)" \
 		bash -c "$(CARGO_ENV_VARS) cargo deny --all-features check --disable-fetch licenses bans sources"
 
+fmt:
+	cargo fmt --check
+
+clippy:
+	cargo clippy --locked -- -D warnings --no-deps
+
+check: fmt clippy check-licenses
+
 # Builds, Lints, and Tests the Rust workspace locally
-build: check-licenses
+build: check
 	$(CARGO_ENV_VARS) cargo fmt -- --check
 	$(CARGO_ENV_VARS) cargo test --locked
 	$(CARGO_ENV_VARS) cargo build --locked

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -9,21 +9,19 @@ publish = false
 models = { path = "../models", version = "0.1.0" }
 apiserver = { path = "../apiserver", version = "0.1.0", default-features = false, features = ["client"] }
 
-dotenv = "0.15"
-futures = "0.3"
-governor = "0.6"
-lazy_static = "1"
-nonzero_ext = "0.3"
-tracing = "0.1"
+futures = { workspace = true }
+governor = { workspace = true }
+lazy_static = { workspace = true }
+nonzero_ext = { workspace = true }
+tracing = { workspace = true }
 
-# k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.21", default-features = false, features = ["v1_24"] }
-kube = { version = "0.88", default-features = false, features = [ "derive", "runtime", "rustls-tls" ] }
+k8s-openapi = { workspace = true }
+kube = { workspace = true }
 
-semver = { version = "1.0", features = [ "serde" ] }
-serde = { version = "1", features = [ "derive" ] }
-serde_json = "1"
-snafu = "0.7"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-chrono = { version = "0.4", default-features = false, features = ["serde"] }
-tokio-retry = "0.3"
+semver = { workspace = true, features = [ "serde" ] }
+serde = { workspace = true, features = [ "derive" ] }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true }
+chrono = { workspace = true }
+tokio-retry = { workspace = true }

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -5,6 +5,9 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 models = { path = "../models", version = "0.1.0" }
 apiserver = { path = "../apiserver", version = "0.1.0", default-features = false, features = ["client"] }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -30,6 +30,13 @@ async fn main() {
     let termination_log =
         env::var("TERMINATION_LOG").unwrap_or_else(|_| TERMINATION_LOG.to_string());
 
+    if let Err(error) = models::crypto::install_default_crypto_provider() {
+        event!(Level::ERROR, %error);
+        fs::write(&termination_log, format!("{}", error))
+            .expect("Could not write k8s termination log.");
+        return;
+    }
+
     if let Err(error) = run_agent().await {
         fs::write(&termination_log, format!("{}", error))
             .expect("Could not write k8s termination log.");

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -5,11 +5,13 @@ edition = "2018"
 publish = false
 license = "Apache-2.0 OR MIT"
 
+[lints]
+workspace = true
+
 [features]
 default = ["client", "server"]
 client = []
 server = []
-
 
 [dependencies]
 models = { path = "../models", version = "0.1.0" }

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -14,41 +14,39 @@ server = []
 [dependencies]
 models = { path = "../models", version = "0.1.0" }
 
-# tracing-actix-web version must align with actix-web version
-actix-web = { version = "4.4", features = ["rustls-0_21"] }
-awc = "3"
-actix-web-opentelemetry = { version = "0.17", features = ["metrics", "metrics-prometheus"] }
-rustls = { version = "0.21" }
-rustls-pemfile = { version = "1" }
-webpki = { version = "0.22.4", features = ["std"] }
-opentelemetry = { version = "0.22"}
-opentelemetry_sdk = {version = "0.22", features = ["rt-tokio-current-thread"]}
-opentelemetry-prometheus = "0.15"
-tracing = "0.1"
-tracing-actix-web = "0.7"
-prometheus = "0.13.0"
+actix-web = { workspace = true }
+awc = { workspace = true }
+actix-web-opentelemetry = { workspace = true }
+rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
+webpki = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-prometheus = { workspace = true }
+tracing = { workspace = true }
+tracing-actix-web = { workspace = true }
+prometheus = { workspace = true }
 
-# k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.21", default-features = false, features = ["v1_24"] }
-kube = { version = "0.88", default-features = false, features = [ "client", "derive", "runtime", "rustls-tls" ] }
+k8s-openapi = { workspace = true }
+kube = { workspace = true, features = ["client"] }
 
-async-trait = "0.1"
-futures = "0.3"
-governor = "0.6"
-lazy_static = "1.4"
-log = "0.4"
-mockall = { version = "0.11", optional = true }
-nonzero_ext = "0.3"
-reqwest = { version = "0.11", default-features = false, features =  [ "json", "rustls-tls" ] }
+async-trait = { workspace = true }
+futures = { workspace = true }
+governor = { workspace = true }
+lazy_static = { workspace = true }
+log = { workspace = true }
+mockall = { workspace = true, optional = true }
+nonzero_ext = { workspace = true }
+reqwest = { workspace = true }
 schemars = "0.8.11"
-serde = { version = "1", features = [ "derive" ] }
-serde_json = "1"
-snafu = "0.7"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-tokio-retry = "0.3"
+serde = { workspace = true, features = [ "derive" ] }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true }
+tokio-retry = { workspace = true }
 
 [dev-dependencies]
-http = "0.2"
-maplit = "1.0"
-mockall = "0.11"
+http = { workspace = true }
+maplit = { workspace = true }
+mockall = { workspace = true }
 models = { path = "../models", version = "0.1.0", features = [ "mockall" ] }

--- a/apiserver/src/api/error.rs
+++ b/apiserver/src/api/error.rs
@@ -58,6 +58,15 @@ pub enum Error {
     #[snafu(display("Failed to build TLS config from loaded certs: {}", source))]
     TLSConfigBuild { source: rustls::Error },
 
+    #[snafu(display(
+        "More than one private key for tls configured for apiserver in '{}'",
+        path
+    ))]
+    MultiplePrivateKeys { path: String },
+
+    #[snafu(display("No private key for tls provided in  '{}'", path))]
+    NoPrivateKeys { path: String },
+
     #[snafu(display("Failed to serialize Webhook response: {}", source))]
     WebhookError { source: serde_json::error::Error },
 }

--- a/apiserver/src/lib.rs
+++ b/apiserver/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "server")]
 pub mod api;
 #[cfg(feature = "server")]
-mod auth;
+pub mod auth;
 #[cfg(feature = "server")]
 pub mod telemetry;
 

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -6,30 +6,26 @@ publish = false
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-actix-web = "4"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
-cron = "0.12"
-futures = "0.3"
-http = "0.2.9"
-lazy_static = "1.2"
-maplit = "1.0"
-regex = "1.9"
-semver = "1.0"
-serde = "1"
-serde_plain = "1"
-# k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.21", default-features = false, features = ["v1_24"] }
-kube = { version = "0.88", default-features = false, features = [ "derive", "runtime", "rustls-tls" ] }
 models = { path = "../models", version = "0.1.0" }
-opentelemetry = { version = "0.22"}
-opentelemetry_sdk = { version = "0.22", features = ["rt-tokio-current-thread"]}
-opentelemetry-prometheus = "0.15"
-prometheus = "0.13.0"
 
-snafu = "0.7"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-tracing = "0.1"
-validator = { version = "0.16", features = ["derive"] }
-
-[dev-dependencies]
-maplit = "1"
+actix-web = { workspace = true }
+chrono = { workspace = true }
+cron = { workspace = true }
+futures = { workspace = true }
+http = { workspace = true }
+lazy_static = { workspace = true }
+maplit = { workspace = true }
+regex = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true }
+serde_plain = { workspace = true }
+k8s-openapi = { workspace = true }
+kube = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-prometheus = { workspace = true }
+prometheus = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+validator = { workspace = true }

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2018"
 publish = false
 license = "Apache-2.0 OR MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 models = { path = "../models", version = "0.1.0" }
 

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -30,6 +30,9 @@ type Result<T> = std::result::Result<T, controller_error::Error>;
 
 #[actix_web::main]
 async fn main() -> Result<()> {
+    models::crypto::install_default_crypto_provider()
+        .context(controller_error::CryptoConfigureSnafu)?;
+
     telemetry::init_telemetry_from_env().context(controller_error::TelemetryInitSnafu)?;
 
     let incluster_config =
@@ -160,6 +163,11 @@ pub mod controller_error {
         #[snafu(display("Error running controller server: '{}'", source))]
         ControllerError {
             source: controllerclient_error::Error,
+        },
+
+        #[snafu(display("Failed to configure crypto provider: '{}'", source))]
+        CryptoConfigure {
+            source: models::crypto::CryptoConfigError,
         },
 
         #[snafu(display("Unable to get associated node name: {}", source))]

--- a/deploy/Cargo.toml
+++ b/deploy/Cargo.toml
@@ -7,9 +7,8 @@ license = "Apache-2.0 OR MIT"
 
 [build-dependencies]
 models = { path = "../models", version = "0.1.0" }
-dotenv = "0.15"
-kube = { version = "0.88", default-features = false, features = [ "derive", "runtime" ] }
-serde_yaml = "0.9"
+kube = { workspace = true }
+serde_yaml = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.34.0", features = ["yaml"] }
+insta = { workspace = true }

--- a/deploy/Cargo.toml
+++ b/deploy/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2018"
 publish = false
 license = "Apache-2.0 OR MIT"
 
+[lints]
+workspace = true
+
 [build-dependencies]
 models = { path = "../models", version = "0.1.0" }
 kube = { workspace = true }

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -8,36 +8,35 @@ publish = false
 [dependencies]
 models = { path = "../models", version = "0.1.0" }
 
-argh = "0.1"
-aws-config = "0.56.1"
-aws-sdk-ec2 = "0.33.1"
-aws-sdk-eks = "0.34.0"
-aws-sdk-iam = "0.30.0"
-aws-sdk-ssm = "0.30.0"
-async-trait = "0.1"
-base64 = "0.21.0"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
-console_log = { version = "1.0", features = ["color"] }
-env_logger = "0.10"
-hex ="0.4.3"
-lazy_static = "1.4"
-log = "0.4"
-maplit = "1.0.2"
-mockall = { version = "0.11", optional = true }
-semver = "1.0"
-serde = { version = "1", features = [ "derive" ] }
-serde_json = "1"
-snafu = "0.7"
-strum_macros = "0.24.3"
-tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
-tokio-retry = "0.3"
-uuid = { version = "0.8", default-features = false, features = ["serde", "v4"] }
+argh = { workspace = true }
+aws-config = { workspace = true }
+aws-sdk-ec2 = { workspace = true }
+aws-sdk-eks = { workspace = true }
+aws-sdk-iam = { workspace = true }
+aws-sdk-ssm = { workspace = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+chrono = { workspace = true }
+console_log = { workspace = true }
+env_logger = { workspace = true }
+hex = { workspace = true }
+lazy_static = {workspace = true }
+log = { workspace = true }
+maplit = { workspace = true }
+mockall = { workspace = true, optional = true }
+semver = { workspace = true }
+serde = { workspace = true, features = [ "derive" ] }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+strum_macros = { workspace = true }
+tokio = { workspace = true }
+tokio-retry = { workspace = true }
+uuid = { workspace = true }
 
-# k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.21", default-features = false, features = ["v1_24"] }
-kube = { version = "0.88", default-features = false, features = [ "derive", "runtime" ] }
+k8s-openapi = { workspace = true }
+kube = { workspace = true }
 
 
 [dev-dependencies]
-mockall = "0.11"
+mockall = { workspace = true }
 models = { path = "../models", version = "0.1.0", features = [ "mockall" ] }

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -5,6 +5,9 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 models = { path = "../models", version = "0.1.0" }
 

--- a/integ/src/eks_provider.rs
+++ b/integ/src/eks_provider.rs
@@ -158,7 +158,7 @@ async fn dns_ip(
         .ip_family
         .as_ref()
         .context("IP family missing data")
-        .map(|ids| ids.clone())?;
+        .cloned()?;
 
     match ip_family {
         IpFamily::Ipv4 => {
@@ -218,7 +218,7 @@ async fn eks_version(
         .version
         .as_ref()
         .context("Cluster missing version field")
-        .map(|ids| ids.clone())
+        .cloned()
 }
 
 async fn eks_subnet_ids(
@@ -243,7 +243,7 @@ async fn eks_subnet_ids(
         .subnet_ids
         .as_ref()
         .context("resources_vpc_config missing subnet ids")
-        .map(|ids| ids.clone())
+        .cloned()
 }
 
 async fn endpoint(eks_client: &aws_sdk_eks::Client, cluster_name: &str) -> ProviderResult<String> {
@@ -261,7 +261,7 @@ async fn endpoint(eks_client: &aws_sdk_eks::Client, cluster_name: &str) -> Provi
         .endpoint
         .as_ref()
         .context("Cluster missing endpoint field")
-        .map(|ids| ids.clone())
+        .cloned()
 }
 
 async fn certificate(
@@ -286,7 +286,7 @@ async fn certificate(
         .data
         .as_ref()
         .context("Certificate authority missing data")
-        .map(|ids| ids.clone())
+        .cloned()
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -401,7 +401,7 @@ async fn instance_profile(
         .arn
         .as_ref()
         .context("Node instance profile missing arn field")
-        .map(|profile| profile.clone())
+        .cloned()
 }
 
 fn cluster_iam_identity_mapping(cluster_name: &str, region: &str) -> ProviderResult<String> {

--- a/integ/src/main.rs
+++ b/integ/src/main.rs
@@ -45,6 +45,9 @@ lazy_static! {
 
 #[tokio::main]
 async fn main() {
+    models::crypto::install_default_crypto_provider()
+        .expect("Failed to configure crypto provider.");
+
     env_logger::init();
 
     if let Err(e) = run().await {

--- a/integ/src/main.rs
+++ b/integ/src/main.rs
@@ -450,8 +450,5 @@ mod error {
 
         #[snafu(display("Failed to write content to kubeconfig: {}", source))]
         WriteKubeconfig { source: ProviderError },
-
-        #[snafu(display("Logger setup error: {}", source))]
-        Logger { source: log::SetLoggerError },
     }
 }

--- a/integ/src/nodegroup_provider.rs
+++ b/integ/src/nodegroup_provider.rs
@@ -408,7 +408,7 @@ async fn instance_type(ec2_client: &aws_sdk_ec2::Client, node_ami: &str) -> Prov
         .context("Unable to get ami architecture")?
         .images
         .context("Unable to get ami architecture")?
-        .get(0)
+        .first()
         .context("Unable to get ami architecture")?
         .architecture
         .clone()
@@ -424,7 +424,7 @@ async fn instance_type(ec2_client: &aws_sdk_ec2::Client, node_ami: &str) -> Prov
 
 fn first_subnet_id(subnet_ids: &[String]) -> ProviderResult<String> {
     subnet_ids
-        .get(0)
+        .first()
         .map(|id| id.to_string())
         .context("There are no private subnet ids")
 }
@@ -584,7 +584,7 @@ async fn instance_profile_arn(
         .instance_profile()
         .and_then(|instance_profile| instance_profile.roles())
         .context("Instance profile does not contain roles.")?
-        .get(0)
+        .first()
         .context("Instance profile does not contain roles.")?
         .arn
         .as_ref()

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -23,6 +23,7 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio-current-thread"]}
 regex = { workspace = true }
 reqwest = { workspace = true }
+rustls = { workspace = true }
 schemars = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = [ "derive" ] }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2018"
 publish = false
 license = "Apache-2.0 OR MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -6,28 +6,28 @@ publish = false
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-async-trait = "0.1"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
-futures = "0.3"
-# k8s-openapi must match the version required by kube and enable a k8s version feature
-k8s-openapi = { version = "0.21", default-features = false, features = ["v1_24"] }
-kube = { version = "0.88", default-features = false, features = [ "client", "derive", "runtime" ] }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+futures = { workspace = true }
 
-lazy_static = "1.4"
-maplit = "1.0"
-mockall = { version = "0.11", optional = true }
-opentelemetry = { version = "0.22"}
-opentelemetry_sdk = { version = "0.22", features = ["rt-tokio-current-thread"]}
-regex = "1.9"
-reqwest = { version = "0.11", default-features = false, features =  [ "json" ] }
-schemars = "0.8.11"
-semver = "1.0"
-serde = { version = "1", features = [ "derive" ] }
-serde_plain = "1"
-serde_json = "1"
-snafu = "0.7"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-tokio-retry = "0.3"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "json"] }
-validator = { version = "0.16", features = ["derive"] }
+k8s-openapi = { workspace = true }
+kube = { workspace = true, features = ["client"] }
+
+lazy_static = { workspace = true }
+maplit = { workspace = true }
+mockall = { workspace = true, optional = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio-current-thread"]}
+regex = { workspace = true }
+reqwest = { workspace = true }
+schemars = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true, features = [ "derive" ] }
+serde_plain = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+tokio-retry = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+validator = { workspace = true }

--- a/models/src/crypto.rs
+++ b/models/src/crypto.rs
@@ -1,0 +1,19 @@
+//! Installs a default `CryptoProvider` for use with `rustls`.
+//!
+//! While the default *should* be correctly selected based on the feature flags chosen for rustls,
+//! it is easy to accidentally enable multiple providers and make the default selection ambiguous
+//! for `rustls`, which results in a panic.
+//!
+//! This function will panic if a crypto provider cannot be installed.
+
+use rustls::crypto::CryptoProvider;
+use snafu::Snafu;
+
+pub fn install_default_crypto_provider() -> Result<(), CryptoConfigError> {
+    CryptoProvider::install_default(rustls::crypto::ring::default_provider())
+        .map_err(|_| CryptoConfigError)
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(display("Failed to install crypto provider."), visibility(pub))]
+pub struct CryptoConfigError;

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod constants;
+pub mod crypto;
 pub mod node;
 pub mod telemetry;


### PR DESCRIPTION
**Description of changes:**
This PR is definitely best viewed commit-by-commit. It:
* Moves dependency version constraints to the workspace level, making it easier to maintain versions across subcrates
* Fixes clippy warnings
* Updates actix-web, rustls, and other packages which are coupled with those.

**Testing done:**
* [x] Testing updates across a cluster
* [x] Metrics successfully gathered

```
❯ curl localhost:8080/metrics
# HELP brupop_hosts_state Brupop host's state
# TYPE brupop_hosts_state gauge
brupop_hosts_state{state="Idle",otel_scope_name="brupop-controller"} 3
brupop_hosts_state{state="MonitoringUpdate",otel_scope_name="brupop-controller"} 0
brupop_hosts_state{state="RebootedIntoUpdate",otel_scope_name="brupop-controller"} 0
brupop_hosts_state{state="StagedAndPerformedUpdate",otel_scope_name="brupop-controller"} 0
# HELP brupop_hosts_version Brupop host's bottlerocket version
# TYPE brupop_hosts_version gauge
brupop_hosts_version{bottlerocket_version="1.21.0",otel_scope_name="brupop-controller"} 1
brupop_hosts_version{bottlerocket_version="1.21.1",otel_scope_name="brupop-controller"} 2
# HELP target_info Target metadata
# TYPE target_info gauge
target_info{service_name="unknown_service",telemetry_sdk_language="rust",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="0.23.0"} 1
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
