### PR TITLE
Fix CI build to unblock dependabots 

### DIFF
--- a/apiserver/src/auth/mod.rs
+++ b/apiserver/src/auth/mod.rs
@@ -6,5 +6,5 @@ pub use authorizor::{K8STokenAuthorizor, K8STokenReviewer, TokenAuthorizor};
 pub use error::AuthorizationError;
 pub use middleware::TokenAuthMiddleware;
 
-#[cfg(any(mockall, test))]
+#[cfg(any(feature = "mockall", test))]
 pub use authorizor::mock;

--- a/integ/src/nodegroup_provider.rs
+++ b/integ/src/nodegroup_provider.rs
@@ -96,7 +96,7 @@ pub async fn create_nodegroup(
         .launch_template(
             LaunchTemplateSpecification::builder()
                 .id(&launch_template.launch_template_id)
-                .version(&launch_template.latest_version_number.to_string())
+                .version(launch_template.latest_version_number.to_string())
                 .build(),
         )
         .labels(LABEL_BRUPOP_INTERFACE_NAME, BRUPOP_INTERFACE_VERSION)
@@ -257,61 +257,61 @@ async fn create_iam_instance_profile(
     let iam_instance_profile_name = format!("{}-{}", IAM_INSTANCE_PROFILE_NAME, nodegroup_name);
     let get_instance_profile_result = iam_client
         .get_instance_profile()
-        .instance_profile_name(&iam_instance_profile_name.clone())
+        .instance_profile_name(iam_instance_profile_name.clone())
         .send()
         .await;
     if instance_profile_exists(get_instance_profile_result) {
-        instance_profile_arn(iam_client, &iam_instance_profile_name.clone()).await
+        instance_profile_arn(iam_client, iam_instance_profile_name.as_str()).await
     } else {
         iam_client
             .create_role()
-            .role_name(&iam_instance_profile_name.clone())
+            .role_name(iam_instance_profile_name.clone())
             .assume_role_policy_document(eks_role_policy_document(region))
             .send()
             .await
             .context("Unable to create new role.")?;
         iam_client
             .attach_role_policy()
-            .role_name(&iam_instance_profile_name.clone())
+            .role_name(iam_instance_profile_name.clone())
             .policy_arn(SSM_MANAGED_INSTANCE_CORE_ARN)
             .send()
             .await
             .context("Unable to attach AmazonSSM policy")?;
         iam_client
             .attach_role_policy()
-            .role_name(&iam_instance_profile_name.clone())
+            .role_name(iam_instance_profile_name.clone())
             .policy_arn(EKS_WORKER_NODE_POLICY_ARN)
             .send()
             .await
             .context("Unable to attach AmazonEKSWorkerNode policy")?;
         iam_client
             .attach_role_policy()
-            .role_name(&iam_instance_profile_name.clone())
+            .role_name(iam_instance_profile_name.clone())
             .policy_arn(EKS_CNI_ARN)
             .send()
             .await
             .context("Unable to attach AmazonEKS CNI policy")?;
         iam_client
             .attach_role_policy()
-            .role_name(&iam_instance_profile_name.clone())
+            .role_name(iam_instance_profile_name.clone())
             .policy_arn(EC2_CONTAINER_REGISTRY_ARN)
             .send()
             .await
             .context("Unable to attach AmazonEC2ContainerRegistry policy")?;
         iam_client
             .create_instance_profile()
-            .instance_profile_name(&iam_instance_profile_name.clone())
+            .instance_profile_name(iam_instance_profile_name.clone())
             .send()
             .await
             .context("Unable to create instance profile")?;
         iam_client
             .add_role_to_instance_profile()
-            .instance_profile_name(&iam_instance_profile_name.clone())
-            .role_name(&iam_instance_profile_name.clone())
+            .instance_profile_name(iam_instance_profile_name.clone())
+            .role_name(iam_instance_profile_name.clone())
             .send()
             .await
             .context("Unable to add role to instance profile")?;
-        instance_profile_arn(iam_client, &iam_instance_profile_name.clone()).await
+        instance_profile_arn(iam_client, iam_instance_profile_name.as_str()).await
     }
 }
 
@@ -322,48 +322,48 @@ async fn delete_iam_instance_profile(
     let iam_instance_profile_name = format!("{}-{}", IAM_INSTANCE_PROFILE_NAME, nodegroup_name);
     iam_client
         .remove_role_from_instance_profile()
-        .role_name(&iam_instance_profile_name.clone())
-        .instance_profile_name(&iam_instance_profile_name.clone())
+        .role_name(iam_instance_profile_name.clone())
+        .instance_profile_name(iam_instance_profile_name.clone())
         .send()
         .await
         .context("Unable to remove roles from instance profile.")?;
     iam_client
         .detach_role_policy()
-        .role_name(&iam_instance_profile_name.clone())
+        .role_name(iam_instance_profile_name.clone())
         .policy_arn(SSM_MANAGED_INSTANCE_CORE_ARN)
         .send()
         .await
         .context("Unable to detach AmazonSSM policy")?;
     iam_client
         .detach_role_policy()
-        .role_name(&iam_instance_profile_name.clone())
+        .role_name(iam_instance_profile_name.clone())
         .policy_arn(EKS_WORKER_NODE_POLICY_ARN)
         .send()
         .await
         .context("Unable to detach AmazonEKSWorkerNode policy")?;
     iam_client
         .detach_role_policy()
-        .role_name(&iam_instance_profile_name.clone())
+        .role_name(iam_instance_profile_name.clone())
         .policy_arn(EKS_CNI_ARN)
         .send()
         .await
         .context("Unable to detach AmazonEKS CNI policy")?;
     iam_client
         .detach_role_policy()
-        .role_name(&iam_instance_profile_name.clone())
+        .role_name(iam_instance_profile_name.clone())
         .policy_arn(EC2_CONTAINER_REGISTRY_ARN)
         .send()
         .await
         .context("Unable to detach AmazonEC2ContainerRegistry policy")?;
     iam_client
         .delete_instance_profile()
-        .instance_profile_name(&iam_instance_profile_name.clone())
+        .instance_profile_name(iam_instance_profile_name.clone())
         .send()
         .await
         .context("Unable to create instance profile")?;
     iam_client
         .delete_role()
-        .role_name(&iam_instance_profile_name.clone())
+        .role_name(iam_instance_profile_name.clone())
         .send()
         .await
         .context("Unable to delete role.")?;


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fix the CI to unblock PRs:
https://github.com/bottlerocket-os/bottlerocket-update-operator/pull/658
https://github.com/bottlerocket-os/bottlerocket-update-operator/pull/657
https://github.com/bottlerocket-os/bottlerocket-update-operator/pull/656
https://github.com/bottlerocket-os/bottlerocket-update-operator/pull/654


**Description of changes:**
I am seeing build failures when running `make build` with the latest rustc version (`rustup update stable` to update).
 
**Failure 1:** Starting with Rust 1.80 (or nightly-2024-05-05) every reachable `#[cfg]` will be **automatically checked** that they match the **expected config names and values**. See more details in this [blog](https://blog.rust-lang.org/2024/05/06/check-cfg.html).

Our CI build failed with
```
error: unexpected `cfg` condition name: `mockall`
 --> apiserver/src/auth/mod.rs:9:11
  |
9 | #[cfg(any(mockall, test))]
  |           ^^^^^^^ help: found config with similar value: `feature = "mockall"`
```

One way to fix it is to add the lints table in `Cargo.toml`. 
```
[lints.rust]
unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mockall)'] }
```
But we are using `feature = "mockall"` everywhere else, so making the change for consistency.

**Failure 2:** Also with the Rust 1.80 release, there is another linter error `clippy::needless_borrows_for_generic_args` (See more details [here](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_borrows_for_generic_args)).

```
error: the borrowed expression implements the required traits
   --> integ/src/nodegroup_provider.rs:366:20
    |
366 |         .role_name(&iam_instance_profile_name.clone())
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `iam_instance_profile_name.clone()`
```

**Testing done:**
`make build` passed.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
