### PR TITLE
feat(bottlerocket-update-operator):  Add an option to specify topologySpreadConstraints for the apiserver deployment resource.

### DIFF
--- a/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
@@ -85,6 +85,10 @@ spec:
             - mountPath: /etc/brupop-tls-keys
               name: bottlerocket-tls-keys
       serviceAccountName: brupop-agent-service-account
+      {{- with .Values.placement.apiserver.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- if ((.Values.image_pull_secrets)) }}
       image_pull_secrets: 
         {{ .Values.image_pull_secrets }}

--- a/deploy/charts/bottlerocket-update-operator/values.yaml
+++ b/deploy/charts/bottlerocket-update-operator/values.yaml
@@ -25,6 +25,8 @@ placement:
     priorityClassName: brupop-controller-high-priority
 
   apiserver:
+    # -- Topology spread constraints.
+    topologySpreadConstraints: []
     tolerations: []
     nodeSelector: {}
     podAffinity: {}


### PR DESCRIPTION

<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
Add an option to specify topologySpreadConstraints for the apiserver deployment resource.


**Testing done:**
I manually tested this by running the helm template with the default values to ensure the default behavior is retained. Then, I added the following values to verify that the new topologySpreadConstraints was applied to the deployment resource.

```yaml
placement:
  apiserver: 
    topologySpreadConstraints:
    - maxSkew: 1
      topologyKey: kubernetes.io/hostname
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchLabels:
          brupop.bottlerocket.aws/component: agent
    - maxSkew: 1
      topologyKey: topology.kubernetes.io/zone
      whenUnsatisfiable: ScheduleAnyway
      labelSelector:
        matchLabels:
          brupop.bottlerocket.aws/component: agent
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
