### PR TITLE
Allow brupop-controller-deployment pods to be discovered by Splunk otel-collector

### DIFF
--- a/bottlerocket-update-operator.yaml
+++ b/bottlerocket-update-operator.yaml
@@ -699,6 +699,9 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
       labels:
         brupop.bottlerocket.aws/component: brupop-controller
       namespace: brupop-bottlerocket-aws

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
@@ -18,6 +18,9 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
       labels:
         brupop.bottlerocket.aws/component: brupop-controller
         {{- if .Values.podLabels }}


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#676 


**Description of changes:**
Ensured `deployment/brupop-controller-deployment` is annotated for Splunk otel-collector to discover its pods:
```yaml
spec:
  template:
    metadata:
      annotations:
        prometheus.io/port: "8080"
        prometheus.io/scrape: "true"
```


**Testing done:**
1. I manually edited `deploy/brupop-controller-deployment` and added the above annotations
2. ```kubectl rollout restart deployment brupop-controller-deployment```
3. I had to wait for the `scheduler_cron_expression` for metrics to become available
4. Checked for the metrics in Splunk


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
