### PR TITLE
fix: rename image_pull_secrets to ImagePullSecrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ placement:
 #  --docker-username=AWS \
 #  --docker-password=$(aws --region us-west-2 ecr get-login-password) \
 #  --namespace=brupop-bottlerocket-aws
-#image_pull_secrets: |-
+#imagePullSecrets:
 #  - name: "brupop"
 
 # External load balancer setting.

--- a/deploy/charts/bottlerocket-update-operator/README.md
+++ b/deploy/charts/bottlerocket-update-operator/README.md
@@ -120,7 +120,7 @@ placement:
 #  --docker-username=AWS \
 #  --docker-password=$(aws --region us-west-2 ecr get-login-password) \
 #  --namespace=brupop-bottlerocket-aws
-#image_pull_secrets: |-
+#imagePullSecrets:
 #  - name: "brupop"
 
 # External load balancer setting.

--- a/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
@@ -89,9 +89,9 @@ spec:
       topologySpreadConstraints:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
-      {{- if ((.Values.image_pull_secrets)) }}
-      image_pull_secrets: 
-        {{ .Values.image_pull_secrets }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
         - hostPath:

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
@@ -83,8 +83,8 @@ spec:
       {{- if .Values.placement.controller.priorityClassName }}
       priorityClassName: {{ .Values.placement.controller.priorityClassName | quote }}
       {{- end }}
-      {{ if ((.Values.image_pull_secrets)) }}
-      image_pull_secrets: 
-        {{ .Values.image_pull_secrets }}
-      {{ end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: brupop-controller-service-account

--- a/deploy/charts/bottlerocket-update-operator/values.yaml
+++ b/deploy/charts/bottlerocket-update-operator/values.yaml
@@ -51,7 +51,7 @@ placement:
 #  --docker-username=AWS \
 #  --docker-password=$(aws --region us-west-2 ecr get-login-password) \
 #  --namespace=brupop-bottlerocket-aws
-#image_pull_secrets: |-
+#imagePullSecrets:
 #  - name: "brupop"
 
 # External load balancer setting.


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#708 


**Description of changes:**
Fixed a bug by changing image_pull_secrets to ImagePullSecrets


**Testing done:**

Setup cross account brupop where IAM role has no access, and use secret to deploy container:

```
 kubectl create secret docker-registry brupop \
  --docker-server=<cross-account>.dkr.ecr.us-west-2.amazonaws.com \
  --docker-username=AWS \
  --docker-password="${ECR_CROSS_ACCOUNT_PASSWORD}" \
  --namespace=brupop-bottlerocket-aws
```

kubectl edit deployment brupop-controller-deployment -n brupop-bottlerocket-aws
```    
.
..
...
        image: <cross-account>.dkr.ecr.us-west-2.amazonaws.com/brupop:v1.4.0
        imagePullPolicy: IfNotPresent
        name: brupop
        resources:
          limits:
            memory: 256Mi
          requests:
            cpu: 10m
            memory: 40Mi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      imagePullSecrets:
      - name: brupop
      priorityClassName: brupop-controller-high-priority
...
..
.


```

Successful brupop execution done manually: 
```
Every 2.0s: kubectl get bottlerocketshadows --namespace brupop-bottlerocket-aws                                                                                   

NAME                                              STATE                      VERSION   TARGET STATE         TARGET VERSION   CRASH COUNT
brs-ip-<>.us-west-2.compute.internal    Idle                       1.32.0    Idle                                  0
brs-ip-<>.us-west-2.compute.internal   Idle                       1.20.2    Idle                 <no value>       0
brs-ip<>.us-west-2.compute.internal   StagedAndPerformedUpdate   1.20.2    RebootedIntoUpdate   1.32.0           0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
