### PR TITLE
script: use --update=none for mv in publish-charts

### DIFF
--- a/scripts/publish-charts.sh
+++ b/scripts/publish-charts.sh
@@ -11,7 +11,7 @@ if [[ "${VERSION}" =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
     git config pull.rebase false
     git checkout gh-pages
     git checkout -b "gh-pages-release-${VERSION}"
-    mv -n "${CHART_BUILD_DIR}"/charts/*.tgz .
+    mv --update=none "${CHART_BUILD_DIR}"/charts/*.tgz .
     helmv3 repo index . --url "https://${GITHUB_REPO_OWNER}.github.io/${GITHUB_REPO_NAME}"
     git add ./*.tgz index.yaml
     git commit -m "Publish helm charts for ${VERSION}"


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->




**Description of changes:**
We saw failures in workflow run [v1.5.0 #4](https://github.com/bottlerocket-os/bottlerocket-update-operator/actions/runs/13506797423/job/37738304873)
```
mv: not replacing './bottlerocket-shadow-1.0.0.tgz'
make: *** [Makefile:138: publish-charts] Error 1
```

The issue is with the [backward incompatible change](https://github.com/coreutils/coreutils/blame/master/NEWS#L525-L528) introduced in `coreutils` v9.2 for `mv` so that `mv -n` would exit with non zero value if the destination file exists.

This is not reproduced in my local dev box because it is using `v8.22` and the ubuntu-latest uses `v9.4`. New approach is introduced in [v9.3](https://github.com/coreutils/coreutils/blame/master/NEWS#L435-L437), which is to use "--update=none". 
> cp and mv now support --update=none to always skip existing files
  in the destination, while not affecting the exit status.
  This is equivalent to the --no-clobber behavior from before v9.2.


**Testing done:**
Test in the ubuntu image with "mv --update=none" for a dummy file and verified that it does move if destination **does not exists** and does not clobber the file if **destination exists**. This is the exact behavior we want.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
