### PR TITLE
allow for custom cluster domain for agent to api connection

### DIFF
--- a/apiserver/src/client/webclient.rs
+++ b/apiserver/src/client/webclient.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use models::{
-    constants::{APISERVER_SERVICE_NAME, CA_NAME, TLS_KEY_MOUNT_PATH},
+    constants::{APISERVER_SERVICE_NAME, CA_NAME, KUBERNETES_SERVICE_CLUSTER_DOMAIN, TLS_KEY_MOUNT_PATH},
     node::{BottlerocketShadow, BottlerocketShadowSelector, BottlerocketShadowStatus},
 };
 use snafu::ResultExt;
@@ -65,6 +65,7 @@ pub struct K8SAPIServerClient {
     k8s_projected_token_path: String,
     service_port: u16,
     namespace: String,
+    cluster_domain_suffix: String,
 }
 
 impl K8SAPIServerClient {
@@ -77,10 +78,16 @@ impl K8SAPIServerClient {
             .context(error::CreateK8sClientSnafu)?;
         event!(Level::INFO, %service_port, "Created K8s API Server client using service port");
 
+        // Get cluster domain suffix from env var or use default
+        let cluster_domain_suffix = env::var("KUBERNETES_SERVICE_CLUSTER_DOMAIN")
+            .unwrap_or_else(|_| KUBERNETES_SERVICE_CLUSTER_DOMAIN.to_string());
+        event!(Level::INFO, %cluster_domain_suffix, "Using cluster domain suffix");
+
         Ok(Self {
             k8s_projected_token_path,
             service_port: service_port as u16,
             namespace: namespace.to_string(),
+            cluster_domain_suffix,
         })
     }
 
@@ -99,8 +106,8 @@ impl K8SAPIServerClient {
     /// Returns the domain on which the server can be reached.
     pub fn server_domain(&self) -> String {
         format!(
-            "{}.{}.svc.cluster.local:{}",
-            APISERVER_SERVICE_NAME, self.namespace, self.service_port
+            "{}.{}.{}:{}",
+            APISERVER_SERVICE_NAME, self.namespace, self.cluster_domain_suffix, self.service_port
         )
     }
 

--- a/models/src/constants.rs
+++ b/models/src/constants.rs
@@ -58,6 +58,7 @@ pub const APISERVER_MAX_UNAVAILABLE: &str = "33%"; // The maximum number of unav
 pub const APISERVER_HEALTH_CHECK_ROUTE: &str = "/ping"; // Route used for apiserver k8s liveness and readiness checks.
 pub const APISERVER_CRD_CONVERT_ENDPOINT: &str = "/crdconvert"; // Custom Resource convert endpoint
 pub const APISERVER_SERVICE_NAME: &str = "brupop-apiserver"; // The name for the `svc` fronting the apiserver.
+pub const KUBERNETES_SERVICE_CLUSTER_DOMAIN: &str = "svc.cluster.local"; // The default cluster domain suffix used for internal service communication.
 
 // agent constants
 pub const AGENT: &str = "agent";


### PR DESCRIPTION
<!--
Tips:
- Please read the CONTRIBUTING document to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #735



**Description of changes:**
Introduces a `KUBERNETES_SERVICE_CLUSTER_DOMAIN` env var that allows you to set the service cluster domain for the cluster which it uses to talk to the brupop apiserver.


**Testing done:**
None yet.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
