### PR TITLE
Allow customization of service annotations in Helm values #566

### DIFF
--- a/deploy/charts/bottlerocket-update-operator/templates/controller-service.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-service.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    prometheus.io/port: "8080"
-    prometheus.io/scrape: "true"
+    {{- toYaml .Values.prometheus.controller.service.annotations | nindent 4 }}
   labels:
     app.kubernetes.io/component: brupop-controller
     app.kubernetes.io/managed-by: brupop

--- a/deploy/charts/bottlerocket-update-operator/values.yaml
+++ b/deploy/charts/bottlerocket-update-operator/values.yaml
@@ -121,6 +121,10 @@ prometheus:
   controller:
     serviceMonitor:
       enabled: false
+    service:
+      annotations:
+        prometheus.io/port: "80"
+        prometheus.io/scrape: "true"
 
 resources:
   agent:


### PR DESCRIPTION
**Issue number:**

#566 

**Description of changes:**

Allow customization of service annotations in Helm values
This also fix a bug, since the previous annotations where wrong and made unable to scrape port "8080" on the service address

**Testing done:**

Verified with `helm template` `helm install` and `kubeconform`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
