### PR TITLE
feat: allow arbitrary labels and annotations to be added to all workloads or selectively

### DIFF
--- a/deploy/charts/bottlerocket-update-operator/README.md
+++ b/deploy/charts/bottlerocket-update-operator/README.md
@@ -80,6 +80,21 @@ namespace: "brupop-bottlerocket-aws"
 # The image to use for brupop
 image: "public.ecr.aws/bottlerocket/bottlerocket-update-operator:v1.5.0"
 
+# Provide pod level labels and annotations for all brupop workloads
+podLabels: {}
+podAnnotations: {}
+
+# Brupop workload specific pod labels and annotations
+controller:
+  podLabels: {}
+  podAnnotations: {}
+apiserver:
+  podLabels: {}
+  podAnnotations: {}
+agent:
+  podLabels: {}
+  podAnnotations: {}
+
 # Placement controls
 # See the Kubernetes documentation about placement controls for more details:
 # * https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/

--- a/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/agent-daemonset.yaml
@@ -15,10 +15,22 @@ spec:
       brupop.bottlerocket.aws/component: agent
   template:
     metadata:
+      {{- if or .Values.podAnnotations .Values.agent.podAnnotations }}
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.agent.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       labels:
         brupop.bottlerocket.aws/component: agent
-        {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.agent.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       namespace: {{ .Values.namespace }}
     spec:

--- a/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/api-server-deployment.yaml
@@ -19,10 +19,22 @@ spec:
       maxUnavailable: 33%
   template:
     metadata:
+      {{- if or .Values.podAnnotations .Values.apiserver.podAnnotations }}
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.apiserver.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       labels:
         brupop.bottlerocket.aws/component: apiserver
-        {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.apiserver.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       namespace: {{ .Values.namespace }}
     spec:

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-deployment.yaml
@@ -21,10 +21,19 @@ spec:
       annotations:
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.controller.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         brupop.bottlerocket.aws/component: brupop-controller
-        {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.controller.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       namespace: {{ .Values.namespace }}
     spec:

--- a/deploy/charts/bottlerocket-update-operator/templates/controller-service.yaml
+++ b/deploy/charts/bottlerocket-update-operator/templates/controller-service.yaml
@@ -2,8 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.prometheus.controller.service.annotations }}
   annotations:
     {{- toYaml .Values.prometheus.controller.service.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: brupop-controller
     app.kubernetes.io/managed-by: brupop

--- a/deploy/charts/bottlerocket-update-operator/values.yaml
+++ b/deploy/charts/bottlerocket-update-operator/values.yaml
@@ -150,5 +150,17 @@ resources:
         cpu: 10m
         memory: 40Mi
 
-# Provide pod level labels for the brupop resources.
+# Provide pod level labels and annotations for all brupop workloads
 podLabels: {}
+podAnnotations: {}
+
+# Brupop workload specific pod labels and annotations
+controller:
+  podLabels: {}
+  podAnnotations: {}
+apiserver:
+  podLabels: {}
+  podAnnotations: {}
+agent:
+  podLabels: {}
+  podAnnotations: {}


### PR DESCRIPTION
**Issue number:**

resolves #646

**Description of changes:**

This PR allows arbitrary labels/annotations to be added to pods. It allows the to be set across all pods or sub selections of pods. 

Why is this functionality needed?

1. Like #646 and #644 we need to send metrics to datadog. Will there's prometheus endpoints available, we need to add some annotations to the workload so the datadog agents scrape just the metrics endpoints we need. Enabling prometheus endpoints cluster wide causes a massive cost increase in collected custom metrics. 
2. I also need a label that will be used to assign a team that owns the workload. This is used by infosec to attribute the owner back to a team for CVE remediation and scanning results.

**Testing done:**

### In repo tests

I only saw these tests for the controller (maybe I missed something).

```
bottlerocket-update-operator on  allow-arbitrary-annotations-and-labels [!?] via 🦀 v1.75.0 on ☁️  (us-west-2)
❯ export CHARTS_DIR=$(pwd)/deploy/charts

bottlerocket-update-operator on  allow-arbitrary-annotations-and-labels [!?] via 🦀 v1.75.0 on ☁️  (us-west-2)
❯ ./scripts/validate-charts.sh
Validating chart bottlerocket-shadow/ w/ helm v3
Validating chart bottlerocket-update-operator/ w/ helm v3
All charts passed validations!

bottlerocket-update-operator on  allow-arbitrary-annotations-and-labels [!?] via 🦀 v1.75.0 on ☁️  (us-west-2)
❯ ./scripts/lint-charts.sh
Linting chart bottlerocket-shadow/ w/ helm v3
==> Linting /home/grumps/projects/bottlerocket-update-operator/deploy/charts/bottlerocket-shadow/

1 chart(s) linted, 0 chart(s) failed
Linting chart bottlerocket-update-operator/ w/ helm v3
==> Linting /home/grumps/projects/bottlerocket-update-operator/deploy/charts/bottlerocket-update-operator/

1 chart(s) linted, 0 chart(s) failed
All charts passed linting!
```
### Manual validation

A subselection of label/annotation settings:

```
# values2.yaml
# Component-specific pod labels and annotations
controller:
  podAnnotations:
    iamaannotationcontrollerkey: iamaannotationcontrollervalue
apiserver:
  podLabels:
    iamalabelapiserverkey: iamalabelapiservervalue
agent:
  podLabels: 
    iamalabelagentkey: iamalabelagentvalue
  podAnnotations:
    iamaannotationagentkey: iamaannotationagentvalue
```

Then render `helm template -f values2.yaml bottlerocket-update-operator | yq 'select(.kind == "DaemonSet" or .kind == "Deployment") | {kind: .kind, metadata: .metadata.name, spec_template_metadata: .spec.template.metadata}'`

```
{
  "kind": "DaemonSet",
  "metadata": "brupop-agent",
  "spec_template_metadata": {
    "annotations": {
      "iamaannotationagentkey": "iamaannotationagentvalue"
    },
    "labels": {
      "brupop.bottlerocket.aws/component": "agent",
      "iamalabelagentkey": "iamalabelagentvalue"
    },
    "namespace": "brupop-bottlerocket-aws"
  }
}
{
  "kind": "Deployment",
  "metadata": "brupop-apiserver",
  "spec_template_metadata": {
    "labels": {
      "brupop.bottlerocket.aws/component": "apiserver",
      "iamalabelapiserverkey": "iamalabelapiservervalue"
    },
    "namespace": "brupop-bottlerocket-aws"
  }
}
{
  "kind": "Deployment",
  "metadata": "brupop-controller-deployment",
  "spec_template_metadata": {
    "annotations": {
      "prometheus.io/port": "8080",
      "prometheus.io/scrape": "true",
      "iamaannotationcontrollerkey": "iamaannotationcontrollervalue"
    },
    "labels": {
      "brupop.bottlerocket.aws/component": "brupop-controller"
    },
    "namespace": "brupop-bottlerocket-aws"
  }
}
```

```
# values.yaml

# Provide pod level labels for the brupop resources.
podLabels:
  iamalabelkey: iamalabelvalue

# Provide pod level annotations for the brupop resources.
podAnnotations:
  iamaannotationkey: iamaannotationvalue


# Component-specific pod labels and annotations
controller:
  podLabels:
    iamalabelcontrollerkey: iamalabelcontrollervalue
  podAnnotations:
    iamaannotationcontrollerkey: iamaannotationcontrollervalue
apiserver:
  podLabels:
    iamalabelapiserverkey: iamalabelapiservervalue
  podAnnotations:
    iamaannotationapiserverkey: iamaannotationapiservervalue
agent:
  podLabels: 
    iamalabelagentkey: iamalabelagentvalue
  podAnnotations:
    iamaannotationagentkey: iamaannotationagentvalue
```
 
Then render all values/annotations

`helm template -f values.yaml bottlerocket-update-operator | yq 'select(.kind == "DaemonSet" or .kind == "Deployment") | {kind: .kind, metadata: .metadata.name, spec_template_metadata: .spec.template.metadata}'`

```{
  "kind": "DaemonSet",
  "metadata": "brupop-agent",
  "spec_template_metadata": {
    "annotations": {
      "iamaannotationkey": "iamaannotationvalue",
      "iamaannotationagentkey": "iamaannotationagentvalue"
    },
    "labels": {
      "brupop.bottlerocket.aws/component": "agent",
      "iamalabelkey": "iamalabelvalue",
      "iamalabelagentkey": "iamalabelagentvalue"
    },
    "namespace": "brupop-bottlerocket-aws"
  }
}
{
  "kind": "Deployment",
  "metadata": "brupop-apiserver",
  "spec_template_metadata": {
    "annotations": {
      "iamaannotationkey": "iamaannotationvalue",
      "iamaannotationapiserverkey": "iamaannotationapiservervalue"
    },
    "labels": {
      "brupop.bottlerocket.aws/component": "apiserver",
      "iamalabelkey": "iamalabelvalue",
      "iamalabelapiserverkey": "iamalabelapiservervalue"
    },
    "namespace": "brupop-bottlerocket-aws"
  }
}
{
  "kind": "Deployment",
  "metadata": "brupop-controller-deployment",
  "spec_template_metadata": {
    "annotations": {
      "prometheus.io/port": "8080",
      "prometheus.io/scrape": "true",
      "iamaannotationkey": "iamaannotationvalue",
      "iamaannotationcontrollerkey": "iamaannotationcontrollervalue"
    },
    "labels": {
      "brupop.bottlerocket.aws/component": "brupop-controller",
      "iamalabelkey": "iamalabelvalue",
      "iamalabelcontrollerkey": "iamalabelcontrollervalue"
    },
    "namespace": "brupop-bottlerocket-aws"
  }
}
```

Here's no (aka current configuration) labels/annotations:

`helm template bottlerocket-update-operator | yq 'select(.kind == "DaemonSet" or .kind == "Deployment") | {kind: .kind, metadata: .metadata.name, spec_template_metadata: .spec.template.metadata}'`

```{
  "kind": "DaemonSet",
  "metadata": "brupop-agent",
  "spec_template_metadata": {
    "labels": {
      "brupop.bottlerocket.aws/component": "agent"
    },
    "namespace": "brupop-bottlerocket-aws"
  }
}
{
  "kind": "Deployment",
  "metadata": "brupop-apiserver",
  "spec_template_metadata": {
    "labels": {
      "brupop.bottlerocket.aws/component": "apiserver"
    },
    "namespace": "brupop-bottlerocket-aws"
  }
}
{
  "kind": "Deployment",
  "metadata": "brupop-controller-deployment",
  "spec_template_metadata": {
    "annotations": {
      "prometheus.io/port": "8080",
      "prometheus.io/scrape": "true"
    },
    "labels": {
      "brupop.bottlerocket.aws/component": "brupop-controller"
    },
    "namespace": "brupop-bottlerocket-aws"
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.

