### PR TITLE
fix: improve status code extraction from API client error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "chrono",
  "futures",
  "governor",
+ "http 1.3.1",
  "k8s-openapi",
  "kube",
  "lazy_static",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -14,6 +14,7 @@ apiserver = { path = "../apiserver", version = "0.1.0", default-features = false
 
 futures = { workspace = true }
 governor = { workspace = true }
+http = { workspace = true }
 lazy_static = { workspace = true }
 nonzero_ext = { workspace = true }
 tracing = { workspace = true }

--- a/agent/src/apiclient.rs
+++ b/agent/src/apiclient.rs
@@ -115,7 +115,7 @@ pub(super) mod api {
     use nonzero_ext::nonzero;
     use semver::Version;
     use serde::Deserialize;
-    use snafu::ResultExt;
+    use snafu::{OptionExt, ResultExt};
     use std::process::{Command, Output};
     use tokio::time::Duration;
     use tokio_retry::{
@@ -233,15 +233,22 @@ pub(super) mod api {
     /// Extract error statuscode from stderr string
     /// Error Example:
     /// "Failed POST request to '/actions/refresh-updates': Status 423 when POSTing /actions/refresh-updates: Update lock held\n"
-    fn extract_status_code_from_error(error: &str) -> Option<StatusCode> {
-        error
+    pub fn extract_status_code_from_error(error: &str) -> Result<StatusCode> {
+        let status_str = error
             .split("Status ")
-            .nth(1)?
+            .nth(1)
+            .context(apiclient_error::StatusCodeParsingSnafu)?;
+
+        let code_str = status_str
             .split_whitespace()
-            .next()?
+            .next()
+            .context(apiclient_error::StatusCodeParsingSnafu)?;
+
+        let code = code_str
             .parse::<u16>()
-            .ok()
-            .and_then(|code| StatusCode::from_u16(code).ok())
+            .context(apiclient_error::StatusCodeIntParsingSnafu)?;
+
+        StatusCode::from_u16(code).context(apiclient_error::InvalidStatusCodeSnafu)
     }
 
     /// Wait time between invoking the Bottlerocket API
@@ -298,7 +305,7 @@ pub(super) mod api {
                         let error_statuscode = extract_status_code_from_error(&error_content);
 
                         match error_statuscode {
-                            Some(UPDATE_API_BUSY_STATUSCODE) => {
+                            Ok(UPDATE_API_BUSY_STATUSCODE) => {
                                 event!(
                                     Level::DEBUG,
                                     "The lock for the update API is held by another process ..."
@@ -312,7 +319,7 @@ pub(super) mod api {
                                     args: args.clone(),
                                     error_content: &error_content,
                                     statuscode: error_statuscode.map_or_else(
-                                        || "None".to_string(),
+                                        |_| "None".to_string(),
                                         |s| s.as_u16().to_string(),
                                     ),
                                 }
@@ -454,5 +461,69 @@ pub mod apiclient_error {
 
         #[snafu(display("Unable to parse version information: '{}'", source))]
         VersionParseError { source: semver::Error },
+
+        #[snafu(display("Failed to parse status code from error string"))]
+        StatusCodeParsing,
+
+        #[snafu(display("Failed to parse integer from status code string"))]
+        StatusCodeIntParsing { source: std::num::ParseIntError },
+
+        #[snafu(display("Invalid HTTP status code"))]
+        InvalidStatusCode {
+            source: http::status::InvalidStatusCode,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::api::*;
+    use super::apiclient_error::Error;
+    use http::StatusCode;
+
+    #[test]
+    fn test_extract_status_code_from_error_success() {
+        let error = "Failed POST request to '/actions/refresh-updates': Status 423 when POSTing /actions/refresh-updates: Update lock held";
+        let result = extract_status_code_from_error(error);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), StatusCode::LOCKED);
+    }
+
+    #[test]
+    fn test_extract_status_code_from_error_no_status() {
+        let error = "Some error without status code";
+        let result = extract_status_code_from_error(error);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::StatusCodeParsing));
+    }
+
+    #[test]
+    fn test_extract_status_code_from_error_invalid_number() {
+        let error = "Failed POST request: Status abc when POSTing";
+        let result = extract_status_code_from_error(error);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            Error::StatusCodeIntParsing { .. }
+        ));
+    }
+
+    #[test]
+    fn test_extract_status_code_from_error_invalid_status_code() {
+        let error = "Failed POST request: Status 1000 when POSTing";
+        let result = extract_status_code_from_error(error);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            Error::InvalidStatusCode { .. }
+        ));
+    }
+
+    #[test]
+    fn test_extract_status_code_from_error_no_whitespace() {
+        let error = "Status 200";
+        let result = extract_status_code_from_error(error);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), StatusCode::OK);
     }
 }

--- a/agent/src/apiclient.rs
+++ b/agent/src/apiclient.rs
@@ -110,6 +110,7 @@ pub(super) mod api {
         state::{InMemoryState, NotKeyed},
         Quota, RateLimiter,
     };
+    use http::StatusCode;
     use lazy_static::lazy_static;
     use nonzero_ext::nonzero;
     use semver::Version;
@@ -124,7 +125,7 @@ pub(super) mod api {
     use tracing::{event, instrument, Level};
 
     const API_CLIENT_BIN: &str = "apiclient";
-    const UPDATE_API_BUSY_STATUSCODE: &str = "423";
+    const UPDATE_API_BUSY_STATUSCODE: StatusCode = StatusCode::LOCKED;
     const ACTIVATE_UPDATES_URI: &str = "/actions/activate-update";
     const OS_URI: &str = "/os";
     const PREPARE_UPDATES_URI: &str = "/actions/prepare-update";
@@ -232,12 +233,15 @@ pub(super) mod api {
     /// Extract error statuscode from stderr string
     /// Error Example:
     /// "Failed POST request to '/actions/refresh-updates': Status 423 when POSTing /actions/refresh-updates: Update lock held\n"
-    fn extract_status_code_from_error(error: &str) -> &str {
-        let error_content_split_by_status: Vec<&str> = error.split("Status").collect();
-        let error_content_split_by_whitespace: Vec<&str> = error_content_split_by_status[1]
+    fn extract_status_code_from_error(error: &str) -> Option<StatusCode> {
+        error
+            .split("Status ")
+            .nth(1)?
             .split_whitespace()
-            .collect();
-        error_content_split_by_whitespace[0]
+            .next()?
+            .parse::<u16>()
+            .ok()
+            .and_then(|code| StatusCode::from_u16(code).ok())
     }
 
     /// Wait time between invoking the Bottlerocket API
@@ -294,7 +298,7 @@ pub(super) mod api {
                         let error_statuscode = extract_status_code_from_error(&error_content);
 
                         match error_statuscode {
-                            UPDATE_API_BUSY_STATUSCODE => {
+                            Some(UPDATE_API_BUSY_STATUSCODE) => {
                                 event!(
                                     Level::DEBUG,
                                     "The lock for the update API is held by another process ..."
@@ -307,7 +311,10 @@ pub(super) mod api {
                                 apiclient_error::BadHttpResponseSnafu {
                                     args: args.clone(),
                                     error_content: &error_content,
-                                    statuscode: error_statuscode,
+                                    statuscode: error_statuscode.map_or_else(
+                                        || "None".to_string(),
+                                        |s| s.as_u16().to_string(),
+                                    ),
                                 }
                                 .fail()
                             }


### PR DESCRIPTION
**Issue number:**
#774 

**Description of changes:**
Fix a bug where an index out-of-bounds error would be returned when "Status" is not in  the apiclient response error message.  The previous string-based approach using "Status" as a delimiter could fail if the delimiter was not present or formatted differently.  

This change replaces string manipulation with proper HTTP status code parsing using the http crate's StatusCode type. The extraction now safely handles missing delimiters and invalid status codes by returning the StatusCode instead of raw string slices.

**Testing done:**
Ran ```make build```

Validated status code parsing function locally.

Created unit tests for status code parsing function

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
