### PR TITLE
limit permissions of GITHUB_TOKEN in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on:
       - 'design/**'
     branches: [develop]
 
+permissions:
+  contents: read
+
 jobs:
 
   build-binary:


### PR DESCRIPTION
**Description of changes:**

Explicitly set the permissions in the CI GitHub Actions workflow to read-only access of the contents.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
