### PR TITLE
Replace ring with aws-lc-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,12 +511,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.13.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede71ad84efb06d748d9af3bc500b14957a96282a69a6833b1420dcacb411cc3"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "regex",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
 dependencies = [
+ "aws-lc-fips-sys",
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -2490,6 +2506,7 @@ name = "models"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "chrono",
  "futures",
  "k8s-openapi",
@@ -3205,7 +3222,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3323,7 +3340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3335,7 +3352,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3396,7 +3413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4153,6 +4170,12 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -4379,7 +4402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ argh = "0.1"
 async-trait = "0.1"
 awc = "3"
 aws-config = { version = "1", default-features = false, features = ["credentials-process", "default-https-client", "rt-tokio"] }
+aws-lc-rs = { version = "1", features = ["bindgen"] }
 aws-sdk-ec2 = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 aws-sdk-eks = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 aws-sdk-iam = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
@@ -55,7 +56,7 @@ kube = { version = "0.88", default-features = false, features = [ "derive", "run
 
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features =  [ "json", "rustls-tls" ] }
-rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "logging", "std", "tls12"] }
 rustls-pemfile = { version = "2" }
 schemars = "0.8"
 semver = "1"

--- a/clarify.toml
+++ b/clarify.toml
@@ -70,6 +70,20 @@ license-files = [
     { path = "src/unicode_tables/LICENSE-UNICODE", hash = 0xa7f28b93 },
 ]
 
+[clarify.aws-lc-rs]
+expression = "ISC AND (Apache-2.0 OR ISC) AND MIT"
+license-files = [
+    { path = "LICENSE", hash = 0x8f713da7 },
+]
+
+[clarify.aws-lc-fips-sys]
+expression = "ISC AND (Apache-2.0 OR ISC) AND OpenSSL AND MIT"
+license-files = [
+    { path = "LICENSE", hash = 0xf308ccd7 },
+    { path = "aws-lc/LICENSE", hash = 0xb6d14686 },
+    { path = "aws-lc/third_party/fiat/LICENSE", hash = 0x75829ee2 },
+]
+
 [clarify.ring]
 expression = "Apache-2.0 AND ISC AND MIT AND OpenSSL"
 license-files = [

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+aws-lc-rs = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 

--- a/models/src/crypto.rs
+++ b/models/src/crypto.rs
@@ -10,7 +10,7 @@ use rustls::crypto::CryptoProvider;
 use snafu::Snafu;
 
 pub fn install_default_crypto_provider() -> Result<(), CryptoConfigError> {
-    CryptoProvider::install_default(rustls::crypto::ring::default_provider())
+    CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider())
         .map_err(|_| CryptoConfigError)
 }
 


### PR DESCRIPTION
**Issue number:**
#703


**Description of changes:**
Replaces dependency on `ring` to instead use `aws-lc-rs` for cryptographic operations

**Testing done:**
- Ran `make build` and integration tests to ensure that the replacement did not break anything
- Ran `make check-licenses` to validate `aws-lc-rs` licenses

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
