### PR TITLE
Add EBS CSI driver policy to nodegroup IAM role

### DIFF
--- a/integ/src/nodegroup_provider.rs
+++ b/integ/src/nodegroup_provider.rs
@@ -46,6 +46,8 @@ const EKS_CNI_ARN: &str = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy";
 const EC2_CONTAINER_REGISTRY_ARN: &str =
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly";
 const SSM_MANAGED_INSTANCE_CORE_ARN: &str = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore";
+const EBS_CSI_DRIVER_POLICY_ARN: &str =
+    "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy";
 const EKS_ROLE_POLICY_DOCUMENT_CN: &str = "ec2.amazonaws.com.cn";
 const EKS_ROLE_POLICY_DOCUMENT: &str = "ec2.amazonaws.com";
 const CHINA_REGION_PREFIX: &str = "cn-";
@@ -304,6 +306,13 @@ async fn create_iam_instance_profile(
             .send()
             .await
             .context("Unable to attach AmazonEC2ContainerRegistry policy")?;
+        iam_client
+            .attach_role_policy()
+            .role_name(iam_instance_profile_name.clone())
+            .policy_arn(EBS_CSI_DRIVER_POLICY_ARN)
+            .send()
+            .await
+            .context("Unable to attach AmazonEBSCSIDriver policy")?;
         iam_client
             .create_instance_profile()
             .instance_profile_name(iam_instance_profile_name.clone())


### PR DESCRIPTION
**Description of changes:**
Updated integration tests to include EBS CSI driver IAM policy in nodegroup creation. This resolves pod scheduling issues where StatefulSets with PersistentVolumeClaims would remain in ContainerCreating state due to volume attachment failures.

**Testing done:**
* Ran integration tests with StatefulSet pods requiring persistent storage
* Confirmed all test pods reach Running state without timeout errors
* Validated brupop successfully updates nodes


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
