### PR TITLE
Bump bottlerocket-sdk from 0.62.0 to 0.65.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DESTDIR ?= .
 # tarball.
 DISTFILE ?= $(DESTDIR:/=)/$(subst /,_,$(IMAGE_NAME)).tar.gz
 
-BOTTLEROCKET_SDK_VERSION = v0.62.0
+BOTTLEROCKET_SDK_VERSION = v0.65.0
 
 # Tools used during the chart release lifecycle
 export KUBECONFORM_VERSION = v0.6.3


### PR DESCRIPTION
**Description of changes:**
Updates Bottlerocket-sdk from 0.62.0 to 0.65.0

**Testing done:**
* Ran `make build`
* Verified successful build with updated sdk version
* Ran integration tests to ensure compatibility with new SDK

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
